### PR TITLE
fix(cli): add missing pagination and sonner icon mappings

### DIFF
--- a/apps/v4/public/r/icons/index.json
+++ b/apps/v4/public/r/icons/index.json
@@ -90,6 +90,22 @@
     "phosphor": "PhCaretUp",
     "remixicon": "RiArrowUpSLine"
   },
+  "ChevronsLeft": {
+    "lucide": "ChevronsLeftIcon",
+    "radix": "DoubleArrowLeftIcon",
+    "tabler": "IconChevronsLeft",
+    "hugeicons": "ArrowLeftDoubleIcon",
+    "phosphor": "PhCaretDoubleLeft",
+    "remixicon": "RiArrowLeftDoubleLine"
+  },
+  "ChevronsRight": {
+    "lucide": "ChevronsRightIcon",
+    "radix": "DoubleArrowRightIcon",
+    "tabler": "IconChevronsRight",
+    "hugeicons": "ArrowRightDoubleIcon",
+    "phosphor": "PhCaretDoubleRight",
+    "remixicon": "RiArrowRightDoubleLine"
+  },
   "ChevronsUpDown": {
     "lucide": "ChevronsUpDown",
     "radix": "CaretSortIcon",
@@ -103,6 +119,14 @@
     "tabler": "IconCircle",
     "phosphor": "PhCircle",
     "remixicon": "RiCircleLine"
+  },
+  "CircleCheck": {
+    "lucide": "CircleCheckIcon",
+    "radix": "CheckCircledIcon",
+    "tabler": "IconCircleCheck",
+    "hugeicons": "CheckmarkCircle01Icon",
+    "phosphor": "PhCheckCircle",
+    "remixicon": "RiCheckboxCircleLine"
   },
   "Copy": {
     "lucide": "Copy",
@@ -124,6 +148,14 @@
     "tabler": "IconGripVertical",
     "phosphor": "PhDotsSixVertical",
     "remixicon": "RiDraggable"
+  },
+  "Info": {
+    "lucide": "InfoIcon",
+    "radix": "InfoCircledIcon",
+    "tabler": "IconInfoCircle",
+    "hugeicons": "InformationCircleIcon",
+    "phosphor": "PhInfo",
+    "remixicon": "RiInformationLine"
   },
   "Italic": {
     "lucide": "Italic",
@@ -173,6 +205,14 @@
     "tabler": "IconDots",
     "phosphor": "PhDotsThree",
     "remixicon": "RiMoreLine"
+  },
+  "OctagonX": {
+    "lucide": "OctagonXIcon",
+    "radix": "CrossCircledIcon",
+    "tabler": "IconOctagonOff",
+    "hugeicons": "CancelCircleIcon",
+    "phosphor": "PhXCircle",
+    "remixicon": "RiCloseCircleLine"
   },
   "PanelLeft": {
     "lucide": "PanelLeft",
@@ -236,6 +276,14 @@
     "tabler": "IconTerminal",
     "phosphor": "PhTerminal",
     "remixicon": "RiTerminalBoxLine"
+  },
+  "TriangleAlert": {
+    "lucide": "TriangleAlertIcon",
+    "radix": "ExclamationTriangleIcon",
+    "tabler": "IconAlertTriangle",
+    "hugeicons": "Alert02Icon",
+    "phosphor": "PhWarning",
+    "remixicon": "RiAlertLine"
   },
   "Underline": {
     "lucide": "Underline",

--- a/packages/cli/test/utils/transform-icons.test.ts
+++ b/packages/cli/test/utils/transform-icons.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { transform as metaTransform } from 'vue-metamorph'
+import registryIcons from '../../../../apps/v4/public/r/icons/index.json'
 import { transform } from '../../src/utils/transformers'
 import { transformIcons } from '../../src/utils/transformers/transform-icons'
 
@@ -136,6 +137,51 @@ import { Primitive } from 'reka-ui'
     expect(result).not.toContain('@lucide/vue')
     expect(result).not.toContain('CheckIcon')
     expect(result).not.toContain('ChevronDownIcon')
+  })
+
+  it('transforms pagination and sonner icons to phosphor', () => {
+    const source = `<script lang="ts" setup>
+import {
+  ChevronsLeftIcon,
+  ChevronsRightIcon,
+  CircleCheckIcon,
+  InfoIcon,
+  Loader2Icon,
+  OctagonXIcon,
+  TriangleAlertIcon,
+  XIcon,
+} from '@lucide/vue'
+</script>
+
+<template>
+  <ChevronsLeftIcon />
+  <ChevronsRightIcon />
+  <CircleCheckIcon />
+  <InfoIcon />
+  <Loader2Icon />
+  <OctagonXIcon />
+  <TriangleAlertIcon />
+  <XIcon />
+</template>
+`
+    const result = metaTransform(source, 'app.vue', [
+      transformIcons(
+        { filename: 'app.vue', raw: source, config: { iconLibrary: 'phosphor' } },
+        registryIcons,
+      ),
+    ]).code
+
+    expect(result).toContain('@phosphor-icons/vue')
+    expect(result).toContain('PhCaretDoubleLeft')
+    expect(result).toContain('PhCaretDoubleRight')
+    expect(result).toContain('PhCheckCircle')
+    expect(result).toContain('PhInfo')
+    expect(result).toContain('PhCircleNotch')
+    expect(result).toContain('PhXCircle')
+    expect(result).toContain('PhWarning')
+    expect(result).toContain('PhX')
+    expect(result).not.toContain('@lucide/vue')
+    expect(result).not.toMatch(/\b(?:ChevronsLeft|ChevronsRight|CircleCheck|Info|Loader2|OctagonX|TriangleAlert|X)Icon\b/)
   })
 
   it('does nothing', async () => {

--- a/packages/cli/test/utils/transform-icons.test.ts
+++ b/packages/cli/test/utils/transform-icons.test.ts
@@ -179,7 +179,7 @@ import {
     expect(result).toContain('PhCircleNotch')
     expect(result).toContain('PhXCircle')
     expect(result).toContain('PhWarning')
-    expect(result).toContain('PhX')
+    expect(result).toMatch(/\bPhX\b/)
     expect(result).not.toContain('@lucide/vue')
     expect(result).not.toMatch(/\b(?:ChevronsLeft|ChevronsRight|CircleCheck|Info|Loader2|OctagonX|TriangleAlert|X)Icon\b/)
   })


### PR DESCRIPTION
<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue

#1893

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`Pagination` and `Sonner` use six Lucide icons that were missing from the public icon registry. When a project selects Phosphor, `Pagination` retains its Lucide imports and `Sonner` generates an invalid mixed import containing Lucide identifiers from `@phosphor-icons/vue`.

This PR:

- Adds Lucide, Radix, Tabler, Hugeicons, Phosphor, and Remix mappings for `ChevronsLeft`, `ChevronsRight`, `CircleCheck`, `Info`, `OctagonX`, and `TriangleAlert`.
- Ensures Phosphor projects generate `PhCaretDoubleLeft`, `PhCaretDoubleRight`, `PhCheckCircle`, `PhInfo`, `PhXCircle`, and `PhWarning` for the affected components.
- Adds a regression test that transforms the complete `Pagination` and `Sonner` icon set using the checked-in public registry map and verifies that no Lucide import or identifier remains. The test uses the real registry data so removing one of these mappings will reproduce the original failure.

Fixes #1893

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added additional icon mappings, including chevrons, status indicators, information, and warning/error icons, across supported icon libraries.
* **Bug Fixes**
  * Improved icon transformation for Vue SFCs when using the Phosphor icon library, ensuring the correct `@phosphor-icons/vue` imports and expected icon names are generated (and avoiding leftover Lucide references).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->