### PR TITLE
fix(cli): fall back to root tsconfig for non-PHP Inertia projects

### DIFF
--- a/packages/cli/src/utils/get-config.ts
+++ b/packages/cli/src/utils/get-config.ts
@@ -10,7 +10,7 @@ import {
   rawConfigSchema,
   workspaceConfigSchema,
 } from '@/src/schema'
-import { detectFrameworkConfigFiles, getProjectInfo, isTypeScriptProject } from '@/src/utils/get-project-info'
+import { detectFrameworkConfigFiles, getFrameworkTsConfigPath, getProjectInfo, isTypeScriptProject } from '@/src/utils/get-project-info'
 import { resolveImport } from '@/src/utils/resolve-import'
 
 export const DEFAULT_STYLE = 'default'
@@ -53,15 +53,7 @@ export async function resolveConfigPaths(
 
   const tsConfigPath = path.resolve(
     cwd,
-    detectedFramework?.name === 'nuxt4'
-      ? './.nuxt/tsconfig.app.json'
-      : detectedFramework?.name === 'nuxt3'
-        ? './.nuxt/tsconfig.json'
-        : detectedFramework?.name === 'inertia'
-          ? './inertia/tsconfig.json'
-          : isTypeScript
-            ? './tsconfig.json'
-            : './jsconfig.json',
+    await getFrameworkTsConfigPath(cwd, detectedFramework, isTypeScript),
   )
 
   // Read tsconfig.json.

--- a/packages/cli/src/utils/get-project-info.ts
+++ b/packages/cli/src/utils/get-project-info.ts
@@ -225,18 +225,36 @@ export async function getTailwindConfigFile(cwd: string) {
   return files[0]
 }
 
+export async function getFrameworkTsConfigPath(
+  cwd: string,
+  detectedFramework: Framework | null,
+  isTypeScript: boolean,
+): Promise<string> {
+  if (detectedFramework?.name === 'nuxt4') {
+    return './.nuxt/tsconfig.app.json'
+  }
+  if (detectedFramework?.name === 'nuxt3') {
+    return './.nuxt/tsconfig.json'
+  }
+  // Inertia PHP places tsconfig.json under ./inertia, but other Inertia
+  // integrations (e.g. Inertia + Rails) keep it at the project root. Use the
+  // Inertia-specific path only when it actually exists.
+  if (
+    detectedFramework?.name === 'inertia'
+    && (await fs.pathExists(path.resolve(cwd, 'inertia/tsconfig.json')))
+  ) {
+    return './inertia/tsconfig.json'
+  }
+  return isTypeScript ? './tsconfig.json' : './jsconfig.json'
+}
+
 export async function getTsConfigAliasPrefix(cwd: string) {
   const detectedFramework = await detectFrameworkConfigFiles(cwd)
   const isTypeScript = await isTypeScriptProject(cwd)
-  const tsConfig = await getTsconfig(cwd, detectedFramework?.name === 'nuxt4'
-    ? './.nuxt/tsconfig.app.json'
-    : detectedFramework?.name === 'nuxt3'
-      ? './.nuxt/tsconfig.json'
-      : detectedFramework?.name === 'inertia'
-        ? './inertia/tsconfig.json'
-        : isTypeScript
-          ? './tsconfig.json'
-          : './jsconfig.json')
+  const tsConfig = await getTsconfig(
+    cwd,
+    await getFrameworkTsConfigPath(cwd, detectedFramework, isTypeScript),
+  )
 
   if (
     tsConfig === null

--- a/packages/cli/test/fixtures/frameworks/inertia-adonis/inertia/css/app.css
+++ b/packages/cli/test/fixtures/frameworks/inertia-adonis/inertia/css/app.css
@@ -1,0 +1,1 @@
+@import "tailwindcss";

--- a/packages/cli/test/fixtures/frameworks/inertia-adonis/inertia/tsconfig.json
+++ b/packages/cli/test/fixtures/frameworks/inertia-adonis/inertia/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "jsx": "preserve",
+    "baseUrl": ".",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "paths": {
+      "~/*": ["./*"]
+    },
+    "strict": true
+  },
+  "include": ["./**/*"]
+}

--- a/packages/cli/test/fixtures/frameworks/inertia-adonis/package.json
+++ b/packages/cli/test/fixtures/frameworks/inertia-adonis/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "test-cli-inertia-adonis",
+  "type": "module",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "node ace serve --hmr",
+    "build": "node ace build"
+  },
+  "dependencies": {
+    "@inertiajs/vue3": "^2.0.0",
+    "vue": "^3.5.12"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^5.1.4",
+    "tailwindcss": "^4.0.0",
+    "typescript": "~5.6.3",
+    "vite": "^5.4.10"
+  }
+}

--- a/packages/cli/test/fixtures/frameworks/inertia-adonis/tsconfig.json
+++ b/packages/cli/test/fixtures/frameworks/inertia-adonis/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true
+  },
+  "include": ["**/*"],
+  "exclude": ["node_modules", "build", "inertia"]
+}

--- a/packages/cli/test/fixtures/frameworks/inertia-rails/app/frontend/entrypoint.css
+++ b/packages/cli/test/fixtures/frameworks/inertia-rails/app/frontend/entrypoint.css
@@ -1,0 +1,1 @@
+@import "tailwindcss";

