### PR TITLE
fix: constrain dialog content height

### DIFF
--- a/apps/v4/registry/bases/reka/ui/dialog/DialogContent.vue
+++ b/apps/v4/registry/bases/reka/ui/dialog/DialogContent.vue
@@ -33,7 +33,7 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits)
     <DialogContent
       data-slot="dialog-content"
       v-bind="{ ...$attrs, ...forwarded }"
-      :class="cn('cn-dialog-content fixed top-1/2 left-1/2 z-50 w-full -translate-x-1/2 -translate-y-1/2 outline-none', props.class)"
+      :class="cn('cn-dialog-content fixed top-1/2 left-1/2 z-50 max-h-[calc(100dvh-2rem)] w-full overflow-y-auto -translate-x-1/2 -translate-y-1/2 outline-none', props.class)"
     >
       <slot />
 

--- a/apps/v4/registry/new-york-v4/ui/dialog/DialogContent.vue
+++ b/apps/v4/registry/new-york-v4/ui/dialog/DialogContent.vue
@@ -34,7 +34,7 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits)
       v-bind="{ ...$attrs, ...forwarded }"
       :class="
         cn(
-          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg',
+          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid max-h-[calc(100dvh-2rem)] w-full max-w-[calc(100%-2rem)] overflow-y-auto translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg',
           props.class,
         )"
     >

--- a/apps/v4/styles/reka-luma/ui/dialog/DialogContent.vue
+++ b/apps/v4/styles/reka-luma/ui/dialog/DialogContent.vue
@@ -34,7 +34,7 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits)
     <DialogContent
       data-slot="dialog-content"
       v-bind="{ ...$attrs, ...forwarded }"
-      :class="cn('bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 ring-foreground/5 dark:ring-foreground/10 grid max-w-[calc(100%-2rem)] gap-6 rounded-4xl p-6 text-sm shadow-xl ring-1 duration-100 sm:max-w-md fixed top-1/2 left-1/2 z-50 w-full -translate-x-1/2 -translate-y-1/2 outline-none', props.class)"
+      :class="cn('bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 ring-foreground/5 dark:ring-foreground/10 grid max-w-[calc(100%-2rem)] gap-6 rounded-4xl p-6 text-sm shadow-xl ring-1 duration-100 sm:max-w-md fixed top-1/2 left-1/2 z-50 max-h-[calc(100dvh-2rem)] w-full overflow-y-auto -translate-x-1/2 -translate-y-1/2 outline-none', props.class)"
     >
       <slot />
 

--- a/apps/v4/styles/reka-lyra/ui/dialog/DialogContent.vue
+++ b/apps/v4/styles/reka-lyra/ui/dialog/DialogContent.vue
@@ -34,7 +34,7 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits)
     <DialogContent
       data-slot="dialog-content"
       v-bind="{ ...$attrs, ...forwarded }"
-      :class="cn('bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 ring-foreground/10 grid max-w-[calc(100%-2rem)] gap-4 rounded-none p-4 text-xs/relaxed ring-1 duration-100 sm:max-w-sm fixed top-1/2 left-1/2 z-50 w-full -translate-x-1/2 -translate-y-1/2 outline-none', props.class)"
+      :class="cn('bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 ring-foreground/10 grid max-w-[calc(100%-2rem)] gap-4 rounded-none p-4 text-xs/relaxed ring-1 duration-100 sm:max-w-sm fixed top-1/2 left-1/2 z-50 max-h-[calc(100dvh-2rem)] w-full overflow-y-auto -translate-x-1/2 -translate-y-1/2 outline-none', props.class)"
     >
       <slot />
 

--- a/apps/v4/styles/reka-maia/ui/dialog/DialogContent.vue
+++ b/apps/v4/styles/reka-maia/ui/dialog/DialogContent.vue
@@ -34,7 +34,7 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits)
     <DialogContent
       data-slot="dialog-content"
       v-bind="{ ...$attrs, ...forwarded }"
