### PR TITLE
fix(cli): use nypm for dependency installs

### DIFF
--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -3,10 +3,9 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { Command } from 'commander'
 import deepmerge from 'deepmerge'
 import fsExtra from 'fs-extra'
-import { detectPackageManager } from 'nypm'
+import { addDevDependency, detectPackageManager } from 'nypm'
 import path from 'pathe'
 import prompts from 'prompts'
-import { x } from 'tinyexec'
 import z from 'zod'
 import { server } from '@/src/mcp'
 import { loadEnvFiles } from '@/src/utils/env-loader'
@@ -160,20 +159,8 @@ mcp
           })
         }
         else {
-          const packageManager = await detectPackageManager(options.cwd)
-          const installCommand = packageManager?.name === 'npm' ? 'install' : 'add'
-          const devFlag = packageManager?.name === 'npm' ? '--save-dev' : '-D'
-
           const installSpinner = spinner('Installing dependencies...').start()
-          await x(
-            packageManager?.name || 'npm',
-            [installCommand, devFlag, ...DEPENDENCIES],
-            {
-              nodeOptions: {
-                cwd: options.cwd,
-              },
-            },
-          )
+          await installMcpDependencies(options.cwd)
           installSpinner.succeed('Installing dependencies.')
         }
 
@@ -206,20 +193,8 @@ args = ["shadcn-vue@${SHADCN_MCP_VERSION}", "mcp"]`)
         })
       }
       else {
-        const packageManager = await detectPackageManager(options.cwd)
-        const installCommand = packageManager?.name === 'npm' ? 'install' : 'add'
-        const devFlag = packageManager?.name === 'npm' ? '--save-dev' : '-D'
-
         const installSpinner = spinner('Installing dependencies...').start()
-        await x(
-          packageManager?.name || 'npm',
-          [installCommand, devFlag, ...DEPENDENCIES],
-          {
-            nodeOptions: {
-              cwd: options.cwd,
-            },
-          },
-        )
+        await installMcpDependencies(options.cwd)
         installSpinner.succeed('Installing dependencies.')
       }
 
@@ -270,4 +245,13 @@ async function runMcpInit(options: z.infer<typeof mcpInitOptionsSchema>) {
   )
 
   return clientInfo.configPath
+}
+
+async function installMcpDependencies(cwd: string) {
+  const packageManager = await detectPackageManager(cwd)
+  await addDevDependency(DEPENDENCIES, {
+    cwd,
+    packageManager: packageManager?.name ?? 'npm',
+    silent: true,
+  })
 }

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -3,7 +3,7 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { Command } from 'commander'
 import deepmerge from 'deepmerge'
 import fsExtra from 'fs-extra'
-import { addDevDependency, detectPackageManager } from 'nypm'
+import { addDevDependency } from 'nypm'
 import path from 'pathe'
 import prompts from 'prompts'
 import z from 'zod'
@@ -14,7 +14,10 @@ import { handleError } from '@/src/utils/handle-error'
 import { highlighter } from '@/src/utils/highlighter'
 import { logger } from '@/src/utils/logger'
 import { spinner } from '@/src/utils/spinner'
-import { updateDependencies } from '@/src/utils/updaters/update-dependencies'
+import {
+  getPackageManager,
+  updateDependencies,
+} from '@/src/utils/updaters/update-dependencies'
 
 const SHADCN_MCP_VERSION = 'latest'
 
@@ -248,10 +251,10 @@ async function runMcpInit(options: z.infer<typeof mcpInitOptionsSchema>) {
 }
 
 async function installMcpDependencies(cwd: string) {
-  const packageManager = await detectPackageManager(cwd)
+  const packageManager = await getPackageManager(cwd, { withFallback: true })
   await addDevDependency(DEPENDENCIES, {
     cwd,
-    packageManager: packageManager?.name ?? 'npm',
+    packageManager,
     silent: true,
   })
 }

--- a/packages/cli/src/utils/create-project.ts
+++ b/packages/cli/src/utils/create-project.ts
@@ -2,6 +2,7 @@ import type { z } from 'zod'
 import type { initOptionsSchema } from '@/src/commands/init'
 import fs from 'fs-extra'
 import { downloadTemplate } from 'giget'
+import { installDependencies } from 'nypm'
 import path from 'pathe'
 import prompts from 'prompts'
 import { x } from 'tinyexec'
@@ -133,11 +134,10 @@ export async function createProject(
     })
 
     // Install dependencies
-    await x(packageManager, ['install'], {
-      throwOnError: true,
-      nodeOptions: {
-        cwd: projectPath,
-      },
+    await installDependencies({
+      cwd: projectPath,
+      packageManager,
+      silent: true,
     })
 
     createSpinner?.succeed(`Created a new ${template} project.`)

--- a/packages/cli/src/utils/updaters/update-dependencies.ts
+++ b/packages/cli/src/utils/updaters/update-dependencies.ts
@@ -89,6 +89,7 @@ export async function updateDependencies(
     dependencies,
     devDependencies,
     config.resolvedPaths.cwd,
+    options.silent,
   )
 
   dependenciesSpinner?.succeed()
@@ -99,11 +100,12 @@ async function installWithPackageManager(
   dependencies: string[],
   devDependencies: string[],
   cwd: string,
+  silent: boolean,
 ) {
   const options = {
     cwd,
     packageManager,
-    silent: true,
+    silent,
   }
 
   if (dependencies?.length) {

--- a/packages/cli/src/utils/updaters/update-dependencies.ts
+++ b/packages/cli/src/utils/updaters/update-dependencies.ts
@@ -3,8 +3,7 @@ import type { RegistryItem } from '@/src/schema'
 import type { Config } from '@/src/utils/get-config'
 import fs from 'node:fs'
 import path from 'node:path'
-import { detectPackageManager } from 'nypm'
-import { x } from 'tinyexec'
+import { addDependency, addDevDependency, detectPackageManager } from 'nypm'
 import { spinner } from '@/src/utils/spinner'
 
 export type SupportedPackageManager = PackageManagerName
@@ -101,70 +100,17 @@ async function installWithPackageManager(
   devDependencies: string[],
   cwd: string,
 ) {
-  if (packageManager === 'npm') {
-    return installWithNpm(dependencies, devDependencies, cwd)
+  const options = {
+    cwd,
+    packageManager,
+    silent: true,
   }
 
-  if (packageManager === 'deno') {
-    return installWithDeno(dependencies, devDependencies, cwd)
-  }
-
-  // pnpm, yarn, bun all use `add` / `add -D`.
   if (dependencies?.length) {
-    await x(packageManager, ['add', ...dependencies], {
-      throwOnError: true,
-      nodeOptions: { cwd },
-    })
+    await addDependency(dependencies, options)
   }
 
   if (devDependencies?.length) {
-    await x(packageManager, ['add', '-D', ...devDependencies], {
-      throwOnError: true,
-      nodeOptions: { cwd },
-    })
-  }
-}
-
-async function installWithNpm(
-  dependencies: string[],
-  devDependencies: string[],
-  cwd: string,
-) {
-  if (dependencies?.length) {
-    await x('npm', ['install', ...dependencies], {
-      throwOnError: true,
-      nodeOptions: { cwd },
-    })
-  }
-
-  if (devDependencies?.length) {
-    await x('npm', ['install', '-D', ...devDependencies], {
-      throwOnError: true,
-      nodeOptions: { cwd },
-    })
-  }
-}
-
-async function installWithDeno(
-  dependencies: string[],
-  devDependencies: string[],
-  cwd: string,
-) {
-  if (dependencies?.length) {
-    await x('deno', ['add', ...dependencies.map(dep => `npm:${dep}`)], {
-      throwOnError: true,
-      nodeOptions: { cwd },
-    })
-  }
-
-  if (devDependencies?.length) {
-    await x(
-      'deno',
-      ['add', '-D', ...devDependencies.map(dep => `npm:${dep}`)],
-      {
-        throwOnError: true,
-        nodeOptions: { cwd },
-      },
-    )
+    await addDevDependency(devDependencies, options)
   }
 }

--- a/packages/cli/test/utils/create-project.test.ts
+++ b/packages/cli/test/utils/create-project.test.ts
@@ -1,7 +1,7 @@
 import type { MockInstance } from 'vitest'
 import fs from 'fs-extra'
 import { downloadTemplate } from 'giget'
-import { detectPackageManager } from 'nypm'
+import { detectPackageManager, installDependencies } from 'nypm'
 import prompts from 'prompts'
 import { x } from 'tinyexec'
 import {
@@ -23,6 +23,7 @@ vi.mock('tinyexec')
 vi.mock('prompts')
 vi.mock('nypm', () => ({
   detectPackageManager: vi.fn(),
+  installDependencies: vi.fn(),
 }))
 vi.mock('@/src/utils/spinner')
 vi.mock('@/src/utils/logger', () => ({
@@ -45,6 +46,7 @@ describe('createProject', () => {
       name: 'npm',
       command: 'npm',
     })
+    vi.mocked(installDependencies).mockResolvedValue({} as any)
 
     // Reset all fs mocks
     vi.mocked(fs.access).mockResolvedValue(undefined)
@@ -234,11 +236,11 @@ describe('createProject', () => {
       template: undefined,
     })
 
-    expect(x).toHaveBeenCalledWith(
-      'npm',
-      ['install'],
-      { throwOnError: true, nodeOptions: { cwd: '/test/my-app' } },
-    )
+    expect(installDependencies).toHaveBeenCalledWith({
+      cwd: '/test/my-app',
+      packageManager: 'npm',
+      silent: true,
+    })
   })
 
   it('should throw error if project path already exists', async () => {

--- a/packages/cli/test/utils/updaters/update-dependencies.test.ts
+++ b/packages/cli/test/utils/updaters/update-dependencies.test.ts
@@ -1,0 +1,87 @@
+import { addDependency, addDevDependency, detectPackageManager } from 'nypm'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { spinner } from '../../../src/utils/spinner'
+import { updateDependencies } from '../../../src/utils/updaters/update-dependencies'
+
+vi.mock('nypm', () => ({
+  addDependency: vi.fn(),
+  addDevDependency: vi.fn(),
+  detectPackageManager: vi.fn(),
+}))
+
+vi.mock('../../../src/utils/spinner', () => ({
+  spinner: vi.fn(),
+}))
+
+const config = {
+  resolvedPaths: {
+    cwd: '/test/project',
+  },
+} as any
+
+describe('updateDependencies', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    delete process.env.npm_config_user_agent
+
+    vi.mocked(detectPackageManager).mockResolvedValue({
+      name: 'pnpm',
+      command: 'pnpm',
+    })
+    vi.mocked(addDependency).mockResolvedValue({} as any)
+    vi.mocked(addDevDependency).mockResolvedValue({} as any)
+
+    const mockSpinner = {
+      start: vi.fn().mockReturnThis(),
+      succeed: vi.fn().mockReturnThis(),
+    }
+    vi.mocked(spinner).mockReturnValue(mockSpinner as any)
+  })
+
+  it('installs de-duplicated dependencies with nypm', async () => {
+    await updateDependencies(
+      ['@tanstack/vue-table', 'reka-ui', 'reka-ui'],
+      ['tailwindcss', 'tailwindcss'],
+      config,
+      { silent: false },
+    )
+
+    expect(addDependency).toHaveBeenCalledWith(
+      ['@tanstack/vue-table', 'reka-ui'],
+      {
+        cwd: '/test/project',
+        packageManager: 'pnpm',
+        silent: true,
+      },
+    )
+    expect(addDevDependency).toHaveBeenCalledWith(['tailwindcss'], {
+      cwd: '/test/project',
+      packageManager: 'pnpm',
+      silent: true,
+    })
+  })
+
+  it('falls back to the dlx package manager user agent', async () => {
+    vi.mocked(detectPackageManager).mockResolvedValue(undefined)
+    process.env.npm_config_user_agent = 'pnpm/11.5.0 npm/? node/v24.11.1'
+
+    await updateDependencies(['@tanstack/vue-table'], [], config, {
+      silent: true,
+    })
+
+    expect(addDependency).toHaveBeenCalledWith(['@tanstack/vue-table'], {
+      cwd: '/test/project',
+      packageManager: 'pnpm',
+      silent: true,
+    })
+  })
+
+  it('skips package manager detection when there is nothing to install', async () => {
+    await updateDependencies([], [], config, { silent: true })
+
+    expect(detectPackageManager).not.toHaveBeenCalled()
+    expect(addDependency).not.toHaveBeenCalled()
+    expect(addDevDependency).not.toHaveBeenCalled()
+  })
+})

--- a/packages/cli/test/utils/updaters/update-dependencies.test.ts
+++ b/packages/cli/test/utils/updaters/update-dependencies.test.ts
@@ -52,13 +52,13 @@ describe('updateDependencies', () => {
       {
         cwd: '/test/project',
         packageManager: 'pnpm',
-        silent: true,
+        silent: false,
       },
     )
     expect(addDevDependency).toHaveBeenCalledWith(['tailwindcss'], {
       cwd: '/test/project',
       packageManager: 'pnpm',
-      silent: true,
+      silent: false,
     })
   })
 


### PR DESCRIPTION
## Summary

- route CLI dependency installs through `nypm` so pnpm/yarn can use Corepack-aware package manager resolution
- update project creation and MCP dependency installs to use the same install path
- add tests for dependency de-duplication and `pnpm dlx` user-agent fallback

Fixes #1839.

## Verification

- `pnpm --filter shadcn-vue test test/utils/updaters/update-dependencies.test.ts test/utils/create-project.test.ts`
- `pnpm --filter shadcn-vue build`

Notes: `pnpm --filter shadcn-vue typecheck` is currently blocked by existing errors in `src/preset/preset.ts`, `src/registry/api.test.ts`, `src/utils/transformers/transform-icons.ts`, and `src/utils/transformers/transform-import.ts`. The full test suite also still has pre-existing Windows path/local registry test failures unrelated to this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched to a unified package-manager installation layer for dependency installs, improving reliability and consistency across environments.
  * Made project-creation and update installs quieter by default (silent operations) and streamlined the install flow.

* **Tests**
  * Added tests covering dependency management: deduplication, package-manager detection fallback, and empty-list behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->