### PR TITLE
feat(cli): add pointer cursor init option

### DIFF
--- a/apps/v4/components/CreateProjectDialog.vue
+++ b/apps/v4/components/CreateProjectDialog.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { Copy01Icon, Tick02Icon } from '@hugeicons/core-free-icons'
+import { Copy01Icon, HandPointingRight04Icon, Tick02Icon } from '@hugeicons/core-free-icons'
 import { HugeiconsIcon } from '@hugeicons/vue'
 import { useClipboard } from '@vueuse/core'
 import { PACKAGE_MANAGERS, TEMPLATES } from '@/lib/templates'
@@ -21,6 +21,7 @@ import {
   FieldTitle,
 } from '@/styles/reka-nova/ui/field'
 import { RadioGroup, RadioGroupItem } from '@/styles/reka-nova/ui/radio-group'
+import { Switch } from '@/styles/reka-nova/ui/switch'
 import {
   Tabs,
   TabsContent,
@@ -37,7 +38,8 @@ const { config } = useConfig()
 const presetId = computed(() => params.preset.value)
 
 const commands = computed(() => {
-  const flags = `--preset ${presetId.value} --template ${params.template.value ?? 'nuxt'}`
+  const pointerFlag = params.pointer.value ? ' --pointer' : ''
+  const flags = `--preset ${presetId.value} --template ${params.template.value ?? 'nuxt'}${pointerFlag}`
   return {
     pnpm: `pnpm dlx shadcn-vue@latest init ${flags}`,
     npm: `npx shadcn-vue@latest init ${flags}`,
@@ -102,6 +104,21 @@ function handleCopy() {
                 </Field>
               </FieldLabel>
             </RadioGroup>
+          </Field>
+          <FieldSeparator class="-mx-6" />
+          <Field orientation="horizontal">
+            <FieldLabel for="pointer" class="gap-2">
+              <HugeiconsIcon
+                :icon="HandPointingRight04Icon"
+                class="size-4 -rotate-90"
+              />
+              Use pointer on buttons
+            </FieldLabel>
+            <Switch
+              id="pointer"
+              :model-value="params.pointer.value"
+              @update:model-value="params.pointer.value = $event === true"
+            />
           </Field>
         </FieldGroup>
       </div>

--- a/apps/v4/components/ShareButton.vue
+++ b/apps/v4/components/ShareButton.vue
@@ -11,11 +11,19 @@ import {
   TooltipTrigger,
 } from '@/registry/new-york-v4/ui/tooltip'
 
-const route = useRoute()
+const params = useDesignSystemSearchParams()
 const { copy, copied } = useClipboard()
 
 function handleCopy() {
-  copy(window.location.href)
+  const url = new URL(window.location.href)
+  if (params.pointer.value) {
+    url.searchParams.set('pointer', 'true')
+  }
+  else {
+    url.searchParams.delete('pointer')
+  }
+
+  copy(url.toString())
 }
 </script>
 

--- a/apps/v4/composables/useDesignSystemProvider.ts
+++ b/apps/v4/composables/useDesignSystemProvider.ts
@@ -1,9 +1,15 @@
 import type { DesignSystemConfig } from '~/registry/config'
 import { FONTS } from '~/lib/fonts'
-import { buildRegistryTheme, DEFAULT_CONFIG, getTheme } from '~/registry/config'
+import { buildRegistryTheme, DEFAULT_CONFIG, getTheme, POINTER_CURSOR_SELECTOR } from '~/registry/config'
 
 const THEME_STYLE_ELEMENT_ID = 'design-system-theme-vars'
 const MANAGED_BODY_CLASS_PREFIXES = ['style-', 'base-color-'] as const
+const POINTER_CURSOR_CSS = `@layer base {
+  ${POINTER_CURSOR_SELECTOR} {
+    cursor: pointer;
+  }
+}
+`
 
 function removeManagedBodyClasses(body: Element) {
   for (const className of Array.from(body.classList)) {
@@ -38,6 +44,7 @@ export function useDesignSystemProvider() {
     radius,
     iconLibrary,
     chartColor,
+    pointer,
   } = useDesignSystemSearchParams('replace')
   const colorMode = useColorMode()
 
@@ -56,6 +63,9 @@ export function useDesignSystemProvider() {
     radius.value = value.radius
     iconLibrary.value = value.iconLibrary
     chartColor.value = value.chartColor
+    if ('pointer' in value) {
+      pointer.value = value.pointer === true
+    }
   })
 
   const isReady = ref(false)
@@ -214,7 +224,8 @@ export function useDesignSystemProvider() {
     styleElement.textContent = [
       buildCssRule(':root', mergedLight),
       buildCssRule('.dark', mergedDark),
-    ].join('\n')
+      pointer.value ? POINTER_CURSOR_CSS : '',
+    ].filter(Boolean).join('\n')
   })
 
   // Handle menu color inversion by adding/removing dark class to elements with cn-menu-target.

--- a/apps/v4/composables/useDesignSystemSearchParams.ts
+++ b/apps/v4/composables/useDesignSystemSearchParams.ts
@@ -45,6 +45,7 @@ export function useDesignSystemSearchParams(mode: 'push' | 'replace' = 'push') {
   const item = useRouteQuery<string>('item', 'preview-02', DEFAULT_OPTIONS)
   const template = useRouteQuery<'nuxt' | 'vite' | 'laravel' | 'astro'>('template', 'nuxt', DEFAULT_OPTIONS)
   const size = useRouteQuery<number>('size', 100, DEFAULT_OPTIONS)
+  const pointerQuery = useRouteQuery<string | undefined>('pointer', undefined, DEFAULT_OPTIONS)
 
   const preset = useRouteQuery<string>('preset', DEFAULT_PRESET, DEFAULT_OPTIONS)
 
@@ -76,6 +77,12 @@ export function useDesignSystemSearchParams(mode: 'push' | 'replace' = 'push') {
   const iconLibrary = presetField<IconLibraryName>('iconLibrary')
   const menuColor = presetField<MenuColorValue>('menuColor')
   const menuAccent = presetField<MenuAccentValue>('menuAccent')
+  const pointer = computed<boolean>({
+    get: () => pointerQuery.value === 'true',
+    set: (value) => {
+      pointerQuery.value = value ? 'true' : undefined
+    },
+  })
 
   return {
     base,
@@ -91,6 +98,7 @@ export function useDesignSystemSearchParams(mode: 'push' | 'replace' = 'push') {
     menuColor,
     radius,
     template,
+    pointer,
     size,
     preset,
   }

--- a/apps/v4/content/docs/06.cli.md
+++ b/apps/v4/content/docs/06.cli.md
@@ -43,6 +43,8 @@ Options:
   --no-reinstall                 do not re-install existing UI components.
   --rtl                          enable RTL support.
   --no-rtl                       disable RTL support.
+  --pointer                      enable pointer cursor for buttons.
+  --no-pointer                   disable pointer cursor for buttons.
   --css-variables                use css variables for theming. (default: true)
   --no-css-variables             do not use css variables for theming.
   --no-base-style                do not install the base shadcn style.

--- a/apps/v4/content/docs/components/button.md
+++ b/apps/v4/content/docs/components/button.md
@@ -82,6 +82,8 @@ Tailwind v4 [switched](https://tailwindcss.com/docs/upgrade-guide#buttons-use-th
 
 If you want to keep the `cursor: pointer` behavior, add the following code to your CSS file:
 
+You can also enable this during project setup with `npx shadcn-vue@latest init --pointer`.
+
 ```css showLineNumbers title="tailwind.css"
 @layer base {
   button:not(:disabled),

--- a/apps/v4/lib/parse-design-system-config.ts
+++ b/apps/v4/lib/parse-design-system-config.ts
@@ -20,6 +20,7 @@ export function parseDesignSystemConfig(
       base: searchParams.base ?? decoded.base,
       template: searchParams.template,
       rtl: searchParams.rtl === 'true',
+      pointer: searchParams.pointer === 'true',
     }
   }
   else {
@@ -36,6 +37,7 @@ export function parseDesignSystemConfig(
       radius: searchParams.radius,
       template: searchParams.template,
       rtl: searchParams.rtl === 'true',
+      pointer: searchParams.pointer === 'true',
     }
   }
 
@@ -50,6 +52,7 @@ export function parseDesignSystemConfig(
     data: {
       ...result.data,
       rtl: configInput.rtl === true,
-    } as DesignSystemConfig & { rtl: boolean },
+      pointer: configInput.pointer === true,
+    } as DesignSystemConfig & { rtl: boolean, pointer: boolean },
   }
 }

--- a/apps/v4/public/schema.json
+++ b/apps/v4/public/schema.json
@@ -72,6 +72,9 @@
     "rtl": {
       "type": "boolean"
     },
+    "pointer": {
+      "type": "boolean"
+    },
     "registries": {
       "type": "object",
       "patternProperties": {

--- a/apps/v4/registry/config.ts
+++ b/apps/v4/registry/config.ts
@@ -26,6 +26,9 @@ export type StyleName = Style["name"]
 export type ThemeName = Theme["name"]
 export type BaseColorName = BaseColor["name"]
 
+export const POINTER_CURSOR_SELECTOR
+  = "button:not(:disabled), [role=\"button\"]:not(:disabled)"
+
 // Derive font values from registry fonts (e.g., "font-inter" -> "inter").
 const fontValues = fonts.map(f => f.name.replace("font-", "")) as [
   string,
@@ -104,6 +107,7 @@ export const designSystemConfigSchema = z
       .enum(RADII.map(r => r.name) as [RadiusValue, ...RadiusValue[]])
       .default("default"),
     template: z.enum(["nuxt", "vite", "laravel", "astro"]).default("nuxt").optional(),
+    pointer: z.boolean().default(false),
   })
   .refine(
     (data) => {
@@ -131,13 +135,14 @@ export const DEFAULT_CONFIG: DesignSystemConfig = {
   menuColor: "default",
   radius: "default",
   template: "nuxt",
+  pointer: false,
 }
 
 export type Preset = {
   name: string
   title: string
   description: string
-} & DesignSystemConfig
+} & Omit<DesignSystemConfig, "pointer">
 
 export const PRESETS: Preset[] = [
   {
@@ -324,7 +329,7 @@ export function buildRegistryTheme(config: DesignSystemConfig) {
 
 // Builds a registry:base item from a design system config.
 export function buildRegistryBase(
-  config: DesignSystemConfig & { rtl?: boolean },
+  config: DesignSystemConfig & { rtl?: boolean, pointer?: boolean },
 ) {
   const baseItem = getBase(config.base)
   const iconLibraryItem = getIconLibrary(config.iconLibrary)
@@ -413,6 +418,7 @@ export function buildRegistryBase(
       ...(normalizedFontHeading !== "inherit"
         && { fontHeading: normalizedFontHeading }),
       rtl: config.rtl ?? false,
+      pointer: config.pointer ?? false,
       menuColor: config.menuColor,
       menuAccent: config.menuAccent,
       tailwind: {
@@ -431,6 +437,11 @@ export function buildRegistryBase(
       "@layer base": {
         "*": { "@apply border-border outline-ring/50": {} },
         "body": bodyRules,
+        ...(config.pointer && {
+          [POINTER_CURSOR_SELECTOR]: {
+            cursor: "pointer",
+          },
+        }),
       },
     },
   }

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -181,7 +181,29 @@ export const initOptionsSchema = z.object({
   monorepo: z.boolean().optional(),
   reinstall: z.boolean().optional(),
   rtl: z.boolean().optional(),
+  pointer: z.boolean().optional(),
 })
+
+export function applyInitUrlOptions(
+  url: URL,
+  options: Pick<z.infer<typeof initOptionsSchema>, 'rtl' | 'pointer'>,
+) {
+  if (options.rtl) {
+    url.searchParams.set('rtl', 'true')
+  }
+  else if (options.rtl === false) {
+    url.searchParams.delete('rtl')
+  }
+
+  if (options.pointer) {
+    url.searchParams.set('pointer', 'true')
+  }
+  else if (options.pointer === false) {
+    url.searchParams.delete('pointer')
+  }
+
+  return url
+}
 
 export const init = new Command()
   .name('init')
@@ -249,6 +271,8 @@ export const init = new Command()
   .option('--no-reinstall', 'do not re-install existing UI components.')
   .option('--rtl', 'enable RTL support.')
   .option('--no-rtl', 'disable RTL support.')
+  .option('--pointer', 'enable pointer cursor for buttons.')
+  .option('--no-pointer', 'disable pointer cursor for buttons.')
   .action(async (components, opts) => {
     // NOTE: --monorepo is not yet supported in shadcn-vue since Vue-specific
     // monorepo templates aren't available. We keep the flag for parity so
@@ -313,6 +337,7 @@ export const init = new Command()
         if (presetArg === true) {
           const result = await promptForPreset({
             rtl: options.rtl ?? false,
+            pointer: options.pointer,
             template: options.template,
             base: options.base ?? (await promptForBase()),
           })
@@ -336,12 +361,7 @@ export const init = new Command()
 
           if (isUrl(presetArg)) {
             const url = new URL(presetArg)
-            if (options.rtl) {
-              url.searchParams.set('rtl', 'true')
-            }
-            else if (options.rtl === false) {
-              url.searchParams.delete('rtl')
-            }
+            applyInitUrlOptions(url, options)
             initUrl = url.toString()
           }
           else if (isPresetCode(presetArg)) {
@@ -359,7 +379,7 @@ export const init = new Command()
                 base: options.base ?? 'reka',
                 rtl: options.rtl ?? false,
               },
-              { template: options.template, preset: presetArg },
+              { template: options.template, preset: presetArg, pointer: options.pointer },
             )
           }
           else {
@@ -373,7 +393,7 @@ export const init = new Command()
                 base: options.base ?? preset.base,
                 rtl: options.rtl ?? preset.rtl,
               },
-              { template: options.template },
+              { template: options.template, pointer: options.pointer },
             )
           }
 
@@ -583,6 +603,11 @@ export async function runInit(
     config.rtl = options.rtl
   }
 
+  // pointer from CLI takes priority over registryBaseConfig.
+  if (options.pointer !== undefined) {
+    config.pointer = options.pointer
+  }
+
   // Make sure to filter out built-in registries.
   // TODO: fix this in ensureRegistriesInConfig.
   config.registries = Object.fromEntries(
@@ -781,6 +806,7 @@ async function promptForConfig(defaultConfig: Config | null = null, opts?: z.inf
     font,
     iconLibrary,
     rtl: opts?.rtl ?? false,
+    pointer: opts?.pointer ?? false,
     tailwind: {
       config: tailwindConfig,
       css: tailwindCss,
@@ -899,6 +925,7 @@ async function promptForMinimalConfig(
       && { fontHeading: defaultConfig.fontHeading }),
     iconLibrary,
     rtl: opts.rtl ?? defaultConfig.rtl ?? false,
+    pointer: opts.pointer ?? defaultConfig.pointer ?? false,
     tailwind: {
       ...defaultConfig?.tailwind,
       baseColor,

--- a/packages/cli/src/preset/presets.ts
+++ b/packages/cli/src/preset/presets.ts
@@ -112,11 +112,12 @@ export function resolveCreateUrl(
     command: 'create' | 'init'
     template: string
     rtl: boolean
+    pointer: boolean
     base: string
   }>,
 ) {
   const url = new URL(`${SHADCN_VUE_URL}/create`)
-  const { rtl, ...params } = searchParams ?? {}
+  const { rtl, pointer, ...params } = searchParams ?? {}
 
   for (const [key, value] of Object.entries(params)) {
     if (value !== undefined) {
@@ -126,6 +127,10 @@ export function resolveCreateUrl(
 
   if (rtl) {
     url.searchParams.set('rtl', 'true')
+  }
+
+  if (pointer) {
+    url.searchParams.set('pointer', 'true')
   }
 
   return url.toString()
@@ -173,7 +178,7 @@ export function resolveInitUrl(
     menuColor: string
     radius: string
   },
-  options?: { template?: string, preset?: string },
+  options?: { template?: string, preset?: string, pointer?: boolean },
 ) {
   const params = new URLSearchParams({
     base: preset.base,
@@ -202,6 +207,10 @@ export function resolveInitUrl(
     params.set('template', options.template)
   }
 
+  if (options?.pointer) {
+    params.set('pointer', 'true')
+  }
+
   // Signal the server to record this init run.
   params.set('track', '1')
 
@@ -221,6 +230,7 @@ export type PromptForPresetResult
 
 export async function promptForPreset(options: {
   rtl: boolean
+  pointer?: boolean
   base: string
   template?: string
 }): Promise<PromptForPresetResult> {
@@ -252,6 +262,7 @@ export async function promptForPreset(options: {
     const createUrl = resolveCreateUrl({
       command: 'init',
       rtl: options.rtl,
+      pointer: options.pointer,
       base: options.base,
       ...(options.template && { template: options.template }),
     })
@@ -273,6 +284,7 @@ export async function promptForPreset(options: {
       { ...preset, base: options.base, rtl: options.rtl },
       {
         template: options.template,
+        pointer: options.pointer,
       },
     ),
     base: options.base,

--- a/packages/cli/src/registry/schema.ts
+++ b/packages/cli/src/registry/schema.ts
@@ -41,6 +41,7 @@ export const rawConfigSchema = z
     }),
     iconLibrary: z.string().optional(),
     rtl: z.boolean().default(false).optional(),
+    pointer: z.boolean().default(false).optional(),
     menuColor: z
       .enum([
         "default",

--- a/packages/cli/test/commands/init.test.ts
+++ b/packages/cli/test/commands/init.test.ts
@@ -3,8 +3,8 @@ import { addDependency } from 'nypm'
 import path from 'pathe'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { initOptionsSchema, runInit } from '../../src/commands/init'
-import { DEFAULT_PRESETS } from '../../src/preset/presets'
+import { applyInitUrlOptions, initOptionsSchema, runInit } from '../../src/commands/init'
+import { DEFAULT_PRESETS, resolveCreateUrl, resolveInitUrl } from '../../src/preset/presets'
 import * as registry from '../../src/registry'
 import { getConfig } from '../../src/utils/get-config'
 
@@ -150,6 +150,29 @@ describe('initOptionsSchema', () => {
     expect(result.preset).toBeUndefined()
   })
 
+  it('parses pointer flags', () => {
+    const result = initOptionsSchema.parse({ ...base, pointer: true })
+    expect(result.pointer).toBe(true)
+  })
+
+  it('applies pointer to raw init urls', () => {
+    const url = applyInitUrlOptions(
+      new URL('https://shadcn-vue.com/init?preset=a0'),
+      { pointer: true },
+    )
+
+    expect(url.searchParams.get('pointer')).toBe('true')
+  })
+
+  it('removes pointer from raw init urls when disabled', () => {
+    const url = applyInitUrlOptions(
+      new URL('https://shadcn-vue.com/init?preset=a0&pointer=true'),
+      { pointer: false },
+    )
+
+    expect(url.searchParams.has('pointer')).toBe(false)
+  })
+
   it('accepts valid style', () => {
     const result = initOptionsSchema.parse({ ...base, style: 'vega' })
     expect(result.style).toBe('vega')
@@ -194,6 +217,39 @@ describe('default presets', () => {
       expect(preset.fontHeading).toBeDefined()
       expect(preset.rtl).toBeDefined()
     }
+  })
+})
+
+describe('preset urls', () => {
+  it('should append search params when provided', () => {
+    const url = resolveCreateUrl({ rtl: true, pointer: true, template: 'nuxt' })
+    const parsed = new URL(url)
+
+    expect(parsed.searchParams.get('rtl')).toBe('true')
+    expect(parsed.searchParams.get('pointer')).toBe('true')
+    expect(parsed.searchParams.get('template')).toBe('nuxt')
+  })
+
+  it('should include pointer when enabled', () => {
+    const url = resolveInitUrl(DEFAULT_PRESETS.nova, { pointer: true })
+    const parsed = new URL(url)
+
+    expect(parsed.searchParams.get('pointer')).toBe('true')
+  })
+
+  it('should not include pointer when disabled', () => {
+    const url = resolveInitUrl(DEFAULT_PRESETS.nova, { pointer: false })
+    const parsed = new URL(url)
+
+    expect(parsed.searchParams.has('pointer')).toBe(false)
+  })
+
+  it('should include pointer with preset codes', () => {
+    const url = resolveInitUrl(DEFAULT_PRESETS.nova, { preset: 'a0', pointer: true })
+    const parsed = new URL(url)
+
+    expect(parsed.searchParams.get('preset')).toBe('a0')
+    expect(parsed.searchParams.get('pointer')).toBe('true')
   })
 })
 


### PR DESCRIPTION
### 🔗 Linked issue

Port of upstream shadcn-ui PR: https://github.com/shadcn-ui/ui/pull/10488
https://github.com/unovue/shadcn-vue/issues/1685

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This ports the upstream `--pointer` init option to shadcn-vue.

Users can now enable `cursor: pointer` for buttons during project setup:

```bash
npx shadcn-vue@latest init --pointer
```

The option is treated as a project setup flag, similar to `rtl`, and is not encoded into preset codes.

Changes include:

- Adds `--pointer` and `--no-pointer` to the CLI `init` command.
- Threads `pointer` through init URL handling, preset code resolution, and create/init URL builders.
- Parses `pointer=true` in the v4 init config flow.
- Adds `pointer` to the design system config schema with a default of `false`.
- Emits pointer cursor CSS from `buildRegistryBase` only when enabled:

```css
button:not(:disabled),
[role="button"]:not(:disabled) {
  cursor: pointer;
}
```

- Adds pointer support to the v4 create UI:
  - pointer toggle in the create project dialog
  - `--pointer` in generated install commands
  - pointer state in shared create URLs
  - pointer CSS in preview
- Updates public schema and CLI documentation.
- Adds regression coverage for CLI option parsing, URL propagation, and config schema support.

### 📸 Screenshots (if appropriate)

Not applicable.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

### ✅ Testing

```bash
pnpm --filter shadcn-vue test test/commands/init.test.ts test/utils/schema.test.ts
```

Result:

```text
Test Files  2 passed (2)
Tests       34 passed | 1 skipped (35)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a pointer-cursor option across init, create, share, and config flows so buttons can use a pointer cursor and the setting is preserved in URLs and generated projects.
* **Documentation**
  * Updated CLI and button docs to describe the new pointer init options.
* **Tests**
  * Extended CLI init tests to cover pointer flag parsing and URL behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->