### PR TITLE
fix(sonner): overwrite vue-sonner x button color

### DIFF
--- a/apps/v4/registry/bases/reka/ui/sonner/Sonner.vue
+++ b/apps/v4/registry/bases/reka/ui/sonner/Sonner.vue
@@ -15,6 +15,11 @@ const props = defineProps<ToasterProps>()
       '--normal-text': 'var(--popover-foreground)',
       '--normal-border': 'var(--border)',
       '--border-radius': 'var(--radius)',
+      '--gray2': 'hsl(var(--popover) / 0.9)',
+      '--gray3': 'var(--border)',
+      '--gray4': 'var(--border)',
+      '--gray5': 'var(--border)',
+      '--gray12': 'var(--popover-foreground)',
     }"
     :toast-options="{
       classes: {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

https://github.com/unovue/shadcn-vue/issues/1783

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
overwrite fixed style for `x` button in `vue-sonner`, after this change, the `x` button will cat normally with dark mode

### 📸 Screenshots (if appropriate)

<!-- Add screenshots to help explain the change. -->

<img width="394" height="87" alt="image" src="https://github.com/user-attachments/assets/faf9ec33-162d-42ea-859c-fda56b737036" />

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced theme variable support for the notification component to ensure improved color consistency and better alignment with the design system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->