### PR TITLE
fix(combobox): export local trigger wrapper

### DIFF
--- a/apps/v4/public/r/styles/default/combobox.json
+++ b/apps/v4/public/r/styles/default/combobox.json
@@ -63,7 +63,7 @@
     },
     {
       "path": "ui/combobox/index.ts",
-      "content": "export { default as Combobox } from \"./Combobox.vue\"\nexport { default as ComboboxAnchor } from \"./ComboboxAnchor.vue\"\nexport { default as ComboboxEmpty } from \"./ComboboxEmpty.vue\"\nexport { default as ComboboxGroup } from \"./ComboboxGroup.vue\"\nexport { default as ComboboxInput } from \"./ComboboxInput.vue\"\nexport { default as ComboboxItem } from \"./ComboboxItem.vue\"\nexport { default as ComboboxList } from \"./ComboboxList.vue\"\nexport { default as ComboboxSeparator } from \"./ComboboxSeparator.vue\"\n\nexport { ComboboxCancel, ComboboxItemIndicator, ComboboxTrigger } from \"reka-ui\"\n",
+      "content": "export { default as Combobox } from \"./Combobox.vue\"\nexport { default as ComboboxAnchor } from \"./ComboboxAnchor.vue\"\nexport { default as ComboboxEmpty } from \"./ComboboxEmpty.vue\"\nexport { default as ComboboxGroup } from \"./ComboboxGroup.vue\"\nexport { default as ComboboxInput } from \"./ComboboxInput.vue\"\nexport { default as ComboboxItem } from \"./ComboboxItem.vue\"\nexport { default as ComboboxList } from \"./ComboboxList.vue\"\nexport { default as ComboboxSeparator } from \"./ComboboxSeparator.vue\"\nexport { default as ComboboxTrigger } from \"./ComboboxTrigger.vue\"\n\nexport { ComboboxCancel, ComboboxItemIndicator } from \"reka-ui\"\n",
       "type": "registry:ui",
       "target": ""
     }

--- a/apps/v4/public/r/styles/new-york-v4/combobox.json
+++ b/apps/v4/public/r/styles/new-york-v4/combobox.json
@@ -63,7 +63,7 @@
     },
     {
       "path": "registry/new-york-v4/ui/combobox/index.ts",
-      "content": "export { default as Combobox } from \"./Combobox.vue\"\nexport { default as ComboboxAnchor } from \"./ComboboxAnchor.vue\"\nexport { default as ComboboxEmpty } from \"./ComboboxEmpty.vue\"\nexport { default as ComboboxGroup } from \"./ComboboxGroup.vue\"\nexport { default as ComboboxInput } from \"./ComboboxInput.vue\"\nexport { default as ComboboxItem } from \"./ComboboxItem.vue\"\nexport { default as ComboboxItemIndicator } from \"./ComboboxItemIndicator.vue\"\nexport { default as ComboboxList } from \"./ComboboxList.vue\"\nexport { default as ComboboxSeparator } from \"./ComboboxSeparator.vue\"\nexport { default as ComboboxViewport } from \"./ComboboxViewport.vue\"\n\nexport { ComboboxCancel, ComboboxTrigger } from \"reka-ui\"\n",
+      "content": "export { default as Combobox } from \"./Combobox.vue\"\nexport { default as ComboboxAnchor } from \"./ComboboxAnchor.vue\"\nexport { default as ComboboxEmpty } from \"./ComboboxEmpty.vue\"\nexport { default as ComboboxGroup } from \"./ComboboxGroup.vue\"\nexport { default as ComboboxInput } from \"./ComboboxInput.vue\"\nexport { default as ComboboxItem } from \"./ComboboxItem.vue\"\nexport { default as ComboboxItemIndicator } from \"./ComboboxItemIndicator.vue\"\nexport { default as ComboboxList } from \"./ComboboxList.vue\"\nexport { default as ComboboxSeparator } from \"./ComboboxSeparator.vue\"\nexport { default as ComboboxTrigger } from \"./ComboboxTrigger.vue\"\nexport { default as ComboboxViewport } from \"./ComboboxViewport.vue\"\n\nexport { ComboboxCancel } from \"reka-ui\"\n",
       "type": "registry:ui"
     }
   ],

