### PR TITLE
fix(cli): normalize quotes when deduping @import in apply

### DIFF
--- a/packages/cli/src/utils/updaters/update-css.ts
+++ b/packages/cli/src/utils/updaters/update-css.ts
@@ -98,12 +98,30 @@ function updateCssPlugin(css: z.infer<typeof registryItemCssSchema>) {
 
           // Special handling for imports - place them at the top.
           if (name === 'import') {
+            // Normalize params for comparison (strip surrounding quotes and
+            // trim whitespace) so we dedupe regardless of quote style — a
+            // file formatted by Prettier/Stylelint may use single quotes
+            // while the registry emits double quotes, otherwise the strict
+            // string compare misses the match and re-applying the preset
+            // duplicates the import.
+            const normalizeImportParams = (p: string) => {
+              const trimmed = p.trim()
+              if (trimmed.startsWith('"') && trimmed.endsWith('"')) {
+                return trimmed.slice(1, -1)
+              }
+              if (trimmed.startsWith('\'') && trimmed.endsWith('\'')) {
+                return trimmed.slice(1, -1)
+              }
+              return trimmed
+            }
+
             // Check if this import already exists.
             const existingImport = root.nodes?.find(
               (node): node is AtRule =>
                 node.type === 'atrule'
                 && node.name === 'import'
-                && node.params === params,
+                && normalizeImportParams(node.params)
+                === normalizeImportParams(params),
             )
 
             if (!existingImport) {

--- a/packages/cli/test/utils/updaters/update-css.test.ts
+++ b/packages/cli/test/utils/updaters/update-css.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+import { transformCss } from '../../../src/utils/updaters/update-css'
+
+describe('transformCss @import dedup', () => {
+  it('does not duplicate an import that already exists with matching quotes', async () => {
+    const input = `@import "tw-animate-css";
+@import "shadcn-vue/tailwind.css";
+
+@custom-variant dark (&:is(.dark *));
+`
+    const css = {
+      '@import "tw-animate-css"': {},
+      '@import "shadcn-vue/tailwind.css"': {},
+    }
+
+    const result = await transformCss(input, css)
+
+    expect((result.match(/@import ["']tw-animate-css["']/g) ?? []).length).toBe(1)
+    expect(
+      (result.match(/@import ["']shadcn-vue\/tailwind\.css["']/g) ?? []).length,
+    ).toBe(1)
+  })
+
+  it('does not duplicate an import when the existing file uses single quotes', async () => {
+    // Mirrors the original report: an `apply` run was duplicating
+    // `tw-animate-css` / `shadcn-vue/tailwind.css` when the project's
+    // `index.css` had been re-formatted with single quotes (e.g. by
+    // Prettier) while the registry emits the same imports with double
+    // quotes.
+    const input = `@import 'tw-animate-css';
+@import 'shadcn-vue/tailwind.css';
+`
+    const css = {
+      '@import "tw-animate-css"': {},
+      '@import "shadcn-vue/tailwind.css"': {},
+    }
+
+    const result = await transformCss(input, css)
+
+    expect((result.match(/@import ["']tw-animate-css["']/g) ?? []).length).toBe(1)
+    expect(
+      (result.match(/@import ["']shadcn-vue\/tailwind\.css["']/g) ?? []).length,
+    ).toBe(1)
+  })
+
+  it('adds a new import when not already present', async () => {
+    const input = `@import "shadcn-vue/tailwind.css";
+`
+    const css = {
+      '@import "tw-animate-css"': {},
+    }
+
+    const result = await transformCss(input, css)
+
+    expect((result.match(/@import ["']tw-animate-css["']/g) ?? []).length).toBe(1)
+    expect(
+      (result.match(/@import ["']shadcn-vue\/tailwind\.css["']/g) ?? []).length,
+    ).toBe(1)
+  })
+})


### PR DESCRIPTION
## Summary

- Fixes #1811: `shadcn-vue apply` was duplicating `@import "tw-animate-css"` and `@import "shadcn-vue/tailwind.css"` in `index.css`.
- Root cause: `updateCssPlugin` deduped `@import` at-rules with a strict `node.params === params` compare. When the project's `index.css` had been re-formatted with single quotes (e.g. by Prettier/Stylelint) and the registry response emits the same imports with double quotes, the strict compare missed the match and the imports were inserted again.
- Fix: normalize the params (strip surrounding quotes, trim) before comparing — same approach already used by the sibling `@plugin` handling a few lines below.

## Test plan

- [x] Added `packages/cli/test/utils/updaters/update-css.test.ts` covering: matching-quote dedup, single-quote-existing vs. double-quote-registry dedup (the reported regression), and adding a new import when not present.
- [x] `pnpm vitest run` in `packages/cli` — 427 passed, 1 skipped, 4 todo.
- [x] `pnpm build` in `packages/cli` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced CSS import handling to prevent duplicate imports in CSS files. The updater now correctly identifies and deduplicates imports with different quote styles or extra whitespace.

* **Tests**
  * Added test coverage for CSS import deduplication scenarios, including handling of quote style variations and whitespace normalization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unovue/shadcn-vue/pull/1821?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->