### PR TITLE
fix(tailwind): prefix misapplied on negative value

### DIFF
--- a/packages/cli/src/utils/transformers/transform-tw-prefix.ts
+++ b/packages/cli/src/utils/transformers/transform-tw-prefix.ts
@@ -89,18 +89,31 @@ export function applyPrefix(input: string, prefix: string = '') {
   const prefixed: string[] = []
   for (const className of classNames) {
     const [variant, value, modifier] = splitClassName(className)
+    const valueWithPrefix = handleNegativeVariants(value, prefix)
     if (variant) {
       modifier
-        ? prefixed.push(`${variant}:${prefix}${value}/${modifier}`)
-        : prefixed.push(`${variant}:${prefix}${value}`)
+        ? prefixed.push(`${variant}:${valueWithPrefix}/${modifier}`)
+        : prefixed.push(`${variant}:${valueWithPrefix}`)
     }
     else {
       modifier
-        ? prefixed.push(`${prefix}${value}/${modifier}`)
-        : prefixed.push(`${prefix}${value}`)
+        ? prefixed.push(`${valueWithPrefix}/${modifier}`)
+        : prefixed.push(`${valueWithPrefix}`)
     }
   }
   return prefixed.join(' ')
+}
+
+function handleNegativeVariants(value: string | null, prefix: string = '') {
+  if (!prefix || !value) {
+    return value
+  }
+
+  if (value.startsWith('-')) {
+    return `-${prefix}${value.substring(1)}`
+  }
+
+  return `${prefix}${value}`
 }
 
 export function applyPrefixesCss(css: string, prefix: string) {

--- a/packages/cli/test/utils/__snapshots__/transform-tw-prefix.test.ts.snap
+++ b/packages/cli/test/utils/__snapshots__/transform-tw-prefix.test.ts.snap
@@ -67,7 +67,7 @@ exports[`transform tailwind prefix 4`] = `
     :class="
       cn(
         'tw-flex',
-        orientation === 'horizontal' ? 'tw--ml-4' : 'tw--mt-4 tw-flex-col',
+        orientation === 'horizontal' ? '-tw-ml-4' : '-tw-mt-4 tw-flex-col',
         props.class,
       )
     "

--- a/packages/cli/test/utils/apply-prefix.test.ts
+++ b/packages/cli/test/utils/apply-prefix.test.ts
@@ -36,6 +36,12 @@ describe('apply tailwind prefix', () => {
       output:
         'tw-absolute tw-right-4 tw-top-4 tw-bg-primary tw-rounded-sm tw-opacity-70 tw-ring-offset-background tw-transition-opacity hover:tw-opacity-100 focus:tw-outline-none focus:tw-ring-2 focus:tw-ring-ring focus:tw-ring-offset-2 disabled:tw-pointer-events-none data-[state=open]:tw-bg-secondary',
     },
+    {
+      input:
+        '-mt-8 hover:-mt-8 focus:-mt-8 active:-mt-8 disabled:-mt-8',
+      output:
+        '-tw-mt-8 hover:-tw-mt-8 focus:-tw-mt-8 active:-tw-mt-8 disabled:-tw-mt-8',
+    },
   ])(`applyTwPrefix($input) -> $output`, ({ input, output }) => {
     expect(applyPrefix(input, 'tw-')).toBe(output)
   })


### PR DESCRIPTION
<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue

#1087
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
This change is required because we are currently not applyting properly tailwind negavite modifier with prefix.

- Added `handleNegativeVariants` function to handle proper prefix application.  
- Ensured negative modifiers are correctly interpreted.  

Resolves #1087 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