--- a/apps/v4/public/r/styles/new-york/combobox.json
+++ b/apps/v4/public/r/styles/new-york/combobox.json
@@ -63,7 +63,7 @@
     },
     {
       "path": "ui/combobox/index.ts",
-      "content": "export { default as Combobox } from \"./Combobox.vue\"\nexport { default as ComboboxAnchor } from \"./ComboboxAnchor.vue\"\nexport { default as ComboboxEmpty } from \"./ComboboxEmpty.vue\"\nexport { default as ComboboxGroup } from \"./ComboboxGroup.vue\"\nexport { default as ComboboxInput } from \"./ComboboxInput.vue\"\nexport { default as ComboboxItem } from \"./ComboboxItem.vue\"\nexport { default as ComboboxList } from \"./ComboboxList.vue\"\nexport { default as ComboboxSeparator } from \"./ComboboxSeparator.vue\"\n\nexport { ComboboxCancel, ComboboxItemIndicator, ComboboxTrigger } from \"reka-ui\"\n",
+      "content": "export { default as Combobox } from \"./Combobox.vue\"\nexport { default as ComboboxAnchor } from \"./ComboboxAnchor.vue\"\nexport { default as ComboboxEmpty } from \"./ComboboxEmpty.vue\"\nexport { default as ComboboxGroup } from \"./ComboboxGroup.vue\"\nexport { default as ComboboxInput } from \"./ComboboxInput.vue\"\nexport { default as ComboboxItem } from \"./ComboboxItem.vue\"\nexport { default as ComboboxList } from \"./ComboboxList.vue\"\nexport { default as ComboboxSeparator } from \"./ComboboxSeparator.vue\"\nexport { default as ComboboxTrigger } from \"./ComboboxTrigger.vue\"\n\nexport { ComboboxCancel, ComboboxItemIndicator } from \"reka-ui\"\n",
       "type": "registry:ui",
       "target": ""
     }

--- a/apps/v4/public/r/styles/reka-luma/combobox.json
+++ b/apps/v4/public/r/styles/reka-luma/combobox.json
@@ -66,7 +66,7 @@
     },
     {
       "path": "styles/reka-luma/ui/combobox/index.ts",
-      "content": "export { default as Combobox } from './Combobox.vue'\nexport { default as ComboboxAnchor } from './ComboboxAnchor.vue'\nexport { default as ComboboxEmpty } from './ComboboxEmpty.vue'\nexport { default as ComboboxGroup } from './ComboboxGroup.vue'\nexport { default as ComboboxInput } from './ComboboxInput.vue'\nexport { default as ComboboxItem } from './ComboboxItem.vue'\nexport { default as ComboboxItemIndicator } from './ComboboxItemIndicator.vue'\nexport { default as ComboboxList } from './ComboboxList.vue'\nexport { default as ComboboxSeparator } from './ComboboxSeparator.vue'\nexport { default as ComboboxViewport } from './ComboboxViewport.vue'\n\nexport { ComboboxCancel, ComboboxTrigger } from 'reka-ui'\n",
+      "content": "export { default as Combobox } from './Combobox.vue'\nexport { default as ComboboxAnchor } from './ComboboxAnchor.vue'\nexport { default as ComboboxEmpty } from './ComboboxEmpty.vue'\nexport { default as ComboboxGroup } from './ComboboxGroup.vue'\nexport { default as ComboboxInput } from './ComboboxInput.vue'\nexport { default as ComboboxItem } from './ComboboxItem.vue'\nexport { default as ComboboxItemIndicator } from './ComboboxItemIndicator.vue'\nexport { default as ComboboxList } from './ComboboxList.vue'\nexport { default as ComboboxSeparator } from './ComboboxSeparator.vue'\nexport { default as ComboboxTrigger } from './ComboboxTrigger.vue'\nexport { default as ComboboxViewport } from './ComboboxViewport.vue'\n\nexport { ComboboxCancel } from 'reka-ui'\n",
       "type": "registry:ui"
     }
   ],

