### PR TITLE
fix(cli): include package manager in project info

### DIFF
--- a/packages/cli/src/utils/get-project-info.ts
+++ b/packages/cli/src/utils/get-project-info.ts
@@ -11,6 +11,7 @@ import { getShadcnRegistryIndex } from '@/src/registry/api'
 import { FRAMEWORKS } from '@/src/utils/frameworks'
 import { getConfig, resolveConfigPaths } from '@/src/utils/get-config'
 import { getPackageInfo } from '@/src/utils/get-package-info'
+import { getPackageManager } from '@/src/utils/updaters/update-dependencies'
 
 export type TailwindVersion = 'v3' | 'v4' | null
 
@@ -24,6 +25,7 @@ export interface ProjectInfo {
   tailwindCssFile: string | null
   tailwindVersion: TailwindVersion
   aliasPrefix: string | null
+  packageManager: string
 }
 
 const PROJECT_SHARED_IGNORE = [
@@ -112,6 +114,7 @@ export async function getProjectInfo(cwd: string): Promise<ProjectInfo | null> {
     tailwindVersion,
     aliasPrefix,
     packageJson,
+    packageManager,
   ] = await Promise.all([
     detectFrameworkConfigFiles(cwd),
     isTypeScriptProject(cwd),
@@ -121,6 +124,7 @@ export async function getProjectInfo(cwd: string): Promise<ProjectInfo | null> {
     getTailwindVersion(cwd),
     getTsConfigAliasPrefix(cwd),
     getPackageInfo(cwd, false),
+    getPackageManager(cwd, { withFallback: true }),
   ])
 
   const type: ProjectInfo = {
@@ -131,6 +135,7 @@ export async function getProjectInfo(cwd: string): Promise<ProjectInfo | null> {
     tailwindCssFile,
     tailwindVersion,
     aliasPrefix,
+    packageManager,
   }
 
   return type

--- a/packages/cli/test/utils/get-project-info.test.ts
+++ b/packages/cli/test/utils/get-project-info.test.ts
@@ -16,6 +16,7 @@ describe('get project info', async () => {
         tailwindCssFile: 'assets/css/tailwind.css',
         tailwindVersion: 'v4',
         aliasPrefix: '@',
+        packageManager: 'pnpm',
       },
     },
     {
@@ -28,6 +29,7 @@ describe('get project info', async () => {
         tailwindCssFile: 'src/index.css',
         tailwindVersion: 'v4',
         aliasPrefix: null,
+        packageManager: 'pnpm',
       },
     },
     {
@@ -40,6 +42,7 @@ describe('get project info', async () => {
         tailwindCssFile: 'src/index.css',
         tailwindVersion: 'v3',
         aliasPrefix: null,
+        packageManager: 'pnpm',
       },
     },
   ])(`getProjectType($name) -> $type`, async ({ name, type }) => {


### PR DESCRIPTION
<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
- fix: #1818 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
Resolves #1818.

This PR updates the CLI project info detection to include the detected package manager in the `info` command output.

The documentation states that `shadcn-vue info` includes a `packageManager` field, but the current implementation of `getProjectInfo()` does not return it. This causes the `info` command and `info --json` output to miss the package manager value.

Changes included:

- Add `packageManager` to the `ProjectInfo` result.
- Reuse the existing package manager detection utility.
- Update `get-project-info` tests to assert the new field.

### 📸 Screenshots (if appropriate)

<!-- Add screenshots to help explain the change. -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Package manager detection: The CLI now automatically detects and reports which package manager (npm, yarn, pnpm, etc.) is being used in your project. Package manager information is now included in project analysis results, enabling improved tool integration and providing context-aware features tailored to your project's specific package manager configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unovue/shadcn-vue/pull/1819?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->