### PR TITLE
fix(cli): route init dependency installs through detected package manager

### DIFF
--- a/packages/cli/src/utils/add-components.ts
+++ b/packages/cli/src/utils/add-components.ts
@@ -257,7 +257,6 @@ async function addWorkspaceComponents(
     mainTargetConfig,
     {
       silent: true,
-
     },
   )
 

--- a/packages/cli/src/utils/create-project.ts
+++ b/packages/cli/src/utils/create-project.ts
@@ -2,7 +2,6 @@ import type { z } from 'zod'
 import type { initOptionsSchema } from '@/src/commands/init'
 import fs from 'fs-extra'
 import { downloadTemplate } from 'giget'
-import { detectPackageManager } from 'nypm'
 import path from 'pathe'
 import prompts from 'prompts'
 import { x } from 'tinyexec'
@@ -10,6 +9,7 @@ import { handleError } from '@/src/utils/handle-error'
 import { highlighter } from '@/src/utils/highlighter'
 import { logger } from '@/src/utils/logger'
 import { spinner } from '@/src/utils/spinner'
+import { getPackageManager } from '@/src/utils/updaters/update-dependencies'
 
 export const TEMPLATES = {
   nuxt: 'nuxt',
@@ -67,7 +67,13 @@ export async function createProject(
     projectName = name ?? projectName
   }
 
-  const packageManager = await detectPackageManager(options.cwd)
+  // Detect once up front (from parent cwd) so we can use the same PM the user
+  // invoked us with (e.g. `pnpm dlx`) when installing template deps. With
+  // `withFallback`, falls through to `npm_config_user_agent` when no lockfile
+  // is found in the parent dir.
+  const packageManager = await getPackageManager(options.cwd, {
+    withFallback: true,
+  })
 
   const projectPath = `${options.cwd}/${projectName}`
 
@@ -127,7 +133,7 @@ export async function createProject(
     })
 
     // Install dependencies
