### PR TITLE
fix(cli): don't crash on init --preset when cwd has a sibling components/ dir

### DIFF
--- a/packages/cli/src/utils/get-config.ts
+++ b/packages/cli/src/utils/get-config.ts
@@ -1,4 +1,5 @@
 import type { z } from 'zod'
+import { existsSync } from 'node:fs'
 import { loadConfig } from 'c12'
 import { getTsconfig } from 'get-tsconfig'
 import path from 'pathe'
@@ -166,12 +167,24 @@ export async function getRawConfig(
     // `MODULE_NOT_FOUND` for `'components'` instead of c12 reporting "no
     // config found". This is indistinguishable from "no config file present"
     // from our side, so treat it the same way (return null) rather than
-    // surfacing it as a config parse error.
+    // surfacing it as a config parse error. Only do this when there's no
+    // explicit config file present — if one of these exists, a
+    // MODULE_NOT_FOUND for 'components' is a real failure (e.g. the user's
+    // own components.config.ts importing a missing module) and must still
+    // surface as ConfigParseError instead of being silently swallowed.
     // See: https://github.com/unjs/c12 (upstream issue pending).
+    const hasExplicitConfigFile
+      = existsSync(path.resolve(cwd, 'components.json'))
+        || existsSync(path.resolve(cwd, 'components.config.ts'))
+        || existsSync(path.resolve(cwd, 'components.config.js'))
+        || existsSync(path.resolve(cwd, 'components.config.mjs'))
+        || existsSync(path.resolve(cwd, 'components.config.cjs'))
+
     if (
       error instanceof Error
       && (error as NodeJS.ErrnoException).code === 'MODULE_NOT_FOUND'
       && error.message.includes('\'components\'')
+      && !hasExplicitConfigFile
     ) {
       return null
     }

--- a/packages/cli/src/utils/get-config.ts
+++ b/packages/cli/src/utils/get-config.ts
@@ -155,6 +155,27 @@ export async function getRawConfig(
     return config
   }
   catch (error) {
+    // Work around a c12/jiti resolution bug: when no `components.json` (or
+    // `components.config.*`) file exists, c12's internal fallback chain for
+    // an extensionless `configFile` (here, the literal string "components")
+    // can end up calling `existsSync("components")` relative to the actual
+    // process cwd instead of the resolved project cwd. Since virtually every
+    // Vue/Nuxt project has a sibling `components/` directory, this
+    // accidentally resolves to that directory and gets passed — as a bare,
+    // unresolved specifier — into `jiti.import()`, which then throws a raw
+    // `MODULE_NOT_FOUND` for `'components'` instead of c12 reporting "no
+    // config found". This is indistinguishable from "no config file present"
+    // from our side, so treat it the same way (return null) rather than
+    // surfacing it as a config parse error.
+    // See: https://github.com/unjs/c12 (upstream issue pending).
+    if (
+      error instanceof Error
+      && (error as NodeJS.ErrnoException).code === 'MODULE_NOT_FOUND'
+      && error.message.includes('\'components\'')
+    ) {
+      return null
+    }
+
     throw new ConfigParseError(cwd, error)
   }
 }

--- a/packages/cli/test/fixtures/config-explicit-broken-import/components.config.ts
+++ b/packages/cli/test/fixtures/config-explicit-broken-import/components.config.ts
@@ -1,0 +1,6 @@
+// Intentionally broken: imports a module that does not exist, named
+// 'components'. Used to verify that getRawConfig still surfaces this as a
+// real ConfigParseError instead of swallowing it as "no config found".
+import 'components'
+
+export default {}

--- a/packages/cli/test/fixtures/config-explicit-broken-import/components/Example.vue
+++ b/packages/cli/test/fixtures/config-explicit-broken-import/components/Example.vue
@@ -1,0 +1,3 @@
+<template>
+  <div>Example</div>
+</template>

--- a/packages/cli/test/fixtures/config-explicit-broken-import/package.json
+++ b/packages/cli/test/fixtures/config-explicit-broken-import/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "test-cli-config-explicit-broken-import",
+  "version": "1.0.0",
+  "author": "shadcn",
+  "license": "MIT",
+  "main": "index.js"
+}

--- a/packages/cli/test/fixtures/config-none-with-components-dir/components/Example.vue
+++ b/packages/cli/test/fixtures/config-none-with-components-dir/components/Example.vue
@@ -1,0 +1,3 @@
+<template>
+  <div>Example</div>
+</template>

--- a/packages/cli/test/fixtures/config-none-with-components-dir/package.json
+++ b/packages/cli/test/fixtures/config-none-with-components-dir/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "test-cli-config-none-with-components-dir",
+  "version": "1.0.0",
+  "author": "shadcn",
+  "license": "MIT",
+  "main": "index.js"
+}

--- a/packages/cli/test/utils/get-config.test.ts
+++ b/packages/cli/test/utils/get-config.test.ts
@@ -34,6 +34,26 @@ it('get raw config does not throw when cwd has a sibling components/ dir and no 
   }
 })
 