--- a/apps/v4/public/r/styles/reka-lyra/combobox.json
+++ b/apps/v4/public/r/styles/reka-lyra/combobox.json
@@ -66,7 +66,7 @@
     },
     {
       "path": "styles/reka-lyra/ui/combobox/index.ts",
-      "content": "export { default as Combobox } from './Combobox.vue'\nexport { default as ComboboxAnchor } from './ComboboxAnchor.vue'\nexport { default as ComboboxEmpty } from './ComboboxEmpty.vue'\nexport { default as ComboboxGroup } from './ComboboxGroup.vue'\nexport { default as ComboboxInput } from './ComboboxInput.vue'\nexport { default as ComboboxItem } from './ComboboxItem.vue'\nexport { default as ComboboxItemIndicator } from './ComboboxItemIndicator.vue'\nexport { default as ComboboxList } from './ComboboxList.vue'\nexport { default as ComboboxSeparator } from './ComboboxSeparator.vue'\nexport { default as ComboboxViewport } from './ComboboxViewport.vue'\n\nexport { ComboboxCancel, ComboboxTrigger } from 'reka-ui'\n",
+      "content": "export { default as Combobox } from './Combobox.vue'\nexport { default as ComboboxAnchor } from './ComboboxAnchor.vue'\nexport { default as ComboboxEmpty } from './ComboboxEmpty.vue'\nexport { default as ComboboxGroup } from './ComboboxGroup.vue'\nexport { default as ComboboxInput } from './ComboboxInput.vue'\nexport { default as ComboboxItem } from './ComboboxItem.vue'\nexport { default as ComboboxItemIndicator } from './ComboboxItemIndicator.vue'\nexport { default as ComboboxList } from './ComboboxList.vue'\nexport { default as ComboboxSeparator } from './ComboboxSeparator.vue'\nexport { default as ComboboxTrigger } from './ComboboxTrigger.vue'\nexport { default as ComboboxViewport } from './ComboboxViewport.vue'\n\nexport { ComboboxCancel } from 'reka-ui'\n",
       "type": "registry:ui"
     }
   ],

--- a/apps/v4/public/r/styles/reka-maia/combobox.json
+++ b/apps/v4/public/r/styles/reka-maia/combobox.json
@@ -66,7 +66,7 @@
     },
     {
       "path": "styles/reka-maia/ui/combobox/index.ts",
-      "content": "export { default as Combobox } from './Combobox.vue'\nexport { default as ComboboxAnchor } from './ComboboxAnchor.vue'\nexport { default as ComboboxEmpty } from './ComboboxEmpty.vue'\nexport { default as ComboboxGroup } from './ComboboxGroup.vue'\nexport { default as ComboboxInput } from './ComboboxInput.vue'\nexport { default as ComboboxItem } from './ComboboxItem.vue'\nexport { default as ComboboxItemIndicator } from './ComboboxItemIndicator.vue'\nexport { default as ComboboxList } from './ComboboxList.vue'\nexport { default as ComboboxSeparator } from './ComboboxSeparator.vue'\nexport { default as ComboboxViewport } from './ComboboxViewport.vue'\n\nexport { ComboboxCancel, ComboboxTrigger } from 'reka-ui'\n",
+      "content": "export { default as Combobox } from './Combobox.vue'\nexport { default as ComboboxAnchor } from './ComboboxAnchor.vue'\nexport { default as ComboboxEmpty } from './ComboboxEmpty.vue'\nexport { default as ComboboxGroup } from './ComboboxGroup.vue'\nexport { default as ComboboxInput } from './ComboboxInput.vue'\nexport { default as ComboboxItem } from './ComboboxItem.vue'\nexport { default as ComboboxItemIndicator } from './ComboboxItemIndicator.vue'\nexport { default as ComboboxList } from './ComboboxList.vue'\nexport { default as ComboboxSeparator } from './ComboboxSeparator.vue'\nexport { default as ComboboxTrigger } from './ComboboxTrigger.vue'\nexport { default as ComboboxViewport } from './ComboboxViewport.vue'\n\nexport { ComboboxCancel } from 'reka-ui'\n",
       "type": "registry:ui"
     }
   ],

