### PR TITLE
fix(v4): preserve Create Project command spacing

### DIFF
--- a/apps/v4/components/CreateProjectDialog.vue
+++ b/apps/v4/components/CreateProjectDialog.vue
@@ -159,7 +159,7 @@ function handleCopy() {
             >
               <div class="relative overflow-hidden border-t bg-popover p-3">
                 <div class="no-scrollbar overflow-x-auto">
-                  <code class="whitespace-nowrap font-mono text-sm">{{ commands[pm.value] }}</code>
+                  <code class="whitespace-nowrap font-mono text-sm [font-variant-ligatures:none]">{{ commands[pm.value] }}</code>
                 </div>
               </div>
             </TabsContent>


### PR DESCRIPTION
## Summary

- disable font ligatures in the Create Project command preview
- keep CLI flags and their preceding spaces visually distinct without changing the copied command

## Root cause

Geist Mono's default ligatures render each `--` sequence in a single character cell. This makes the preceding spaces look missing even though the underlying command string is correct.

## Validation

- reproduced the issue in Chrome on `/create?preset=a1Q1mS&template=vite`
- verified each `--` expands from about 8.4px to 16.8px with ligatures disabled, while the preceding space remains about 8.4px
- `pnpm exec eslint apps/v4/components/CreateProjectDialog.vue`
- `git diff --check`

Closes #1883


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved command text readability in the project creation dialog by disabling font ligatures.
  * Command lookup and copy behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->