### PR TITLE
fix(cli): use `execa` for dependency installs

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -89,6 +89,7 @@
     "dedent": "^1.7.0",
     "deepmerge": "^4.3.1",
     "diff": "^8.0.2",
+    "execa": "^9.6.0",
     "fs-extra": "^11.3.2",
     "fuzzysort": "^3.1.0",
     "get-tsconfig": "^4.13.0",

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -2,8 +2,8 @@ import { promises as fs } from 'node:fs'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { Command } from 'commander'
 import deepmerge from 'deepmerge'
+import { execa } from 'execa'
 import fsExtra from 'fs-extra'
-import { addDevDependency } from 'nypm'
 import path from 'pathe'
 import prompts from 'prompts'
 import z from 'zod'
@@ -251,10 +251,13 @@ async function runMcpInit(options: z.infer<typeof mcpInitOptionsSchema>) {
 }
 
 async function installMcpDependencies(cwd: string) {
-  const packageManager = await getPackageManager(cwd, { withFallback: true })
-  await addDevDependency(DEPENDENCIES, {
+  const packageManager = await getPackageManager(cwd, {
+    withFallback: true,
+  })
+  const installCommand = packageManager === 'npm' ? 'install' : 'add'
+  const devFlag = packageManager === 'npm' ? '--save-dev' : '-D'
+
+  await execa(packageManager, [installCommand, devFlag, ...DEPENDENCIES], {
     cwd,
-    packageManager,
-    silent: true,
   })
 }

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -256,8 +256,11 @@ async function installMcpDependencies(cwd: string) {
   })
   const installCommand = packageManager === 'npm' ? 'install' : 'add'
   const devFlag = packageManager === 'npm' ? '--save-dev' : '-D'
+  const dependencies = packageManager === 'deno'
+    ? DEPENDENCIES.map(dependency => `npm:${dependency}`)
+    : DEPENDENCIES
 
-  await execa(packageManager, [installCommand, devFlag, ...DEPENDENCIES], {
+  await execa(packageManager, [installCommand, devFlag, ...dependencies], {
     cwd,
   })
 }

--- a/packages/cli/src/utils/create-project.ts
+++ b/packages/cli/src/utils/create-project.ts
@@ -1,8 +1,8 @@
 import type { z } from 'zod'
 import type { initOptionsSchema } from '@/src/commands/init'
+import { execa } from 'execa'
 import fs from 'fs-extra'
 import { downloadTemplate } from 'giget'
-import { installDependencies } from 'nypm'
 import path from 'pathe'
 import prompts from 'prompts'
 import { x } from 'tinyexec'
@@ -134,11 +134,7 @@ export async function createProject(
     })
 
     // Install dependencies
-    await installDependencies({
-      cwd: projectPath,
-      packageManager,
-      silent: true,
-    })
+    await execa(packageManager, ['install'], { cwd: projectPath })
 
     createSpinner?.succeed(`Created a new ${template} project.`)
   }

--- a/packages/cli/src/utils/updaters/update-dependencies.ts
+++ b/packages/cli/src/utils/updaters/update-dependencies.ts
@@ -3,7 +3,8 @@ import type { RegistryItem } from '@/src/schema'
 import type { Config } from '@/src/utils/get-config'
 import fs from 'node:fs'
 import path from 'node:path'
-import { addDependency, addDevDependency, detectPackageManager } from 'nypm'
+import { execa } from 'execa'
+import { detectPackageManager } from 'nypm'
 import { spinner } from '@/src/utils/spinner'
 
 export type SupportedPackageManager = PackageManagerName
@@ -89,7 +90,6 @@ export async function updateDependencies(
     dependencies,
     devDependencies,
     config.resolvedPaths.cwd,
-    options.silent,
   )
 
   dependenciesSpinner?.succeed()