--- a/apps/v4/public/r/styles/reka-mira/combobox.json
+++ b/apps/v4/public/r/styles/reka-mira/combobox.json
@@ -66,7 +66,7 @@
     },
     {
       "path": "styles/reka-mira/ui/combobox/index.ts",
-      "content": "export { default as Combobox } from './Combobox.vue'\nexport { default as ComboboxAnchor } from './ComboboxAnchor.vue'\nexport { default as ComboboxEmpty } from './ComboboxEmpty.vue'\nexport { default as ComboboxGroup } from './ComboboxGroup.vue'\nexport { default as ComboboxInput } from './ComboboxInput.vue'\nexport { default as ComboboxItem } from './ComboboxItem.vue'\nexport { default as ComboboxItemIndicator } from './ComboboxItemIndicator.vue'\nexport { default as ComboboxList } from './ComboboxList.vue'\nexport { default as ComboboxSeparator } from './ComboboxSeparator.vue'\nexport { default as ComboboxViewport } from './ComboboxViewport.vue'\n\nexport { ComboboxCancel, ComboboxTrigger } from 'reka-ui'\n",
+      "content": "export { default as Combobox } from './Combobox.vue'\nexport { default as ComboboxAnchor } from './ComboboxAnchor.vue'\nexport { default as ComboboxEmpty } from './ComboboxEmpty.vue'\nexport { default as ComboboxGroup } from './ComboboxGroup.vue'\nexport { default as ComboboxInput } from './ComboboxInput.vue'\nexport { default as ComboboxItem } from './ComboboxItem.vue'\nexport { default as ComboboxItemIndicator } from './ComboboxItemIndicator.vue'\nexport { default as ComboboxList } from './ComboboxList.vue'\nexport { default as ComboboxSeparator } from './ComboboxSeparator.vue'\nexport { default as ComboboxTrigger } from './ComboboxTrigger.vue'\nexport { default as ComboboxViewport } from './ComboboxViewport.vue'\n\nexport { ComboboxCancel } from 'reka-ui'\n",
       "type": "registry:ui"
     }
   ],

--- a/apps/v4/public/r/styles/reka-nova/combobox.json
+++ b/apps/v4/public/r/styles/reka-nova/combobox.json
@@ -66,7 +66,7 @@
     },
     {
       "path": "styles/reka-nova/ui/combobox/index.ts",
-      "content": "export { default as Combobox } from './Combobox.vue'\nexport { default as ComboboxAnchor } from './ComboboxAnchor.vue'\nexport { default as ComboboxEmpty } from './ComboboxEmpty.vue'\nexport { default as ComboboxGroup } from './ComboboxGroup.vue'\nexport { default as ComboboxInput } from './ComboboxInput.vue'\nexport { default as ComboboxItem } from './ComboboxItem.vue'\nexport { default as ComboboxItemIndicator } from './ComboboxItemIndicator.vue'\nexport { default as ComboboxList } from './ComboboxList.vue'\nexport { default as ComboboxSeparator } from './ComboboxSeparator.vue'\nexport { default as ComboboxViewport } from './ComboboxViewport.vue'\n\nexport { ComboboxCancel, ComboboxTrigger } from 'reka-ui'\n",
+      "content": "export { default as Combobox } from './Combobox.vue'\nexport { default as ComboboxAnchor } from './ComboboxAnchor.vue'\nexport { default as ComboboxEmpty } from './ComboboxEmpty.vue'\nexport { default as ComboboxGroup } from './ComboboxGroup.vue'\nexport { default as ComboboxInput } from './ComboboxInput.vue'\nexport { default as ComboboxItem } from './ComboboxItem.vue'\nexport { default as ComboboxItemIndicator } from './ComboboxItemIndicator.vue'\nexport { default as ComboboxList } from './ComboboxList.vue'\nexport { default as ComboboxSeparator } from './ComboboxSeparator.vue'\nexport { default as ComboboxTrigger } from './ComboboxTrigger.vue'\nexport { default as ComboboxViewport } from './ComboboxViewport.vue'\n\nexport { ComboboxCancel } from 'reka-ui'\n",
       "type": "registry:ui"
     }
   ],

