### PR TITLE
fix(scroll-area): add max-h-[inherit] to viewport to fix max-height s…

### DIFF
--- a/apps/v4/registry/bases/reka/ui/scroll-area/ScrollArea.vue
+++ b/apps/v4/registry/bases/reka/ui/scroll-area/ScrollArea.vue
@@ -23,8 +23,7 @@ const delegatedProps = reactiveOmit(props, "class")
   >
     <ScrollAreaViewport
       data-slot="scroll-area-viewport"
-      class="cn-scroll-area-viewport focus-visible:ring-ring/50 size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:outline-1"
-    >
+      class="cn-scroll-area-viewport focus-visible:ring-ring/50 size-full max-h-[inherit] rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:outline-1" >
       <slot />
     </ScrollAreaViewport>
     <ScrollBar />

--- a/apps/v4/registry/new-york-v4/ui/scroll-area/ScrollArea.vue
+++ b/apps/v4/registry/new-york-v4/ui/scroll-area/ScrollArea.vue
@@ -23,7 +23,7 @@ const delegatedProps = reactiveOmit(props, "class")
   >
     <ScrollAreaViewport
       data-slot="scroll-area-viewport"
-      class="focus-visible:ring-ring/50 size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:outline-1"
+      class="focus-visible:ring-ring/50 size-full max-h-[inherit] rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:outline-1"
     >
       <slot />
     </ScrollAreaViewport>


### PR DESCRIPTION
 Linked issue

  Related to upstream issues:
  - radix-ui/primitives#2307
  - radix-ui/primitives#1735
  - shadcn-ui/ui#296
  - shadcn-ui/ui#6659

  Type of change

  - Bug fix (a non-breaking change that fixes an issue)

   Description

  ScrollArea doesn't scroll when the root has a max-height constraint (e.g. max-h-96) instead of an explicit height.

  The ScrollAreaViewport has size-full which sets height: 100%. In CSS, height: 100% resolves against the parent's
  explicit height property, not max-height. So when the root only has max-height, the viewport grows to its content size
   and never scrolls.

  Fix: Add max-h-[inherit] to the ScrollAreaViewport. This makes the viewport inherit the root's max-height constraint,
  so overflow-y: scroll activates correctly. height: 100% continues to work for explicit height cases.

  Reproduction:
  <ScrollArea class="max-h-96">
    <!-- lots of content that exceeds 384px -->
  </ScrollArea>
  Without fix: content overflows outside the popover, no scrolling. With fix: scrolls correctly.

  N/A — reproducible with any ScrollArea using max-h-* instead of h-*.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed scroll-area viewport sizing so it properly inherits and respects parent max-height constraints, preventing unintended overflow and ensuring consistent scrolling behavior and layout stability across affected UI components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->