### PR TITLE
docs: add RTL documentation page

### DIFF
--- a/apps/v4/content/docs/07.rtl.md
+++ b/apps/v4/content/docs/07.rtl.md
@@ -1,0 +1,132 @@
+---
+title: RTL
+description: Adding right-to-left support to your site.
+---
+
+## Right-to-left
+
+<Callout>
+
+This page explains how to add RTL support to your shadcn-vue project. RTL (right-to-left) is essential for languages like Arabic, Hebrew, and Persian.
+
+</Callout>
+
+<Steps>
+
+### Understanding RTL
+
+RTL (right-to-left) languages are read from right to left. shadcn-vue supports RTL through the `rtl` migration which transforms physical CSS properties to their logical equivalents:
+
+| Physical Property | Logical Property |
+| ----------------- | ----------------- |
+| `ml-4`            | `ms-4`            |
+| `mr-4`            | `me-4`            |
+| `pl-4`            | `ps-4`            |
+| `pr-4`            | `pe-4`            |
+| `text-left`       | `text-start`      |
+| `text-right`      | `text-end`       |
+| `justify-start`   | `justify-start`   |
+| `justify-end`     | `justify-end`     |
+
+### Enable RTL in components.json
+
+The RTL migration will automatically update your `components.json` to set `rtl: true`:
+
+```json title="components.json"
+{
+  "$schema": "https://shadcn-vue.com/schema.json",
+  "style": "new-york",
+  "typescript": true,
+  "tailwind": {
+    "config": "",
+    "css": "src/styles/globals.css",
+    "baseColor": "neutral",
+    "cssVariables": true,
+    "prefix": ""
+  },
+  "aliases": {
+    "components": "@/components",
+    "composables": "@/composables",
+    "utils": "@/lib/utils",
+    "ui": "@/components/ui",
+    "lib": "@/lib"
+  },
+  "iconLibrary": "lucide",
+  "pointer": false,
+  "rtl": true
+}
+```
+
+Or manually set `rtl: true` in your `components.json`.
+
+### Run the RTL migration
+
+Use the `migrate rtl` command to transform your components to support RTL:
+
+```bash
+npx shadcn-vue@latest migrate rtl
+```
+
+This will:
+
+1. Transform physical CSS properties to logical equivalents (e.g., `ml-4` → `ms-4`, `text-left` → `text-start`)
+2. Add `rtl:` variants where needed (e.g., `space-x-4` → `space-x-4 rtl:space-x-reverse`)
+
+**Migrate specific files**
+
+You can migrate specific files or use glob patterns:
+
+```bash
+# Migrate a specific file
+npx shadcn-vue@latest migrate rtl src/components/ui/button/Button.vue
+
+# Migrate files matching a glob pattern
+npx shadcn-vue@latest migrate rtl "src/components/ui/**"
+```
+
+### Set the dir attribute
+
+Set the `dir` attribute on the root element of your app:
+
+```vue title="App.vue"
+<script setup lang="ts">
+import { useColorMode } from '@vueuse/core'
+
+const mode = useColorMode()
+</script>
+
+<template>
+  <div :dir="mode === 'rtl' ? 'rtl' : 'ltr'">
+    <NuxtPage />
+  </div>
+</template>
+```
+
+Or set it directly:
+
+```vue title="App.vue"
+<template>
+  <div dir="rtl">
+    <NuxtPage />
+  </div>
+</template>
+```
+
+### RTL utilities
+
+The `rtl:` variant allows you to apply styles only when RTL is active:
+
+```vue
+<div class="space-x-4 rtl:space-x-reverse">
+  <!-- Content -->
+</div>
+```
+
+For components that accept a `dir` prop, you can pass it directly:
+
+```vue
+<Calendar dir="rtl" />
+<Command v-model:dir="dir" />
+```
+
+</Steps>

