### PR TITLE
fix(cli): docs command generates fallback URLs when registry has no m…

### DIFF
--- a/packages/cli/src/commands/docs.ts
+++ b/packages/cli/src/commands/docs.ts
@@ -67,7 +67,7 @@ export const docs = new Command()
           links = metaLinks
         }
         else {
-          const fallbackUrl = `${SHADCN_VUE_URL}/${base}/docs/components/${component}`
+          const fallbackUrl = `${SHADCN_VUE_URL}/docs/components/${component}`
           logger.debug(
             `No registry links found for ${highlighter.info(component)} (base: ${highlighter.info(base)}). Using best-effort fallback: ${fallbackUrl}`,
           )

--- a/packages/cli/src/commands/docs.ts
+++ b/packages/cli/src/commands/docs.ts
@@ -62,9 +62,17 @@ export const docs = new Command()
           item.meta?.links as Record<string, Record<string, string>> | undefined
         )?.[base]
 
-        const links = metaLinks && Object.keys(metaLinks).length > 0
-          ? metaLinks
-          : { docs: `${SHADCN_VUE_URL}/docs/components/${component}` }
+        let links: Record<string, string>
+        if (metaLinks && Object.keys(metaLinks).length > 0) {
+          links = metaLinks
+        }
+        else {
+          const fallbackUrl = `${SHADCN_VUE_URL}/${base}/docs/components/${component}`
+          logger.debug(
+            `No registry links found for ${highlighter.info(component)} (base: ${highlighter.info(base)}). Using best-effort fallback: ${fallbackUrl}`,
+          )
+          links = { docs: fallbackUrl }
+        }
 
         results.push({ component, base, links })
       }

--- a/packages/cli/src/commands/docs.ts
+++ b/packages/cli/src/commands/docs.ts
@@ -2,15 +2,11 @@ import { Command } from 'commander'
 import consola from 'consola'
 import path from 'pathe'
 import { getShadcnRegistryIndex } from '@/src/registry/api'
+import { SHADCN_VUE_URL } from '@/src/registry/constants'
 import { getConfig } from '@/src/utils/get-config'
 import { handleError } from '@/src/utils/handle-error'
 import { highlighter } from '@/src/utils/highlighter'
 import { logger } from '@/src/utils/logger'
-
-// NOTE: shadcn-vue uses `reka` as its only base. Docs links are sourced from
-// the registry item's `meta.links[base]` object if the registry exposes them.
-// If the Vue registry does not yet include doc links, the command will warn
-// the user per-component.
 
 export const docs = new Command()
   .name('docs')
@@ -60,18 +56,15 @@ export const docs = new Command()
           process.exit(1)
         }
 
-        const links = (
+        // Use meta.links from the registry if available, otherwise generate
+        // default documentation links from the shadcn-vue website URL.
+        const metaLinks = (
           item.meta?.links as Record<string, Record<string, string>> | undefined
         )?.[base]
 
-        if (!links || Object.keys(links).length === 0) {
-          logger.warn(
-            `No documentation links available for ${highlighter.info(
-              component,
-            )}.`,
-          )
-          continue
-        }
+        const links = metaLinks && Object.keys(metaLinks).length > 0
+          ? metaLinks
+          : { docs: `${SHADCN_VUE_URL}/docs/components/${component}` }
 
         results.push({ component, base, links })
       }


### PR DESCRIPTION
…eta.links

Agent-Logs-Url: https://github.com/imlargo/shadcn-vue/sessions/2ca0afaa-c518-4e5c-a1fe-1147f5797092

<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📸 Screenshots (if appropriate)

<!-- Add screenshots to help explain the change. -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The docs command now includes all components in results by generating fallback documentation links when registry references are missing or empty.
  * Fallback links point to the standard docs location for each component so components are not skipped.
  * Missing registry links now log at debug level with a fallback message instead of warning and skip.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->