-    await x(packageManager?.name || 'npm', ['install'], {
+    await x(packageManager, ['install'], {
       throwOnError: true,
       nodeOptions: {
         cwd: projectPath,

--- a/packages/cli/src/utils/updaters/update-dependencies.ts
+++ b/packages/cli/src/utils/updaters/update-dependencies.ts
@@ -1,7 +1,61 @@
+import type { PackageManagerName } from 'nypm'
 import type { RegistryItem } from '@/src/schema'
 import type { Config } from '@/src/utils/get-config'
-import { addDependency } from 'nypm'
+import fs from 'node:fs'
+import path from 'node:path'
+import { detectPackageManager } from 'nypm'
+import { x } from 'tinyexec'
 import { spinner } from '@/src/utils/spinner'
+
+export type SupportedPackageManager = PackageManagerName
+
+/**
+ * Detect the package manager in use for `cwd`. Mirrors shadcn-ui's
+ * `getPackageManager` API.
+ *
+ * Detection order:
+ * 1. `nypm.detectPackageManager` (lockfile / `packageManager` field)
+ * 2. `node_modules/.pnpm` directory — strong signal pnpm was used even when
+ *    the lockfile is missing (e.g. interrupted prior install)
+ * 3. With `withFallback: true`, the parent process' `npm_config_user_agent`
+ *    (e.g. `pnpm dlx` exports `pnpm/<version> ...`)
+ * 4. Fallback to `'npm'`
+ */
+export async function getPackageManager(
+  cwd: string,
+  { withFallback }: { withFallback?: boolean } = { withFallback: false },
+): Promise<SupportedPackageManager> {
+  const detected = await detectPackageManager(cwd)
+  if (detected?.name) {
+    return detected.name
+  }
+
+  if (fs.existsSync(path.join(cwd, 'node_modules', '.pnpm'))) {
+    return 'pnpm'
+  }
+
+  if (!withFallback) {
+    return 'npm'
+  }
+
+  return getPackageManagerFromUserAgent() ?? 'npm'
+}
+
+export function getPackageManagerFromUserAgent(
+  userAgent: string = process.env.npm_config_user_agent ?? '',
+): SupportedPackageManager | null {
+  if (userAgent.startsWith('pnpm'))
+    return 'pnpm'
+  if (userAgent.startsWith('yarn'))
+    return 'yarn'
+  if (userAgent.startsWith('bun'))
+    return 'bun'
+  if (userAgent.startsWith('deno'))
+    return 'deno'
+  if (userAgent.startsWith('npm'))
+    return 'npm'
+  return null
+}
 
 export async function updateDependencies(
   dependencies: RegistryItem['dependencies'],
@@ -23,25 +77,94 @@ export async function updateDependencies(
     ...options,
   }
 
-  const dependenciesSpinner = spinner(`Installing dependencies.`, { silent: options.silent })?.start()
-  dependenciesSpinner?.start()
+  const dependenciesSpinner = spinner(`Installing dependencies.`, {
+    silent: options.silent,
+  })?.start()
 
-  if (dependencies?.length) {
-    await addDependency(dependencies, {
-      cwd: config.resolvedPaths.cwd,
-      silent: true,
-      dev: false,
-    })
-  }
+  const packageManager = await getPackageManager(config.resolvedPaths.cwd, {
+    withFallback: true,
+  })
 
-  // Install dev dependencies
-  if (devDependencies?.length) {
-    await addDependency(devDependencies, {
-      cwd: config.resolvedPaths.cwd,
-      silent: true,
-      dev: true,
-    })
-  }
+  await installWithPackageManager(
+    packageManager,
+    dependencies,
+    devDependencies,
+    config.resolvedPaths.cwd,
+  )
 
   dependenciesSpinner?.succeed()
+}
+
+async function installWithPackageManager(
+  packageManager: SupportedPackageManager,
+  dependencies: string[],
+  devDependencies: string[],
+  cwd: string,
+) {
+  if (packageManager === 'npm') {
+    return installWithNpm(dependencies, devDependencies, cwd)
+  }
+
+  if (packageManager === 'deno') {
+    return installWithDeno(dependencies, devDependencies, cwd)
+  }
+
+  // pnpm, yarn, bun all use `add` / `add -D`.
+  if (dependencies?.length) {
+    await x(packageManager, ['add', ...dependencies], {
+      throwOnError: true,
+      nodeOptions: { cwd },
+    })
+  }
+
+  if (devDependencies?.length) {
+    await x(packageManager, ['add', '-D', ...devDependencies], {
+      throwOnError: true,
+      nodeOptions: { cwd },
+    })
+  }
+}
+
+async function installWithNpm(
+  dependencies: string[],
+  devDependencies: string[],
+  cwd: string,
+) {
+  if (dependencies?.length) {
+    await x('npm', ['install', ...dependencies], {
+      throwOnError: true,
+      nodeOptions: { cwd },
+    })
+  }
+
+  if (devDependencies?.length) {
+    await x('npm', ['install', '-D', ...devDependencies], {
+      throwOnError: true,
+      nodeOptions: { cwd },
+    })
+  }
+}
+
+async function installWithDeno(
+  dependencies: string[],
+  devDependencies: string[],
+  cwd: string,
+) {
+  if (dependencies?.length) {
+    await x('deno', ['add', ...dependencies.map(dep => `npm:${dep}`)], {
+      throwOnError: true,
+      nodeOptions: { cwd },
+    })
+  }
+
+  if (devDependencies?.length) {
+    await x(
+      'deno',
+      ['add', '-D', ...devDependencies.map(dep => `npm:${dep}`)],
+      {
+        throwOnError: true,
+        nodeOptions: { cwd },
+      },
+    )
+  }
 }

--- a/packages/cli/test/utils/create-project.test.ts
+++ b/packages/cli/test/utils/create-project.test.ts
@@ -1,6 +1,7 @@
 import type { MockInstance } from 'vitest'
 import fs from 'fs-extra'
 import { downloadTemplate } from 'giget'
+import { detectPackageManager } from 'nypm'
 import prompts from 'prompts'
 import { x } from 'tinyexec'
 import {
@@ -21,7 +22,7 @@ vi.mock('giget')
 vi.mock('tinyexec')
 vi.mock('prompts')
 vi.mock('nypm', () => ({
-  detectPackageManager: vi.fn().mockResolvedValue({ name: 'npm' }),
+  detectPackageManager: vi.fn(),
 }))
 vi.mock('@/src/utils/spinner')
 vi.mock('@/src/utils/logger', () => ({
@@ -37,6 +38,13 @@ describe('createProject', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+
+    // Stable PM detection across tests so we don't fall back to the test
+    // runner's npm_config_user_agent (which would be `pnpm/...`).
+    vi.mocked(detectPackageManager).mockResolvedValue({
+      name: 'npm',
+      command: 'npm',
+    })
 
     // Reset all fs mocks
     vi.mocked(fs.access).mockResolvedValue(undefined)


### PR DESCRIPTION
### 🔗 Linked issue

Fixes #1801

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

`shadcn-vue init` would crash during the registry-dependency install step when the project was already laid out by pnpm but pnpm's lockfile wasn't picked up by detection (e.g. `node_modules/.pnpm/` present but no `pnpm-lock.yaml`). `nypm.addDependency` then fell back to `npm`, which ran lifecycle scripts on pre-existing pnpm-installed packages — failing on fragile prepare scripts (the reporter saw `vp: not found` from `eslint-plugin-oxlint`).

This refactors dependency install to mirror shadcn-ui's pattern:

- New `getPackageManager(cwd, { withFallback })` helper with a clear detection order:
  1. `nypm.detectPackageManager` (lockfile / `packageManager` field)
  2. `node_modules/.pnpm` directory — strong signal pnpm was used even when the lockfile is missing
  3. `npm_config_user_agent` (when `withFallback` is true, e.g. `pnpm dlx`)
  4. Fallback to `npm`
- `updateDependencies` now goes through explicit per-PM install commands (`pnpm add`, `yarn add`, `bun add`, `npm install`, `deno add`) via `tinyexec` instead of `nypm.addDependency`'s opaque wrapper. No more accidental PM switching mid-init.
- `createProject` uses the same helper with `withFallback: true` so `pnpm dlx shadcn-vue init` stays on pnpm even in a parent dir without a lockfile.

The `.pnpm`-dir fallback and `withFallback: true` in `updateDependencies` are deliberately stricter than shadcn-ui — those are the two signals that would have caught #1801.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

### Test plan

- [x] `pnpm test` — 424 pass, no regressions
- [x] `pnpm lint` clean (only the pre-existing `search.ts` warning)
- [x] Local end-to-end repro of #1801's condition (`node_modules/.pnpm` present, no `pnpm-lock.yaml`) — `updateDependencies` produces `pnpm-lock.yaml`, not `package-lock.json`
- [x] Detection table validated across 13 scenarios: lockfile-present, `.pnpm`-dir-only, user-agent-only, no signals, etc.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced package manager detection and support for npm, pnpm, yarn, bun, and deno in CLI operations.

* **Bug Fixes**
  * Improved dependency installation reliability by directly using the detected package manager instead of fallback mechanisms.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unovue/shadcn-vue/pull/1803)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->