--- a/apps/v4/public/r/styles/reka-vega/combobox.json
+++ b/apps/v4/public/r/styles/reka-vega/combobox.json
@@ -66,7 +66,7 @@
     },
     {
       "path": "styles/reka-vega/ui/combobox/index.ts",
-      "content": "export { default as Combobox } from './Combobox.vue'\nexport { default as ComboboxAnchor } from './ComboboxAnchor.vue'\nexport { default as ComboboxEmpty } from './ComboboxEmpty.vue'\nexport { default as ComboboxGroup } from './ComboboxGroup.vue'\nexport { default as ComboboxInput } from './ComboboxInput.vue'\nexport { default as ComboboxItem } from './ComboboxItem.vue'\nexport { default as ComboboxItemIndicator } from './ComboboxItemIndicator.vue'\nexport { default as ComboboxList } from './ComboboxList.vue'\nexport { default as ComboboxSeparator } from './ComboboxSeparator.vue'\nexport { default as ComboboxViewport } from './ComboboxViewport.vue'\n\nexport { ComboboxCancel, ComboboxTrigger } from 'reka-ui'\n",
+      "content": "export { default as Combobox } from './Combobox.vue'\nexport { default as ComboboxAnchor } from './ComboboxAnchor.vue'\nexport { default as ComboboxEmpty } from './ComboboxEmpty.vue'\nexport { default as ComboboxGroup } from './ComboboxGroup.vue'\nexport { default as ComboboxInput } from './ComboboxInput.vue'\nexport { default as ComboboxItem } from './ComboboxItem.vue'\nexport { default as ComboboxItemIndicator } from './ComboboxItemIndicator.vue'\nexport { default as ComboboxList } from './ComboboxList.vue'\nexport { default as ComboboxSeparator } from './ComboboxSeparator.vue'\nexport { default as ComboboxTrigger } from './ComboboxTrigger.vue'\nexport { default as ComboboxViewport } from './ComboboxViewport.vue'\n\nexport { ComboboxCancel } from 'reka-ui'\n",
       "type": "registry:ui"
     }
   ],

--- a/apps/v4/registry/bases/reka/ui/combobox/index.ts
+++ b/apps/v4/registry/bases/reka/ui/combobox/index.ts
@@ -7,6 +7,7 @@ export { default as ComboboxItem } from "./ComboboxItem.vue"
 export { default as ComboboxItemIndicator } from "./ComboboxItemIndicator.vue"
 export { default as ComboboxList } from "./ComboboxList.vue"
 export { default as ComboboxSeparator } from "./ComboboxSeparator.vue"
+export { default as ComboboxTrigger } from "./ComboboxTrigger.vue"
 export { default as ComboboxViewport } from "./ComboboxViewport.vue"
 
-export { ComboboxCancel, ComboboxTrigger } from "reka-ui"
+export { ComboboxCancel } from "reka-ui"

