### PR TITLE
fix(sidebar): prevent overflow in SidebarSeparator with horizontal orientation

### DIFF
--- a/apps/v4/public/r/styles/default/sidebar.json
+++ b/apps/v4/public/r/styles/default/sidebar.json
@@ -148,7 +148,7 @@
     },
     {
       "path": "ui/sidebar/SidebarSeparator.vue",
-      "content": "<script setup lang=\"ts\">\nimport type { HTMLAttributes } from \"vue\"\nimport { cn } from \"@/lib/utils\"\nimport { Separator } from \"@/registry/default/ui/separator\"\n\nconst props = defineProps<{\n  class?: HTMLAttributes[\"class\"]\n}>()\n</script>\n\n<template>\n  <Separator\n    data-sidebar=\"separator\"\n    :class=\"cn('mx-2 w-auto bg-sidebar-border', props.class)\"\n  >\n    <slot />\n  </Separator>\n</template>\n",
+      "content": "<script setup lang=\"ts\">\nimport type { HTMLAttributes } from \"vue\"\nimport { cn } from \"@/lib/utils\"\nimport { Separator } from \"@/registry/default/ui/separator\"\n\nconst props = defineProps<{\n  class?: HTMLAttributes[\"class\"]\n}>()\n</script>\n\n<template>\n  <Separator\n    data-sidebar=\"separator\"\n    :class=\"cn('mx-2 data-[orientation=horizontal]:w-auto bg-sidebar-border', props.class)\"\n  >\n    <slot />\n  </Separator>\n</template>\n",
       "type": "registry:ui",
       "target": ""
     },

--- a/apps/v4/public/r/styles/new-york/sidebar.json
+++ b/apps/v4/public/r/styles/new-york/sidebar.json
@@ -148,7 +148,7 @@
     },
     {
       "path": "ui/sidebar/SidebarSeparator.vue",
-      "content": "<script setup lang=\"ts\">\nimport type { HTMLAttributes } from \"vue\"\nimport { cn } from \"@/lib/utils\"\nimport { Separator } from \"@/registry/new-york/ui/separator\"\n\nconst props = defineProps<{\n  class?: HTMLAttributes[\"class\"]\n}>()\n</script>\n\n<template>\n  <Separator\n    data-sidebar=\"separator\"\n    :class=\"cn('mx-2 w-auto bg-sidebar-border', props.class)\"\n  >\n    <slot />\n  </Separator>\n</template>\n",
+      "content": "<script setup lang=\"ts\">\nimport type { HTMLAttributes } from \"vue\"\nimport { cn } from \"@/lib/utils\"\nimport { Separator } from \"@/registry/new-york/ui/separator\"\n\nconst props = defineProps<{\n  class?: HTMLAttributes[\"class\"]\n}>()\n</script>\n\n<template>\n  <Separator\n    data-sidebar=\"separator\"\n    :class=\"cn('mx-2 data-[orientation=horizontal]:w-auto bg-sidebar-border', props.class)\"\n  >\n    <slot />\n  </Separator>\n</template>\n",
       "type": "registry:ui",
       "target": ""
     },

--- a/apps/v4/registry/new-york-v4/ui/sidebar/SidebarSeparator.vue
+++ b/apps/v4/registry/new-york-v4/ui/sidebar/SidebarSeparator.vue
@@ -12,7 +12,7 @@ const props = defineProps<{
   <Separator
     data-slot="sidebar-separator"
     data-sidebar="separator"
-    :class="cn('bg-sidebar-border mx-2 w-auto', props.class)"
+    :class="cn('bg-sidebar-border mx-2 data-[orientation=horizontal]:w-auto', props.class)"
   >
     <slot />
   </Separator>

--- a/deprecated/www/src/public/r/styles/new-york-v4/sidebar.json
+++ b/deprecated/www/src/public/r/styles/new-york-v4/sidebar.json
@@ -128,7 +128,7 @@
     },
     {
       "path": "registry/new-york-v4/ui/sidebar/SidebarSeparator.vue",
-      "content": "<script setup lang=\"ts\">\nimport type { HTMLAttributes } from \"vue\"\nimport { cn } from \"@/lib/utils\"\nimport { Separator } from \"@/registry/new-york-v4/ui/separator\"\n\nconst props = defineProps<{\n  class?: HTMLAttributes[\"class\"]\n}>()\n</script>\n\n<template>\n  <Separator\n    data-slot=\"sidebar-separator\"\n    data-sidebar=\"separator\"\n    :class=\"cn('bg-sidebar-border mx-2 w-auto', props.class)\"\n  >\n    <slot />\n  </Separator>\n</template>\n",
+      "content": "<script setup lang=\"ts\">\nimport type { HTMLAttributes } from \"vue\"\nimport { cn } from \"@/lib/utils\"\nimport { Separator } from \"@/registry/new-york-v4/ui/separator\"\n\nconst props = defineProps<{\n  class?: HTMLAttributes[\"class\"]\n}>()\n</script>\n\n<template>\n  <Separator\n    data-slot=\"sidebar-separator\"\n    data-sidebar=\"separator\"\n    :class=\"cn('bg-sidebar-border mx-2 data-[orientation=horizontal]:w-auto', props.class)\"\n  >\n    <slot />\n  </Separator>\n</template>\n",
       "type": "registry:ui"
     },
     {

--- a/deprecated/www/src/registry/default/ui/sidebar/SidebarSeparator.vue
+++ b/deprecated/www/src/registry/default/ui/sidebar/SidebarSeparator.vue
@@ -11,7 +11,7 @@ const props = defineProps<{
 <template>
   <Separator
     data-sidebar="separator"
-    :class="cn('mx-2 w-auto bg-sidebar-border', props.class)"
+    :class="cn('mx-2 data-[orientation=horizontal]:w-auto bg-sidebar-border', props.class)"
   >
     <slot />
   </Separator>

--- a/deprecated/www/src/registry/new-york/ui/sidebar/SidebarSeparator.vue
+++ b/deprecated/www/src/registry/new-york/ui/sidebar/SidebarSeparator.vue
@@ -11,7 +11,7 @@ const props = defineProps<{
 <template>
   <Separator
     data-sidebar="separator"
-    :class="cn('mx-2 w-auto bg-sidebar-border', props.class)"
+    :class="cn('mx-2 data-[orientation=horizontal]:w-auto bg-sidebar-border', props.class)"
   >
     <slot />
   </Separator>


### PR DESCRIPTION
## Summary

Fixed overflow issue in `SidebarSeparator` component by updating the width class to use 
`data-[orientation=horizontal]:w-auto` instead of `w-auto`. This makes the width override 
more specific, only applying to horizontal separators, which prevents conflicts with other 
Separator styling.

Fixes #1486

## Changes

- Updated `SidebarSeparator.vue` in all styles (default, new-york, new-york-v4)
- Changed `w-auto` to `data-[orientation=horizontal]:w-auto` to prevent overflow issues
- Rebuilt the registry to include the component changes

## Related

This fix is related to https://github.com/shadcn-ui/ui/pull/8498 which addresses the same 
issue in the main shadcn-ui/ui library.

## Test plan

- [x] Built the registry successfully
- [x] Verified changes in all three style variants
- [x] Follows conventional commit guidelines