--- a/packages/cli/test/fixtures/frameworks/inertia-rails/package.json
+++ b/packages/cli/test/fixtures/frameworks/inertia-rails/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "test-cli-inertia-rails",
+  "type": "module",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build"
+  },
+  "dependencies": {
+    "@inertiajs/vue3": "^2.0.0",
+    "vue": "^3.5.12"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^5.1.4",
+    "tailwindcss": "^4.0.0",
+    "typescript": "~5.6.3",
+    "vite": "^5.4.10"
+  }
+}

--- a/packages/cli/test/fixtures/frameworks/inertia-rails/tsconfig.json
+++ b/packages/cli/test/fixtures/frameworks/inertia-rails/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "jsx": "preserve",
+    "baseUrl": ".",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "paths": {
+      "@/*": ["./app/frontend/*"]
+    },
+    "strict": true
+  },
+  "include": ["app/frontend/**/*", "app/frontend/**/*.vue"]
+}

--- a/packages/cli/test/fixtures/frameworks/inertia-rails/vite.config.ts
+++ b/packages/cli/test/fixtures/frameworks/inertia-rails/vite.config.ts
@@ -1,0 +1,15 @@
+import { fileURLToPath, URL } from 'node:url'
+
+import vue from '@vitejs/plugin-vue'
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  plugins: [
+    vue(),
+  ],
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./app/frontend', import.meta.url)),
+    },
+  },
+})

--- a/packages/cli/test/utils/get-project-info.test.ts
+++ b/packages/cli/test/utils/get-project-info.test.ts
@@ -45,6 +45,22 @@ describe('get project info', async () => {
         packageManager: 'pnpm',
       },
     },
+    {
+      // Inertia + Rails-style project: @inertiajs/vue3 in deps but no
+      // ./inertia/tsconfig.json — the alias should still resolve from the
+      // root tsconfig.json. See issue #1817.
+      name: 'inertia-rails',
+      type: {
+        framework: FRAMEWORKS.inertia,
+        isSrcDir: false,
+        typescript: true,
+        tailwindConfigFile: null,
+        tailwindCssFile: 'app/frontend/entrypoint.css',
+        tailwindVersion: 'v4',
+        aliasPrefix: '@',
+        packageManager: 'pnpm',
+      },
+    },
   ])(`getProjectType($name) -> $type`, async ({ name, type }) => {
     expect(
       await getProjectInfo(

--- a/packages/cli/test/utils/get-project-info.test.ts
+++ b/packages/cli/test/utils/get-project-info.test.ts
@@ -61,6 +61,22 @@ describe('get project info', async () => {
         packageManager: 'pnpm',
       },
     },
+    {
+      // AdonisJS-style Inertia project: ./inertia/tsconfig.json exists and
+      // must take precedence over the root tsconfig.json (which has no
+      // paths — a regression to the root lookup would yield a null prefix).
+      name: 'inertia-adonis',
+      type: {
+        framework: FRAMEWORKS.inertia,
+        isSrcDir: false,
+        typescript: true,
+        tailwindConfigFile: null,
+        tailwindCssFile: 'inertia/css/app.css',
+        tailwindVersion: 'v4',
+        aliasPrefix: '~',
+        packageManager: 'pnpm',
+      },
+    },
   ])(`getProjectType($name) -> $type`, async ({ name, type }) => {
     expect(
       await getProjectInfo(


### PR DESCRIPTION
## Summary

- Fixes the hardcoded `./inertia/tsconfig.json` lookup for Inertia projects so non-PHP Inertia integrations (e.g. Inertia + Rails) can resolve their root `tsconfig.json` during `init`.
- Extracts the per-framework tsconfig path selection into a shared `getFrameworkTsConfigPath` helper used by both `getTsConfigAliasPrefix` and `resolveConfigPaths`, keeping the two call sites in sync.
- Adds an `inertia-rails` test fixture and a regression test covering the case where `@inertiajs/vue3` is present but no `inertia/` directory exists.

Closes #1817

## Why

`@inertiajs/vue3` in `package.json` triggers `FRAMEWORKS.inertia`, which then hardcodes `./inertia/tsconfig.json` as the path used for alias resolution. That assumption only holds for Inertia PHP — Inertia + Rails (and similar setups) keep `tsconfig.json` at the project root, so `init` fails with:

```
✖ Validating import alias.
No import alias found in your tsconfig.json file.
```

The fix preserves the existing Inertia PHP convention but only when `./inertia/tsconfig.json` actually exists; otherwise it falls back to the standard `./tsconfig.json` / `./jsconfig.json` lookup. This is non-breaking for existing Laravel/Inertia users while unblocking Rails/Inertia users.

## Test plan

- [x] Added `inertia-rails` fixture (root `tsconfig.json`, `@inertiajs/vue3` in deps, no `inertia/` dir) and a new `getProjectInfo` case asserting `aliasPrefix === '@'`.
- [x] Confirmed the new test **fails on the unpatched code** (`aliasPrefix` returns `null`) before applying the helper.
- [x] Full `pnpm --filter shadcn-vue test`: 425 passed / 1 skipped / 4 todo (was 424 passed before, +1 new test).
- [x] Lint clean on touched files.
- [ ] Optional manual verification by reproducing with https://github.com/noxasch/shadcn-rails-inertia-repro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced Inertia project detection for Rails-style layouts, including correct TypeScript alias prefix resolution.

* **Refactor**
  * Improved TypeScript/JavaScript config file selection to honor framework-specific tsconfig files when present, while falling back to the root config when absent.

* **Tests**
  * Added Inertia Rails and Inertia Adonis fixtures (tsconfig, package setup, Vite config, Tailwind entrypoints) and expanded coverage to verify alias resolution precedence and expected configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->