### PR TITLE
fix(cli): install user-selected icon library instead of hardcoded lucide

### DIFF
--- a/packages/cli/src/utils/add-components.ts
+++ b/packages/cli/src/utils/add-components.ts
@@ -21,6 +21,7 @@ import {
 } from '@/src/utils/get-config'
 import { getProjectTailwindVersionFromConfig } from '@/src/utils/get-project-info'
 import { handleError } from '@/src/utils/handle-error'
+import { replaceIconLibraryInDependencies } from '@/src/utils/icon-libraries'
 import { isSafeTarget } from '@/src/utils/is-safe-target'
 import { logger } from '@/src/utils/logger'
 import { spinner } from '@/src/utils/spinner'
@@ -131,7 +132,11 @@ async function addProjectComponents(
     silent: options.silent,
   })
 
-  await updateDependencies(tree.dependencies, tree.devDependencies, config, {
+  const resolvedDependencies = replaceIconLibraryInDependencies(
+    tree.dependencies,
+    config.iconLibrary,
+  )
+  await updateDependencies(resolvedDependencies, tree.devDependencies, config, {
     silent: options.silent,
   })
   await updateFiles(tree.files, config, {
@@ -251,8 +256,12 @@ async function addWorkspaceComponents(
   }
 
   // 5. Update dependencies.
-  await updateDependencies(
+  const resolvedDependencies = replaceIconLibraryInDependencies(
     tree.dependencies,
+    mainTargetConfig.iconLibrary,
+  )
+  await updateDependencies(
+    resolvedDependencies,
     tree.devDependencies,
     mainTargetConfig,
     {

--- a/packages/cli/src/utils/icon-libraries.ts
+++ b/packages/cli/src/utils/icon-libraries.ts
@@ -4,6 +4,11 @@ import { ICON_LIBRARIES as IconLibrariesArray } from '@/src/registry/constants'
 // Export as alias for array access
 export { ICON_LIBRARIES as ICON_LIBRARIES_ARRAY } from '@/src/registry/constants'
 
+// Package names previously shipped by icon libraries that have since been
+// renamed. Listed here so we can scrub them out of registry-supplied
+// dependency lists alongside their current package counterparts.
+const LEGACY_ICON_LIBRARY_PACKAGES = ['lucide-vue-next']
+
 /**
  * Get an icon library by name.
  */
@@ -17,6 +22,60 @@ export function getIconLibrary(name: string) {
 export function getIconLibraryPackages(name: string): string[] {
   const lib = getIconLibrary(name)
   return lib?.packages ? [...lib.packages] : []
+}
+
+/**
+ * Set of every package name owned by any supported icon library (including
+ * legacy/renamed ones). Used to scrub icon-library deps from registry-supplied
+ * dependency lists so we can replace them with the user's chosen library.
+ */
+function getAllIconLibraryPackages(): Set<string> {
+  const all = new Set<string>(LEGACY_ICON_LIBRARY_PACKAGES)
+  for (const lib of IconLibrariesArray) {
+    for (const pkg of lib.packages) {
+      all.add(pkg)
+    }
+  }
+  return all
+}
+
+/**
+ * Registry style items (e.g. `styles/<style>/index.json`) hardcode `@lucide/vue`
+ * in their `dependencies` array regardless of which icon library the user
+ * picked. This swaps any known icon-library package in `dependencies` for the
+ * packages of `iconLibrary`, so a user who picked Phosphor doesn't end up with
+ * Lucide installed.
+ *
+ * Returns a new array; the input is not mutated. Falls back to the input
+ * unchanged when `iconLibrary` is unknown so we never silently strip deps.
+ */
+export function replaceIconLibraryInDependencies(
+  dependencies: string[] | undefined,
+  iconLibrary: string | undefined,
+): string[] {
+  if (!dependencies?.length) {
+    return dependencies ? [...dependencies] : []
+  }
+
+  if (!iconLibrary) {
+    return [...dependencies]
+  }
+
+  const chosenPackages = getIconLibraryPackages(iconLibrary)
+  if (chosenPackages.length === 0) {
+    return [...dependencies]
+  }
+
+  const knownIconPackages = getAllIconLibraryPackages()
+  const filtered = dependencies.filter(dep => !knownIconPackages.has(dep))
+
+  for (const pkg of chosenPackages) {
+    if (!filtered.includes(pkg)) {
+      filtered.push(pkg)
+    }
+  }
+
+  return filtered
 }
 
 /**

--- a/packages/cli/test/utils/icon-libraries.test.ts
+++ b/packages/cli/test/utils/icon-libraries.test.ts
@@ -5,6 +5,7 @@ import {
   getIconLibraryPackages,
   getIconUsageExample,
   ICON_LIBRARIES_ARRAY,
+  replaceIconLibraryInDependencies,
 } from '../../src/utils/icon-libraries'
 
 describe('getIconLibrary', () => {
@@ -142,6 +143,71 @@ describe('getIconUsageExample', () => {
   it('returns empty string for unknown library', () => {
     const example = getIconUsageExample('unknown', 'Icon')
     expect(example).toBe('')
+  })
+})
+
+describe('replaceIconLibraryInDependencies', () => {
+  it('swaps @lucide/vue for the chosen library packages', () => {
+    expect(
+      replaceIconLibraryInDependencies(
+        ['class-variance-authority', '@lucide/vue'],
+        'phosphor',
+      ),
+    ).toEqual(['class-variance-authority', '@phosphor-icons/vue'])
+  })
+
+  it('swaps the legacy lucide-vue-next package for the chosen library', () => {
+    expect(
+      replaceIconLibraryInDependencies(
+        ['tailwindcss-animate', 'class-variance-authority', 'lucide-vue-next'],
+        'phosphor',
+      ),
+    ).toEqual([
+      'tailwindcss-animate',
+      'class-variance-authority',
+      '@phosphor-icons/vue',
+    ])
+  })
+
+  it('keeps the lucide package when the user picked lucide', () => {
+    expect(
+      replaceIconLibraryInDependencies(['@lucide/vue'], 'lucide'),
+    ).toEqual(['@lucide/vue'])
+  })
+
+  it('rewrites legacy lucide-vue-next to the current @lucide/vue when lucide is picked', () => {
+    expect(
+      replaceIconLibraryInDependencies(['lucide-vue-next'], 'lucide'),
+    ).toEqual(['@lucide/vue'])
+  })
+
+  it('adds the chosen library packages even when no icon package is present', () => {
+    expect(
+      replaceIconLibraryInDependencies(['class-variance-authority'], 'phosphor'),
+    ).toEqual(['class-variance-authority', '@phosphor-icons/vue'])
+  })
+
+  it('adds all packages for libraries that ship multiple', () => {
+    expect(
+      replaceIconLibraryInDependencies(['@lucide/vue'], 'hugeicons'),
+    ).toEqual(['@hugeicons/vue', '@hugeicons/core-free-icons'])
+  })
+
+  it('returns the original deps unchanged when iconLibrary is missing', () => {
+    expect(
+      replaceIconLibraryInDependencies(['@lucide/vue'], undefined),
+    ).toEqual(['@lucide/vue'])
+  })
+
+  it('returns the original deps unchanged when iconLibrary is unknown', () => {
+    expect(
+      replaceIconLibraryInDependencies(['@lucide/vue'], 'mystery'),
+    ).toEqual(['@lucide/vue'])
+  })
+
+  it('handles empty/undefined dependency lists', () => {
+    expect(replaceIconLibraryInDependencies(undefined, 'phosphor')).toEqual([])
+    expect(replaceIconLibraryInDependencies([], 'phosphor')).toEqual([])
   })
 })
 


### PR DESCRIPTION
## Summary

- The registry's `styles/<style>/index.json` hardcodes the Lucide package in its `dependencies` array (`lucide-vue-next` in v2.7.3, `@lucide/vue` on `dev`). The CLI installed that list verbatim and never reconciled it with `config.iconLibrary`, so a user who picked Phosphor during `init` ended up with `iconLibrary: "phosphor"` in `components.json` but `lucide-vue-next`/`@lucide/vue` in `package.json`.
- The `transform-icons` codemod already rewrites imports inside component files; this PR adds the equivalent substitution for the install list.
- Added `replaceIconLibraryInDependencies(dependencies, iconLibrary)` in `utils/icon-libraries.ts` and applied it in both the project and workspace branches of `add-components.ts` before calling `updateDependencies`.
- The helper strips every known icon-library package (current + the legacy `lucide-vue-next`) and adds the chosen library's packages. It's idempotent: picking `lucide` leaves the deps unchanged but still rewrites the legacy `lucide-vue-next` → `@lucide/vue`.

Fixes #1823.

## Test plan

- [x] `pnpm test` — 9 new cases for `replaceIconLibraryInDependencies` (Phosphor swap, legacy `lucide-vue-next` rewrite, multi-package libraries like HugeIcons, missing/unknown `iconLibrary` fallbacks, empty inputs). 436 pass / 1 skipped.
- [x] `pnpm lint` clean on touched files.
- [ ] Manual: `bunx --bun shadcn-vue@<this-branch> init` in a fresh Vite + Tailwind v4 project, pick **Phosphor Icons** → confirm `@phosphor-icons/vue` lands in `package.json` and `lucide-vue-next`/`@lucide/vue` does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved icon library dependency handling when adding components. The system now correctly replaces legacy and alternate icon library packages with the selected icon library, ensuring consistent and proper dependency installation across projects.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unovue/shadcn-vue/pull/1831?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->