@@ -100,19 +100,54 @@ async function installWithPackageManager(
   dependencies: string[],
   devDependencies: string[],
   cwd: string,
-  silent: boolean,
 ) {
-  const options = {
-    cwd,
-    packageManager,
-    silent,
+  if (packageManager === 'npm') {
+    return installWithNpm(dependencies, devDependencies, cwd)
+  }
+
+  if (packageManager === 'deno') {
+    return installWithDeno(dependencies, devDependencies, cwd)
   }
 
   if (dependencies?.length) {
-    await addDependency(dependencies, options)
+    await execa(packageManager, ['add', ...dependencies], { cwd })
   }
 
   if (devDependencies?.length) {
-    await addDevDependency(devDependencies, options)
+    await execa(packageManager, ['add', '-D', ...devDependencies], { cwd })
+  }
+}
+
+async function installWithNpm(
+  dependencies: string[],
+  devDependencies: string[],
+  cwd: string,
+) {
+  if (dependencies?.length) {
+    await execa('npm', ['install', ...dependencies], { cwd })
+  }
+
+  if (devDependencies?.length) {
+    await execa('npm', ['install', '-D', ...devDependencies], { cwd })
+  }
+}
+
+async function installWithDeno(
+  dependencies: string[],
+  devDependencies: string[],
+  cwd: string,
+) {
+  if (dependencies?.length) {
+    await execa('deno', ['add', ...dependencies.map(dep => `npm:${dep}`)], {
+      cwd,
+    })
+  }
+
+  if (devDependencies?.length) {
+    await execa(
+      'deno',
+      ['add', '-D', ...devDependencies.map(dep => `npm:${dep}`)],
+      { cwd },
+    )
   }
 }

--- a/packages/cli/test/commands/init.test.ts
+++ b/packages/cli/test/commands/init.test.ts
@@ -1,5 +1,5 @@
 import fs from 'node:fs'
-import { addDependency } from 'nypm'
+import { execa } from 'execa'
 import path from 'pathe'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
@@ -8,6 +8,7 @@ import { DEFAULT_PRESETS, resolveCreateUrl, resolveInitUrl } from '../../src/pre
 import * as registry from '../../src/registry'
 import { getConfig } from '../../src/utils/get-config'
 
+vi.mock('execa')
 vi.mock('nypm')
 vi.mock('fs/promises', () => ({
   writeFile: vi.fn(),
@@ -95,8 +96,10 @@ it.skip('init config-full', async () => {
     expect.stringContaining('import { type ClassValue, clsx } from \'clsx\''),
     'utf8',
   )
-  expect(addDependency).toHaveBeenCalledWith(
+  expect(execa).toHaveBeenCalledWith(
+    'npm',
     [
+      'install',
       'tailwindcss-animate',
       'class-variance-authority',
       'clsx',
@@ -106,10 +109,7 @@ it.skip('init config-full', async () => {
       '@tabler/icons-vue',
       '@phosphor-icons/vue',
     ],
-    {
-      cwd: targetDir,
-      silent: true,
-    },
+    { cwd: targetDir },
   )
 
   mockMkdir.mockRestore()

--- a/packages/cli/test/commands/mcp.test.ts
+++ b/packages/cli/test/commands/mcp.test.ts
@@ -1,0 +1,93 @@
+import { execa } from 'execa'
+import { detectPackageManager } from 'nypm'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { mcp } from '../../src/commands/mcp'
+import { getConfig } from '../../src/utils/get-config'
+import { handleError } from '../../src/utils/handle-error'
+
+vi.mock('node:fs', () => ({
+  promises: {
+    readFile: vi.fn().mockRejectedValue(new Error('not found')),
+    writeFile: vi.fn(),
+  },
+}))
+
+vi.mock('execa', () => ({
+  execa: vi.fn(),
+}))
+
+vi.mock('fs-extra', () => ({
+  default: {
+    ensureDir: vi.fn(),
+  },
+}))
+
+vi.mock('nypm', () => ({
+  detectPackageManager: vi.fn(),
+}))
+
+vi.mock('@/src/mcp', () => ({
+  server: {
+    connect: vi.fn(),
+  },
+}))
+
+vi.mock('@/src/utils/get-config', () => ({
+  getConfig: vi.fn(),
+}))
+
+vi.mock('@/src/utils/handle-error', () => ({
+  handleError: vi.fn(),
+}))
+
+vi.mock('@/src/utils/logger', () => ({
+  logger: {
+    break: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    log: vi.fn(),
+    success: vi.fn(),
+  },
+}))
+
+vi.mock('@/src/utils/spinner', () => ({
+  spinner: vi.fn(() => {
+    const instance = {
+      start: vi.fn(),
+      succeed: vi.fn(),
+    }
+    instance.start.mockReturnValue(instance)
+    return instance
+  }),
+}))
+
+describe('mcp init', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(getConfig).mockResolvedValue(null)
+    vi.mocked(detectPackageManager).mockResolvedValue({
+      name: 'deno',
+      command: 'deno',
+    })
+    vi.mocked(execa).mockResolvedValue({} as any)
+  })
+
+  it('prefixes npm dependencies when installing with deno', async () => {
+    await mcp.parseAsync([
+      'node',
+      'mcp',
+      '--cwd',
+      '/test/project',
+      'init',
+      '--client',
+      'vscode',
+    ])
+
+    expect(handleError).not.toHaveBeenCalled()
+    expect(execa).toHaveBeenCalledWith(
+      'deno',
+      ['add', '-D', 'npm:shadcn-vue@latest'],
+      { cwd: '/test/project' },
+    )
+  })
+})

--- a/packages/cli/test/utils/create-project.test.ts
+++ b/packages/cli/test/utils/create-project.test.ts
@@ -1,7 +1,8 @@
 import type { MockInstance } from 'vitest'
+import { execa } from 'execa'
 import fs from 'fs-extra'
 import { downloadTemplate } from 'giget'
-import { detectPackageManager, installDependencies } from 'nypm'
+import { detectPackageManager } from 'nypm'
 import prompts from 'prompts'
 import { x } from 'tinyexec'
 import {
@@ -18,12 +19,14 @@ import { spinner } from '../../src/utils/spinner'
 
 // Mock dependencies
 vi.mock('fs-extra')
+vi.mock('execa', () => ({
+  execa: vi.fn(),
+}))
 vi.mock('giget')
 vi.mock('tinyexec')
 vi.mock('prompts')
 vi.mock('nypm', () => ({
   detectPackageManager: vi.fn(),
-  installDependencies: vi.fn(),
 }))
 vi.mock('@/src/utils/spinner')
 vi.mock('@/src/utils/logger', () => ({
@@ -46,7 +49,7 @@ describe('createProject', () => {
       name: 'npm',
       command: 'npm',
     })
-    vi.mocked(installDependencies).mockResolvedValue({} as any)
+    vi.mocked(execa).mockResolvedValue({} as any)
 
     // Reset all fs mocks
     vi.mocked(fs.access).mockResolvedValue(undefined)
@@ -236,10 +239,8 @@ describe('createProject', () => {
       template: undefined,
     })
 
-    expect(installDependencies).toHaveBeenCalledWith({
+    expect(execa).toHaveBeenCalledWith('npm', ['install'], {
       cwd: '/test/my-app',
-      packageManager: 'npm',
-      silent: true,
     })
   })
 

--- a/packages/cli/test/utils/updaters/update-dependencies.test.ts
+++ b/packages/cli/test/utils/updaters/update-dependencies.test.ts
@@ -1,12 +1,15 @@
-import { addDependency, addDevDependency, detectPackageManager } from 'nypm'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { execa } from 'execa'
+import { detectPackageManager } from 'nypm'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { spinner } from '../../../src/utils/spinner'
 import { updateDependencies } from '../../../src/utils/updaters/update-dependencies'
 
+vi.mock('execa', () => ({
+  execa: vi.fn(),
+}))
+
 vi.mock('nypm', () => ({
-  addDependency: vi.fn(),
-  addDevDependency: vi.fn(),
   detectPackageManager: vi.fn(),
 }))
 
@@ -23,14 +26,11 @@ const config = {
 describe('updateDependencies', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    delete process.env.npm_config_user_agent
-
     vi.mocked(detectPackageManager).mockResolvedValue({
       name: 'pnpm',
       command: 'pnpm',
     })
-    vi.mocked(addDependency).mockResolvedValue({} as any)
-    vi.mocked(addDevDependency).mockResolvedValue({} as any)
+    vi.mocked(execa).mockResolvedValue({} as any)
 
     const mockSpinner = {
       start: vi.fn().mockReturnThis(),
@@ -39,7 +39,11 @@ describe('updateDependencies', () => {
     vi.mocked(spinner).mockReturnValue(mockSpinner as any)
   })
 
-  it('installs de-duplicated dependencies with nypm', async () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('installs de-duplicated dependencies with pnpm', async () => {
     await updateDependencies(
       ['@tanstack/vue-table', 'reka-ui', 'reka-ui'],
       ['tailwindcss', 'tailwindcss'],
@@ -47,41 +51,76 @@ describe('updateDependencies', () => {
       { silent: false },
     )
 
-    expect(addDependency).toHaveBeenCalledWith(
-      ['@tanstack/vue-table', 'reka-ui'],
-      {
-        cwd: '/test/project',
-        packageManager: 'pnpm',
-        silent: false,
-      },
+    expect(execa).toHaveBeenCalledWith(
+      'pnpm',
+      ['add', '@tanstack/vue-table', 'reka-ui'],
+      { cwd: '/test/project' },
     )
-    expect(addDevDependency).toHaveBeenCalledWith(['tailwindcss'], {
+    expect(execa).toHaveBeenCalledWith(
+      'pnpm',
+      ['add', '-D', 'tailwindcss'],
+      { cwd: '/test/project' },
+    )
+  })
+
+  it('uses the package manager that invoked the CLI', async () => {
+    vi.mocked(detectPackageManager).mockResolvedValue(undefined)
+    vi.stubEnv(
+      'npm_config_user_agent',
+      'pnpm/11.5.0 npm/? node/v24.11.1',
+    )
+
+    await updateDependencies(['reka-ui'], [], config, { silent: true })
+
+    expect(execa).toHaveBeenCalledWith('pnpm', ['add', 'reka-ui'], {
       cwd: '/test/project',
-      packageManager: 'pnpm',
-      silent: false,
     })
   })
 
-  it('falls back to the dlx package manager user agent', async () => {
-    vi.mocked(detectPackageManager).mockResolvedValue(undefined)
-    process.env.npm_config_user_agent = 'pnpm/11.5.0 npm/? node/v24.11.1'
+  it('uses npm install commands', async () => {
+    vi.mocked(detectPackageManager).mockResolvedValue({
+      name: 'npm',
+      command: 'npm',
+    })
 
-    await updateDependencies(['@tanstack/vue-table'], [], config, {
+    await updateDependencies(['reka-ui'], ['tailwindcss'], config, {
       silent: true,
     })
 
-    expect(addDependency).toHaveBeenCalledWith(['@tanstack/vue-table'], {
+    expect(execa).toHaveBeenCalledWith('npm', ['install', 'reka-ui'], {
       cwd: '/test/project',
-      packageManager: 'pnpm',
+    })
+    expect(execa).toHaveBeenCalledWith(
+      'npm',
+      ['install', '-D', 'tailwindcss'],
+      { cwd: '/test/project' },
+    )
+  })
+
+  it('prefixes Deno dependencies with npm:', async () => {
+    vi.mocked(detectPackageManager).mockResolvedValue({
+      name: 'deno',
+      command: 'deno',
+    })
+
+    await updateDependencies(['reka-ui'], ['tailwindcss'], config, {
       silent: true,
     })
+
+    expect(execa).toHaveBeenCalledWith('deno', ['add', 'npm:reka-ui'], {
+      cwd: '/test/project',
+    })
+    expect(execa).toHaveBeenCalledWith(
+      'deno',
+      ['add', '-D', 'npm:tailwindcss'],
+      { cwd: '/test/project' },
+    )
   })
 
   it('skips package manager detection when there is nothing to install', async () => {
     await updateDependencies([], [], config, { silent: true })
 
     expect(detectPackageManager).not.toHaveBeenCalled()
-    expect(addDependency).not.toHaveBeenCalled()
-    expect(addDevDependency).not.toHaveBeenCalled()
+    expect(execa).not.toHaveBeenCalled()
   })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -356,6 +356,9 @@ importers:
       diff:
         specifier: ^8.0.2
         version: 8.0.2
+      execa:
+        specifier: ^9.6.0
+        version: 9.6.0
       fs-extra:
         specifier: ^11.3.2
         version: 11.3.2


### PR DESCRIPTION
## Summary

- replace `nypm` install helpers with explicit package-manager commands executed through `execa`
- use the same direct install path for registry dependencies, project scaffolding, and MCP setup
- keep the existing `.pnpm` directory and `npm_config_user_agent` detection fallbacks
- add `execa@^9.6.0` and update the related tests and lockfile

Fixes #1873.

## Historical context and root cause

This divergence from shadcn/ui was intentional rather than an omitted sync:

1. #1803 mirrored shadcn/ui's explicit per-package-manager commands, but used the repository-standard `tinyexec`. It also retained stricter detection fallbacks to prevent `nypm` from silently falling back to npm (#1801).
2. #1839 reported that the direct install path failed on Windows with Node 24 and pnpm 11.
3. #1842 consequently routed dependency installation through `nypm` so it could use Corepack-aware resolution.
4. #1873 exposed the downside of that workaround: Corepack can select pnpm 10 for a project whose `node_modules` was created with pnpm 11, causing `ERR_PNPM_UNEXPECTED_STORE`.

Current shadcn/ui uses `execa` to invoke the detected package manager directly in both dependency updates and MCP installation:

- https://github.com/shadcn-ui/ui/blob/main/packages/shadcn/src/utils/updaters/update-dependencies.ts
- https://github.com/shadcn-ui/ui/blob/main/packages/shadcn/src/commands/mcp.ts

This PR aligns the install execution path with shadcn/ui while preserving shadcn-vue's stricter package-manager detection from #1803.

## Focused reproduction

A focused Windows reproduction was run with the exact versions reported by #1839:

- Windows
- Node 24.16.0
- pnpm 11.5.0
- `execa@9.6.0`
- `tinyexec@1.0.2`

Both runners successfully resolved pnpm 11.5.0 and completed an offline local `pnpm add`. This indicates that direct process execution is not inherently incompatible with pnpm 11; the currently reproducible failure is the Corepack version selection introduced by the `nypm` install path.

## Validation

- `pnpm --filter shadcn-vue test test/utils/updaters/update-dependencies.test.ts test/utils/create-project.test.ts test/commands/init.test.ts`
  - 32 passed, 1 skipped
- changed-file ESLint
- `pnpm install --filter shadcn-vue --offline --frozen-lockfile --ignore-scripts`
- `pnpm --filter shadcn-vue build`
- `git diff --check`

The full CLI test run still has 10 existing Windows path/local-file failures (431 tests pass), and `pnpm --filter shadcn-vue typecheck` still reports existing errors in preset and transformer files. None of those failing files are changed by this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dependency installation for project creation, MCP setup, and dependency updates across npm, pnpm, and Deno, including proper handling of development dependencies.
  * Added correct Deno dependency spec rewriting (e.g., `npm:<name>`) during MCP initialization.
  * Refined package-manager fallback behavior to choose the right install command when detection isn’t available.
* **Tests**
  * Updated existing tests to assert execution via the external install command runner and correct `cwd` usage.
  * Added a new test suite covering `mcp init` on Deno dependency prefixing and invocation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->