--- a/apps/v4/content/docs/08.rtl.md
+++ b/apps/v4/content/docs/08.rtl.md
@@ -18,15 +18,17 @@ This page explains how to add RTL support to your shadcn-vue project. RTL (right
 RTL (right-to-left) languages are read from right to left. shadcn-vue supports RTL through the `rtl` migration which transforms physical CSS properties to their logical equivalents:
 
 | Physical Property | Logical Property |
-| ----------------- | ----------------- |
-| `ml-4`            | `ms-4`            |
-| `mr-4`            | `me-4`            |
-| `pl-4`            | `ps-4`            |
-| `pr-4`            | `pe-4`            |
-| `text-left`       | `text-start`      |
+| ----------------- | ---------------- |
+| `ml-4`            | `ms-4`           |
+| `mr-4`            | `me-4`           |
+| `pl-4`            | `ps-4`           |
+| `pr-4`            | `pe-4`           |
+| `left-0`          | `start-0`        |
+| `right-0`         | `end-0`          |
+| `rounded-l-lg`    | `rounded-s-lg`   |
+| `border-r`        | `border-e`       |
+| `text-left`       | `text-start`     |
 | `text-right`      | `text-end`       |
-| `justify-start`   | `justify-start`   |
-| `justify-end`     | `justify-end`     |
 
 ### Enable RTL in components.json
 
@@ -84,32 +86,48 @@ npx shadcn-vue@latest migrate rtl src/components/ui/button/Button.vue
 npx shadcn-vue@latest migrate rtl "src/components/ui/**"
 ```
 
+See the [CLI documentation](/docs/cli#migrate-rtl) for more details.
+
+### Manual adjustments
+
+Some components may need manual review after running the migration. The CLI will list them when it finishes:
+
+- **Sidebar** - review direction-dependent props such as `side="left"` and any hardcoded positioning.
+- **Pagination** - flip directional icons (e.g. previous/next chevrons) using `rtl:rotate-180`.
+- **Calendar** - verify the navigation arrows and pass `dir="rtl"` where needed.
+
 ### Set the dir attribute
 
-Set the `dir` attribute on the root element of your app:
+Set the `dir` attribute on the `<html>` element so your entire app, including teleported components such as dialogs and dropdown menus, inherits the direction:
+
+```html title="index.html"
+<html dir="rtl">
+```
+
+To switch direction dynamically in Vue, use `useTextDirection` from `@vueuse/core`:
 
 ```vue title="App.vue"
 <script setup lang="ts">
-import { useColorMode } from '@vueuse/core'
+import { useTextDirection } from '@vueuse/core'
 
-const mode = useColorMode()
+const dir = useTextDirection()
+
+function toggleDirection() {
+  dir.value = dir.value === 'rtl' ? 'ltr' : 'rtl'
+}
 </script>
-
-<template>
-  <div :dir="mode === 'rtl' ? 'rtl' : 'ltr'">
-    <NuxtPage />
-  </div>
-</template>
 ```
 
-Or set it directly:
+In Nuxt, you can set it via `useHead`:
 
-```vue title="App.vue"
-<template>
-  <div dir="rtl">
-    <NuxtPage />
-  </div>
-</template>
+```vue title="app.vue"
+<script setup lang="ts">
+useHead({
+  htmlAttrs: {
+    dir: 'rtl',
+  },
+})
+</script>
 ```
 
 ### RTL utilities
@@ -126,7 +144,7 @@ For components that accept a `dir` prop, you can pass it directly:
 
 ```vue
 <Calendar dir="rtl" />
-<Command v-model:dir="dir" />
+<Command :dir="dir" />
 ```
 
 </Steps>

--- a/apps/v4/content/docs/08.rtl.md
+++ b/apps/v4/content/docs/08.rtl.md
@@ -1,82 +1,175 @@
 ---
 title: RTL
-description: Adding right-to-left support to your site.
+description: Right-to-left support for shadcn-vue components.
 ---
 
-## Right-to-left
+shadcn-vue components have first-class support for right-to-left (RTL) layouts. Text alignment, positioning, and directional styles automatically adapt for languages like Arabic, Hebrew, and Persian.
 
-<Callout>
+When you install components, the CLI automatically transforms physical positioning classes to logical equivalents, so your components work seamlessly in both LTR and RTL contexts.
 
-This page explains how to add RTL support to your shadcn-vue project. RTL (right-to-left) is essential for languages like Arabic, Hebrew, and Persian.
-
-</Callout>
+## Get Started
 
 <Steps>
 
-### Understanding RTL
+### Enable RTL
 
-RTL (right-to-left) languages are read from right to left. shadcn-vue supports RTL through the `rtl` migration which transforms physical CSS properties to their logical equivalents:
+Create a new project using the `--rtl` flag:
 
-| Physical Property | Logical Property |
-| ----------------- | ---------------- |
-| `ml-4`            | `ms-4`           |
-| `mr-4`            | `me-4`           |
-| `pl-4`            | `ps-4`           |
-| `pr-4`            | `pe-4`           |
-| `left-0`          | `start-0`        |
-| `right-0`         | `end-0`          |
-| `rounded-l-lg`    | `rounded-s-lg`   |
-| `border-r`        | `border-e`       |
-| `text-left`       | `text-start`     |
-| `text-right`      | `text-end`       |
+```bash
+npx shadcn-vue@latest create --rtl
+```
 
-### Enable RTL in components.json
+This will create a `components.json` file with the `rtl: true` flag.
 
-The RTL migration will automatically update your `components.json` to set `rtl: true`:
-
-```json title="components.json"
+```json title="components.json" showLineNumbers {4}
 {
   "$schema": "https://shadcn-vue.com/schema.json",
-  "style": "new-york",
-  "typescript": true,
-  "tailwind": {
-    "config": "",
-    "css": "src/styles/globals.css",
-    "baseColor": "neutral",
-    "cssVariables": true,
-    "prefix": ""
-  },
-  "aliases": {
-    "components": "@/components",
-    "composables": "@/composables",
-    "utils": "@/lib/utils",
-    "ui": "@/components/ui",
-    "lib": "@/lib"
-  },
-  "iconLibrary": "lucide",
-  "pointer": false,
+  "style": "nova",
   "rtl": true
 }
 ```
 
-Or manually set `rtl: true` in your `components.json`.
+For an existing project, set `rtl: true` in your `components.json` and see [Migrating existing components](#migrating-existing-components) below.
 
-### Run the RTL migration
+### Set the direction
 
-Use the `migrate rtl` command to transform your components to support RTL:
+Add the `dir="rtl"` and `lang="ar"` attributes to the `html` tag. Update `lang="ar"` to your target language.
 
-```bash
-npx shadcn-vue@latest migrate rtl
+For Vite, set them in your `index.html`:
+
+```html title="index.html" showLineNumbers {2}
+<!doctype html>
+<html lang="ar" dir="rtl">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vite App</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>
 ```
 
-This will:
+For Nuxt, set them via `useHead` in your `app.vue`:
 
-1. Transform physical CSS properties to logical equivalents (e.g., `ml-4` → `ms-4`, `text-left` → `text-start`)
-2. Add `rtl:` variants where needed (e.g., `space-x-4` → `space-x-4 rtl:space-x-reverse`)
+```vue title="app.vue" showLineNumbers
+<script setup lang="ts">
+useHead({
+  htmlAttrs: {
+    lang: 'ar',
+    dir: 'rtl',
+  },
+})
+</script>
+```
 
-**Migrate specific files**
+### Add ConfigProvider
 
-You can migrate specific files or use glob patterns:
+Wrap your app with the [`ConfigProvider`](https://reka-ui.com/docs/utilities/config-provider) component from `reka-ui` with the `dir="rtl"` prop, so all components read the correct direction:
+
+```vue title="App.vue" showLineNumbers {2,6,10}
+<script setup lang="ts">
+import { ConfigProvider } from 'reka-ui'
+</script>
+
+<template>
+  <ConfigProvider dir="rtl">
+    <RouterView />
+  </ConfigProvider>
+</template>
+```
+
+### Add Font
+
+For the best RTL experience, we recommend using fonts that have proper support for your target language. [Noto](https://fonts.google.com/noto) is a great font family for this and it pairs well with Inter and Geist.
+
+Install the font using [Fontsource](https://fontsource.org/fonts/noto-sans-arabic):
+
+```bash
+npm install @fontsource-variable/noto-sans-arabic
+```
+
+Import the font in your css file:
+
+```css title="src/assets/index.css" showLineNumbers {3,6}
+@import "tailwindcss";
+@import "tw-animate-css";
+@import "@fontsource-variable/noto-sans-arabic";
+
+@theme inline {
+  --font-sans: "Noto Sans Arabic Variable", sans-serif;
+}
+```
+
+For other languages, eg. Hebrew, you can use `@fontsource-variable/noto-sans-hebrew`.
+
+### Add Components
+
+You are now ready to add components to your project. The CLI will take care of handling RTL support for you.
+
+```bash
+npx shadcn-vue@latest add card
+```
+
+</Steps>
+
+## How it works
+
+When you add components with `rtl: true` set in your `components.json`, the CLI automatically transforms classes to be RTL compatible:
+
+- Physical positioning classes like `left-*` and `right-*` are converted to logical equivalents like `start-*` and `end-*`.
+- Text alignment and spacing classes are adjusted accordingly.
+- Supported icons are automatically flipped using `rtl:rotate-180`.
+
+## Font Recommendations
+
+For the best RTL experience, we recommend using fonts that have proper support for your target language. [Noto](https://fonts.google.com/noto) is a great font family for this and it pairs well with Inter and Geist.
+
+See the [Get Started](#get-started) section for details on installing and configuring RTL fonts.
+
+## Animations
+
+The CLI also handles animation classes, automatically transforming physical directional animations to their logical equivalents. For example, `slide-in-from-right` becomes `slide-in-from-end`.
+
+This ensures animations like dropdowns, popovers, and tooltips animate in the correct direction based on the document's text direction.
+
+**A note on tw-animate-css:**
+
+There is a [known issue](https://github.com/Wombosvideo/tw-animate-css/issues/67) with the `tw-animate-css` library where the logical slide utilities are not working as expected. For now, make sure you pass in the `dir` attribute to portal elements.
+
+```vue showLineNumbers
+<Popover>
+  <PopoverTrigger>Open</PopoverTrigger>
+  <PopoverContent dir="rtl">
+    <div>Content</div>
+  </PopoverContent>
+</Popover>
+```
+
+```vue showLineNumbers
+<Tooltip>
+  <TooltipTrigger>Open</TooltipTrigger>
+  <TooltipContent dir="rtl">
+    <div>Content</div>
+  </TooltipContent>
+</Tooltip>
+```
+
+## Migrating existing components
+
+If you have existing components installed before enabling RTL, you can migrate them using the CLI as follows:
+
+<Steps>
+
+### Run the migrate command
+
+```bash
+npx shadcn-vue@latest migrate rtl [path]
+```
+
+`[path]` accepts a path or glob pattern to migrate. If you don't provide a path, it will migrate all the files in the `ui` directory.
 
 ```bash
 # Migrate a specific file
@@ -86,65 +179,26 @@ npx shadcn-vue@latest migrate rtl src/components/ui/button/Button.vue
 npx shadcn-vue@latest migrate rtl "src/components/ui/**"
 ```
 
-See the [CLI documentation](/docs/cli#migrate-rtl) for more details.
+This will also update your `components.json` to set `rtl: true`. See the [CLI documentation](/docs/cli#migrate-rtl) for more details.
 
-### Manual adjustments
+### Manual Migration (Optional)
 
-Some components may need manual review after running the migration. The CLI will list them when it finishes:
+The following components are not automatically migrated by the CLI and may need manual adjustments:
 
-- **Sidebar** - review direction-dependent props such as `side="left"` and any hardcoded positioning.
-- **Pagination** - flip directional icons (e.g. previous/next chevrons) using `rtl:rotate-180`.
-- **Calendar** - verify the navigation arrows and pass `dir="rtl"` where needed.
+- [Calendar](/docs/components/calendar)
+- [Pagination](/docs/components/pagination)
+- [Sidebar](/docs/components/sidebar)
 
-### Set the dir attribute
+### Migrate Icons
 
-Set the `dir` attribute on the `<html>` element so your entire app, including teleported components such as dialogs and dropdown menus, inherits the direction:
+Some icons like `ArrowRight` or `ChevronLeft` might need the `rtl:rotate-180` class to be flipped correctly. Add the `rtl:rotate-180` class to the icon component to flip it correctly.
 
-```html title="index.html"
-<html dir="rtl">
+```vue showLineNumbers
+<ArrowRight class="rtl:rotate-180" />
 ```
 
-To switch direction dynamically in Vue, use `useTextDirection` from `@vueuse/core`:
+### Add ConfigProvider
 
-```vue title="App.vue"
-<script setup lang="ts">
-import { useTextDirection } from '@vueuse/core'
-
-const dir = useTextDirection()
-
-function toggleDirection() {
-  dir.value = dir.value === 'rtl' ? 'ltr' : 'rtl'
-}
-</script>
-```
-
-In Nuxt, you can set it via `useHead`:
-
-```vue title="app.vue"
-<script setup lang="ts">
-useHead({
-  htmlAttrs: {
-    dir: 'rtl',
-  },
-})
-</script>
-```
-
-### RTL utilities
-
-The `rtl:` variant allows you to apply styles only when RTL is active:
-
-```vue
-<div class="space-x-4 rtl:space-x-reverse">
-  <!-- Content -->
-</div>
-```
-
-For components that accept a `dir` prop, you can pass it directly:
-
-```vue
-<Calendar dir="rtl" />
-<Command :dir="dir" />
-```
+Wrap your app with the `ConfigProvider` component from `reka-ui`. See the [Get Started](#get-started) section for details.
 
 </Steps>


### PR DESCRIPTION
## Summary

Fix #1800 - RTL documentation is not working

Added a comprehensive RTL documentation page covering:
- Understanding RTL and logical CSS properties (ml-4 → ms-4, etc.)
- Enabling RTL in components.json
- Running the RTL migration via CLI
- Setting the dir attribute on the root element
- RTL utilities and variants

## Changes

- Added  (132 lines)
- Documents the existing `migrate rtl` CLI command
- Includes a physical-to-logical properties table
- Shows how to set dir attribute for RTL languages

## Test Plan

The documentation will be available at `/docs/rtl` on the shadcn-vue website after merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added/expanded end-to-end RTL support instructions for shadcn-vue, including enabling via the `--rtl` flag and how it updates project settings.
  * Documented how to set document direction for Vite and Nuxt, and the need to wrap the app with `reka-ui`’s `ConfigProvider` using `dir="rtl"`.
  * Covered RTL-related assets such as font setup and icon flipping, plus an animation/portal workaround that requires passing `dir`.
  * Included migration guidance and a checklist for components to review after migration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->