-      :class="cn('bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 ring-foreground/5 grid max-w-[calc(100%-2rem)] gap-6 rounded-4xl p-6 text-sm ring-1 duration-100 sm:max-w-md fixed top-1/2 left-1/2 z-50 w-full -translate-x-1/2 -translate-y-1/2 outline-none', props.class)"
+      :class="cn('bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 ring-foreground/5 grid max-w-[calc(100%-2rem)] gap-6 rounded-4xl p-6 text-sm ring-1 duration-100 sm:max-w-md fixed top-1/2 left-1/2 z-50 max-h-[calc(100dvh-2rem)] w-full overflow-y-auto -translate-x-1/2 -translate-y-1/2 outline-none', props.class)"
     >
       <slot />
 

--- a/apps/v4/styles/reka-mira/ui/dialog/DialogContent.vue
+++ b/apps/v4/styles/reka-mira/ui/dialog/DialogContent.vue
@@ -34,7 +34,7 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits)
     <DialogContent
       data-slot="dialog-content"
       v-bind="{ ...$attrs, ...forwarded }"
-      :class="cn('bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 ring-foreground/10 grid max-w-[calc(100%-2rem)] gap-4 rounded-xl p-4 text-xs/relaxed ring-1 duration-100 sm:max-w-sm fixed top-1/2 left-1/2 z-50 w-full -translate-x-1/2 -translate-y-1/2 outline-none', props.class)"
+      :class="cn('bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 ring-foreground/10 grid max-w-[calc(100%-2rem)] gap-4 rounded-xl p-4 text-xs/relaxed ring-1 duration-100 sm:max-w-sm fixed top-1/2 left-1/2 z-50 max-h-[calc(100dvh-2rem)] w-full overflow-y-auto -translate-x-1/2 -translate-y-1/2 outline-none', props.class)"
     >
       <slot />
 

--- a/apps/v4/styles/reka-nova/ui/dialog/DialogContent.vue
+++ b/apps/v4/styles/reka-nova/ui/dialog/DialogContent.vue
@@ -34,7 +34,7 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits)
     <DialogContent
       data-slot="dialog-content"
       v-bind="{ ...$attrs, ...forwarded }"
-      :class="cn('bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 ring-foreground/10 grid max-w-[calc(100%-2rem)] gap-4 rounded-xl p-4 text-sm ring-1 duration-100 sm:max-w-sm fixed top-1/2 left-1/2 z-50 w-full -translate-x-1/2 -translate-y-1/2 outline-none', props.class)"
+      :class="cn('bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 ring-foreground/10 grid max-w-[calc(100%-2rem)] gap-4 rounded-xl p-4 text-sm ring-1 duration-100 sm:max-w-sm fixed top-1/2 left-1/2 z-50 max-h-[calc(100dvh-2rem)] w-full overflow-y-auto -translate-x-1/2 -translate-y-1/2 outline-none', props.class)"
     >
       <slot />
 

--- a/apps/v4/styles/reka-sera/ui/dialog/DialogContent.vue
+++ b/apps/v4/styles/reka-sera/ui/dialog/DialogContent.vue
@@ -34,7 +34,7 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits)
     <DialogContent
       data-slot="dialog-content"
       v-bind="{ ...$attrs, ...forwarded }"
-      :class="cn('bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 ring-foreground/10 grid max-w-[calc(100%-2rem)] gap-6 rounded-none p-6 text-sm shadow-md ring-1 duration-100 sm:max-w-md fixed top-1/2 left-1/2 z-50 w-full -translate-x-1/2 -translate-y-1/2 outline-none', props.class)"
+      :class="cn('bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 ring-foreground/10 grid max-w-[calc(100%-2rem)] gap-6 rounded-none p-6 text-sm shadow-md ring-1 duration-100 sm:max-w-md fixed top-1/2 left-1/2 z-50 max-h-[calc(100dvh-2rem)] w-full overflow-y-auto -translate-x-1/2 -translate-y-1/2 outline-none', props.class)"
     >
       <slot />
 

--- a/apps/v4/styles/reka-vega/ui/dialog/DialogContent.vue
+++ b/apps/v4/styles/reka-vega/ui/dialog/DialogContent.vue
@@ -34,7 +34,7 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits)
     <DialogContent
       data-slot="dialog-content"
       v-bind="{ ...$attrs, ...forwarded }"