+// Guards against over-broad suppression: when an explicit components.config.ts
+// *does* exist and genuinely fails to resolve a module (here, one literally
+// named 'components'), that's a real user error and must still surface as
+// ConfigParseError rather than being swallowed by the MODULE_NOT_FOUND
+// work-around above.
+it('get raw config still throws for a real MODULE_NOT_FOUND inside an explicit config file', async () => {
+  const originalCwd = process.cwd()
+  const fixtureDir = path.resolve(
+    __dirname,
+    '../fixtures/config-explicit-broken-import',
+  )
+  process.chdir(fixtureDir)
+  try {
+    await expect(getRawConfig(fixtureDir)).rejects.toThrowError()
+  }
+  finally {
+    process.chdir(originalCwd)
+  }
+})
+
 it('get raw config', async () => {
   expect(
     await getRawConfig(path.resolve(__dirname, '../fixtures/config-none')),

--- a/packages/cli/test/utils/get-config.test.ts
+++ b/packages/cli/test/utils/get-config.test.ts
@@ -7,6 +7,33 @@ import {
   getRawConfig,
 } from '../../src/utils/get-config'
 
+// Regression test for a c12/jiti resolution quirk: when no components.json
+// (or components.config.*) exists, c12's fallback chain for an
+// extensionless `configFile` (the literal string "components") ends up
+// calling `existsSync("components")` relative to the actual process cwd
+// (not the `cwd` argument passed to getRawConfig). Since virtually every
+// Vue/Nuxt project is run from a directory that has a sibling `components/`
+// folder, this accidentally resolves to that directory and gets passed —
+// as a bare, unresolved specifier — into `jiti.import()`, which throws a
+// raw `MODULE_NOT_FOUND` for `'components'` instead of c12 reporting "no
+// config found". We reproduce this here by actually chdir-ing into a
+// fixture with a `components/` directory and no components.json, since the
+// bug is tied to `process.cwd()`, not the function argument.
+it('get raw config does not throw when cwd has a sibling components/ dir and no components.json', async () => {
+  const originalCwd = process.cwd()
+  const fixtureDir = path.resolve(
+    __dirname,
+    '../fixtures/config-none-with-components-dir',
+  )
+  process.chdir(fixtureDir)
+  try {
+    expect(await getRawConfig(fixtureDir)).toEqual(null)
+  }
+  finally {
+    process.chdir(originalCwd)
+  }
+})
+
 it('get raw config', async () => {
   expect(
     await getRawConfig(path.resolve(__dirname, '../fixtures/config-none')),


### PR DESCRIPTION
## Summary

`npx shadcn-vue@latest init --preset <code>` crashes with a misleading **"Invalid components.json configuration"** error on essentially any already-initialized Vue/Nuxt project — reproducible with shadcn-vue's own built-in presets (e.g. `--preset vega`), not specific to any particular preset code.
Issue : https://github.com/unovue/shadcn-vue/issues/1854

```
- Preflight checks.
✔ Preflight checks.
- Verifying framework.

Something went wrong. Please check the error below for more details.

Error:
Invalid components.json configuration in <cwd>.

Message:
Error: Cannot find module 'components'
Require stack:
- <cwd>/components/_index.js

Suggestion:
Check your components.json file for syntax errors or invalid configuration. Run 'npx shadcn@latest init' to regenerate a valid configuration.
```

Plain `init` (no `--preset`) is unaffected — it correctly detects the existing `components.json` and exits early with a clear message.

## Root cause

The `--preset` flow in `commands/init.ts` temporarily renames `components.json` out of the way (`createFileBackup`) so preflight checks can run on what looks like a fresh project. Preflight then calls `getProjectInfo` → `getConfig` → `getRawConfig`, which loads config via:

```ts
loadConfig({ name: 'components', configFile: 'components', cwd, ... })
```

When no `components.json` / `components.config.*` file exists, c12's fallback chain for an **extensionless** `configFile` ends up defaulting `res.configFile` to the literal, unresolved string `"components"`, then calls `existsSync("components")` — relative to the actual **process** `cwd()`, not the `cwd` argument passed into `loadConfig`. Since virtually every Vue/Nuxt project is run from a directory that has a sibling `components/` folder, this accidentally resolves "true" and the bare string `"components"` gets handed to `jiti.import()`, which throws a raw `MODULE_NOT_FOUND` for `'components'` — surfaced from `getRawConfig`'s catch-all as a generic, misleading `ConfigParseError`.

I confirmed this precisely with a minimal standalone repro calling `c12`'s `loadConfig` directly with the exact same options, isolating the trigger to: no `components.json` present + a literal `components/` directory in `process.cwd()` + the explicit `configFile: 'components'` option. Full stack trace and repro steps available on request.

This is an upstream `c12` resolution quirk, but it's straightforward to defend against on our side.

## Fix

In `getRawConfig`'s catch block, detect this specific failure (`error.code === 'MODULE_NOT_FOUND'` and message referencing `'components'`) and treat it the same as "no config file found" (return `null`), rather than surfacing it as a config parse error — since semantically that's exactly what it is.

## Test plan

- [x] Added `test/fixtures/config-none-with-components-dir` (a `package.json` + a `components/` dir, no `components.json`) and a new regression test in `get-config.test.ts`.
- [x] Since the bug is tied to `process.cwd()` rather than the function's `cwd` argument, the test `process.chdir()`s into the fixture for the duration of the assertion.
- [x] Verified the new test **fails** against the pre-fix code with the exact reported error/stack, and **passes** with the fix.
- [x] Full `packages/cli` test suite (440 tests) passes with no regressions.
- [x] `eslint` clean on changed files.

After this fix, `npx shadcn-vue@latest init --preset vega` (or any preset) on an existing project with a `components/` directory should proceed past "Verifying framework" instead of crashing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI config detection to correctly treat “no components config file found” as a non-error, even when a components folder exists, while still surfacing genuine config/import failures.

* **Tests**
  * Added regression coverage for working-directory-related resolution quirks.
  * Added fixtures to ensure broken explicit config imports still raise errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->