### PR TITLE
fix(registry): publish index.json for reka-* styles (#1792)

### DIFF
--- a/apps/v4/scripts/lib/build-styles-registry.ts
+++ b/apps/v4/scripts/lib/build-styles-registry.ts
@@ -83,7 +83,21 @@ async function publishStyle(styleName: string) {
     return { ...item, files }
   })
 
-  const items = [...uiItems, ...libItems]
+  // The CLI's init flow fetches `styles/<style>/index.json` to install base
+  // dependencies, the cn() util, and the Tailwind v4 animation plugin.
+  // `@lucide/vue` is reconciled against the user's chosen icon library by
+  // packages/cli/src/utils/icon-libraries.ts, so listing it here is safe.
+  const indexItem: RegistryItem = {
+    name: 'index',
+    type: 'registry:style',
+    dependencies: ['class-variance-authority', '@lucide/vue'],
+    devDependencies: ['tw-animate-css'],
+    registryDependencies: ['utils'],
+    files: [],
+    cssVars: {},
+  }
+
+  const items = [indexItem, ...uiItems, ...libItems]
 
   const registry = {
     name: REGISTRY_NAME,


### PR DESCRIPTION
## Summary

- Fixes #1792: selecting any `reka-*` visual style during `init` (Vega, Nova, Maia, Lyra, Mira, Luma, Sera) crashed with `The item at https://shadcn-vue.com/r/styles/reka-<style>/index.json was not found.`
- Root cause: the CLI's init flow fetches `styles/<style>/index.json` for the base-style item ([packages/cli/src/commands/init.ts#L557-L561](https://github.com/unovue/shadcn-vue/blob/dev/packages/cli/src/commands/init.ts#L557-L561)), but `publishStyle()` in `build-styles-registry.ts` only wrote per-component JSONs — it never emitted an `index` entry. Every `reka-*/index.json` returned 404 on prod.
- Patch prepends an `index` `registry:style` item to each style's items array before handing it to the CLI build, mirroring the shape of `public/r/styles/new-york-v4/index.json`.
- `@lucide/vue` is listed as a dependency and gets reconciled against the user's chosen icon library by `packages/cli/src/utils/icon-libraries.ts` (added in a052a31c / #1831), so users who pick Phosphor / Tabler / etc. still get the right package.

## Why the index item is required

The `index` registry item carries pieces that aren't per-component:
1. Base npm deps (`class-variance-authority`, `tw-animate-css`).
2. The `utils` registry dep (so `~/lib/utils.ts` with `cn()` gets created).
3. Schema-compatible placeholder for `cssVars` / future global tweaks.

shadcn-ui follows the same model — every supported style there ships an `index.json`. Without it, init has no fallback and dies on the 404.

## Test plan

Verified locally by running the same code path the build pipeline uses (CLI `build` against a minimal `registry.json` containing only the new `index` item):

```bash
$ node packages/cli/dist/index.js build registry.json --output out
- Building index...
✔ Building registry.

$ cat out/index.json
{
  "$schema": "https://shadcn-vue.com/schema/registry-item.json",
  "name": "index",
  "dependencies": ["class-variance-authority", "@lucide/vue"],
  "devDependencies": ["tw-animate-css"],
  "registryDependencies": ["utils"],
  "files": [],
  "cssVars": {},
  "type": "registry:style"
}
```

Structurally identical to `apps/v4/public/r/styles/new-york-v4/index.json`.

- [ ] Maintainer to run `pnpm registry:build` and redeploy `apps/v4` so the new `index.json` files land at `https://shadcn-vue.com/r/styles/reka-<style>/index.json`.
- [ ] Sanity check: `npx shadcn-vue@latest init` with Reka UI + Vega should complete instead of 404ing.
- [ ] Icon-library reconciliation still works for non-lucide picks (Phosphor, Tabler, etc.) — covered by the existing test added in #1831.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the style registry generation system to include a centralized index entry that declares base dependencies, development dependencies, and registry dependencies. This streamlines how style configurations and their dependencies are organized and managed throughout the build process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unovue/shadcn-vue/pull/1832?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->