--- a/apps/v4/registry/new-york-v4/ui/combobox/index.ts
+++ b/apps/v4/registry/new-york-v4/ui/combobox/index.ts
@@ -7,6 +7,7 @@ export { default as ComboboxItem } from "./ComboboxItem.vue"
 export { default as ComboboxItemIndicator } from "./ComboboxItemIndicator.vue"
 export { default as ComboboxList } from "./ComboboxList.vue"
 export { default as ComboboxSeparator } from "./ComboboxSeparator.vue"
+export { default as ComboboxTrigger } from "./ComboboxTrigger.vue"
 export { default as ComboboxViewport } from "./ComboboxViewport.vue"
 
-export { ComboboxCancel, ComboboxTrigger } from "reka-ui"
+export { ComboboxCancel } from "reka-ui"

--- a/apps/v4/styles/reka-luma/ui/combobox/index.ts
+++ b/apps/v4/styles/reka-luma/ui/combobox/index.ts
@@ -7,6 +7,7 @@ export { default as ComboboxItem } from './ComboboxItem.vue'
 export { default as ComboboxItemIndicator } from './ComboboxItemIndicator.vue'
 export { default as ComboboxList } from './ComboboxList.vue'
 export { default as ComboboxSeparator } from './ComboboxSeparator.vue'
+export { default as ComboboxTrigger } from './ComboboxTrigger.vue'
 export { default as ComboboxViewport } from './ComboboxViewport.vue'
 
-export { ComboboxCancel, ComboboxTrigger } from 'reka-ui'
+export { ComboboxCancel } from 'reka-ui'

--- a/apps/v4/styles/reka-lyra/ui/combobox/index.ts
+++ b/apps/v4/styles/reka-lyra/ui/combobox/index.ts
@@ -7,6 +7,7 @@ export { default as ComboboxItem } from './ComboboxItem.vue'
 export { default as ComboboxItemIndicator } from './ComboboxItemIndicator.vue'
 export { default as ComboboxList } from './ComboboxList.vue'
 export { default as ComboboxSeparator } from './ComboboxSeparator.vue'
+export { default as ComboboxTrigger } from './ComboboxTrigger.vue'
 export { default as ComboboxViewport } from './ComboboxViewport.vue'
 
-export { ComboboxCancel, ComboboxTrigger } from 'reka-ui'
+export { ComboboxCancel } from 'reka-ui'

--- a/apps/v4/styles/reka-maia/ui/combobox/index.ts
+++ b/apps/v4/styles/reka-maia/ui/combobox/index.ts
@@ -7,6 +7,7 @@ export { default as ComboboxItem } from './ComboboxItem.vue'
 export { default as ComboboxItemIndicator } from './ComboboxItemIndicator.vue'
 export { default as ComboboxList } from './ComboboxList.vue'
 export { default as ComboboxSeparator } from './ComboboxSeparator.vue'
+export { default as ComboboxTrigger } from './ComboboxTrigger.vue'
 export { default as ComboboxViewport } from './ComboboxViewport.vue'
 
-export { ComboboxCancel, ComboboxTrigger } from 'reka-ui'
+export { ComboboxCancel } from 'reka-ui'

--- a/apps/v4/styles/reka-mira/ui/combobox/index.ts
+++ b/apps/v4/styles/reka-mira/ui/combobox/index.ts
@@ -7,6 +7,7 @@ export { default as ComboboxItem } from './ComboboxItem.vue'
 export { default as ComboboxItemIndicator } from './ComboboxItemIndicator.vue'
 export { default as ComboboxList } from './ComboboxList.vue'
 export { default as ComboboxSeparator } from './ComboboxSeparator.vue'
+export { default as ComboboxTrigger } from './ComboboxTrigger.vue'
 export { default as ComboboxViewport } from './ComboboxViewport.vue'
 
-export { ComboboxCancel, ComboboxTrigger } from 'reka-ui'
+export { ComboboxCancel } from 'reka-ui'