-      :class="cn('bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 ring-foreground/10 grid max-w-[calc(100%-2rem)] gap-6 rounded-xl p-6 text-sm ring-1 duration-100 sm:max-w-md fixed top-1/2 left-1/2 z-50 w-full -translate-x-1/2 -translate-y-1/2 outline-none', props.class)"
+      :class="cn('bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 ring-foreground/10 grid max-w-[calc(100%-2rem)] gap-6 rounded-xl p-6 text-sm ring-1 duration-100 sm:max-w-md fixed top-1/2 left-1/2 z-50 max-h-[calc(100dvh-2rem)] w-full overflow-y-auto -translate-x-1/2 -translate-y-1/2 outline-none', props.class)"
     >
       <slot />
 

--- a/packages/cli/test/utils/dialog-content-overflow.test.ts
+++ b/packages/cli/test/utils/dialog-content-overflow.test.ts
@@ -1,0 +1,24 @@
+import { readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const dialogContentFiles = [
+  'apps/v4/registry/bases/reka/ui/dialog/DialogContent.vue',
+  'apps/v4/registry/new-york-v4/ui/dialog/DialogContent.vue',
+  'apps/v4/styles/reka-luma/ui/dialog/DialogContent.vue',
+  'apps/v4/styles/reka-lyra/ui/dialog/DialogContent.vue',
+  'apps/v4/styles/reka-maia/ui/dialog/DialogContent.vue',
+  'apps/v4/styles/reka-mira/ui/dialog/DialogContent.vue',
+  'apps/v4/styles/reka-nova/ui/dialog/DialogContent.vue',
+  'apps/v4/styles/reka-sera/ui/dialog/DialogContent.vue',
+  'apps/v4/styles/reka-vega/ui/dialog/DialogContent.vue',
+]
+
+describe('v4 dialog content overflow', () => {
+  it.each(dialogContentFiles)('%s stays scrollable in short viewports', async (file) => {
+    const content = await readFile(join(process.cwd(), file), 'utf8')
+
+    expect(content).toContain('max-h-[calc(100dvh-2rem)]')
+    expect(content).toContain('overflow-y-auto')
+  })
+})


### PR DESCRIPTION
## Summary
- Constrain v4 `DialogContent` to the viewport with `max-h-[calc(100dvh-2rem)]`.
- Enable internal scrolling for tall dialog content with `overflow-y-auto`.
- Apply the same fix across the base Reka dialog, `new-york-v4`, and all v4 Reka style variants.
- Add a focused regression test to keep all v4 dialog variants aligned.

## Bug
Tall default dialog content could exceed the viewport and make content inaccessible, especially when a dialog body is taller than the available screen height.

## Root cause
`DialogContent` was fixed and centered, but it did not define a viewport-relative maximum height or overflow behavior. Tall content therefore rendered beyond the visible viewport instead of scrolling inside the dialog.

## Fix
The default dialog content class now includes:

```txt
max-h-[calc(100dvh-2rem)] overflow-y-auto
```

This keeps a 1rem viewport margin above and below the dialog while allowing overflow content to scroll internally.

## Screenshot

Tall dialog content is constrained to the viewport and scrolls internally:

![Tall dialog content constrained to viewport with internal scrolling](https://raw.githubusercontent.com/kgrg/shadcn-vue/pr-assets/dialog-content-scroll-1837/dialog-content-scroll.png)

## Verification
- ✅ `pnpm vitest run packages/cli/test/utils/dialog-content-overflow.test.ts`
  - 1 test file passed, 9 tests passed
- ✅ `pnpm lint`
  - exits 0; existing repo warnings only
- ✅ `pnpm --filter v4 registry:build`
  - succeeded; broad generated public registry output was reverted to keep this PR focused
- ⚠️ `pnpm --filter v4 typecheck`
  - currently fails on existing unrelated v4 type errors outside this change, including tabs, icons, pagination examples, and sonner duplicate `toastOptions` issues

## Notes
- This branch is based on `dev`, because that branch contains the active v4 app and registry source for this issue.
- Visual verification screenshot was reviewed locally before opening this PR.

Fixes unovue/shadcn-vue#1835


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Dialogs now properly constrain to viewport height and automatically enable scrolling when content exceeds available space, improving layout stability across all screen sizes.

* **Tests**
  * Added verification tests for dialog overflow handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unovue/shadcn-vue/pull/1837?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->