--- a/apps/v4/styles/reka-nova/ui/combobox/index.ts
+++ b/apps/v4/styles/reka-nova/ui/combobox/index.ts
@@ -7,6 +7,7 @@ export { default as ComboboxItem } from './ComboboxItem.vue'
 export { default as ComboboxItemIndicator } from './ComboboxItemIndicator.vue'
 export { default as ComboboxList } from './ComboboxList.vue'
 export { default as ComboboxSeparator } from './ComboboxSeparator.vue'
+export { default as ComboboxTrigger } from './ComboboxTrigger.vue'
 export { default as ComboboxViewport } from './ComboboxViewport.vue'
 
-export { ComboboxCancel, ComboboxTrigger } from 'reka-ui'
+export { ComboboxCancel } from 'reka-ui'

--- a/apps/v4/styles/reka-sera/ui/combobox/index.ts
+++ b/apps/v4/styles/reka-sera/ui/combobox/index.ts
@@ -7,6 +7,7 @@ export { default as ComboboxItem } from './ComboboxItem.vue'
 export { default as ComboboxItemIndicator } from './ComboboxItemIndicator.vue'
 export { default as ComboboxList } from './ComboboxList.vue'
 export { default as ComboboxSeparator } from './ComboboxSeparator.vue'
+export { default as ComboboxTrigger } from './ComboboxTrigger.vue'
 export { default as ComboboxViewport } from './ComboboxViewport.vue'
 
-export { ComboboxCancel, ComboboxTrigger } from 'reka-ui'
+export { ComboboxCancel } from 'reka-ui'

--- a/apps/v4/styles/reka-vega/ui/combobox/index.ts
+++ b/apps/v4/styles/reka-vega/ui/combobox/index.ts
@@ -7,6 +7,7 @@ export { default as ComboboxItem } from './ComboboxItem.vue'
 export { default as ComboboxItemIndicator } from './ComboboxItemIndicator.vue'
 export { default as ComboboxList } from './ComboboxList.vue'
 export { default as ComboboxSeparator } from './ComboboxSeparator.vue'
+export { default as ComboboxTrigger } from './ComboboxTrigger.vue'
 export { default as ComboboxViewport } from './ComboboxViewport.vue'
 
-export { ComboboxCancel, ComboboxTrigger } from 'reka-ui'
+export { ComboboxCancel } from 'reka-ui'


### PR DESCRIPTION
Summary:
- export `ComboboxTrigger` from the local `ComboboxTrigger.vue` wrapper in the v4 combobox barrels
- keep `ComboboxCancel` re-exported from `reka-ui`
- update the served combobox registry JSON so installed components receive the local trigger wrapper

Verification:
- `pnpm install --frozen-lockfile --ignore-scripts`
- parsed changed combobox registry JSON and checked no combobox index exports `ComboboxTrigger` from `reka-ui`
- `pnpm exec eslint apps/v4/registry/new-york-v4/ui/combobox/index.ts apps/v4/registry/bases/reka/ui/combobox/index.ts apps/v4/styles/reka-vega/ui/combobox/index.ts apps/v4/styles/reka-nova/ui/combobox/index.ts apps/v4/styles/reka-mira/ui/combobox/index.ts apps/v4/styles/reka-maia/ui/combobox/index.ts apps/v4/styles/reka-lyra/ui/combobox/index.ts apps/v4/styles/reka-luma/ui/combobox/index.ts apps/v4/styles/reka-sera/ui/combobox/index.ts`
- `pnpm --filter shadcn-vue build`

Closes #1810.

This was implemented with Codex assistance, with the final diff manually reviewed and kept to the reported export mismatch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated combobox component exports across multiple design system variants to use localized component implementations instead of library exports. All exported components remain available and functional with no breaking changes to the public API.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unovue/shadcn-vue/pull/1827?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->