### PR TITLE
ci: add an advisory UI audit for apps/v4

### DIFF
--- a/.github/workflows/ui-audit.yaml
+++ b/.github/workflows/ui-audit.yaml
@@ -1,0 +1,31 @@
+name: UI Audit
+
+on:
+  pull_request:
+    branches:
+      - dev
+    paths:
+      - apps/v4/**
+      - .github/workflows/ui-audit.yaml
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    name: shadscan-vue
+    runs-on: ubuntu-latest
+    # Advisory only. The audit reports to the job summary and never blocks a
+    # pull request, so a regression is visible without gating contributors.
+    continue-on-error: true
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      # shadscan-vue reads source files and never runs the app, so the audit
+      # needs no install step and adds no dependency to this repository.
+      - name: Audit apps/v4
+        uses: vinayakkulkarni/shadscan-vue@v0
+        with:
+          path: apps/v4


### PR DESCRIPTION
Follows up on #1898, and implements option 1 from that issue — **advisory only, nothing gated**.

*(Replaces #1899, which I closed after a force-push from a shallow clone detached the branch history and blew its diff up to the whole tree. Same change, now correctly based on `dev`.)*

## What this adds

A single workflow, `.github/workflows/ui-audit.yaml`, that runs [shadscan-vue](https://github.com/vinayakkulkarni/shadscan-vue) against `apps/v4` on pull requests touching it and writes the score, category table, and every failing rule to the job summary.

```yaml
- uses: vinayakkulkarni/shadscan-vue@v0
  with:
    path: apps/v4
```

That is the whole change: 31 lines, one file, no dependency added to the repository.

## Deliberately non-blocking

The job sets `continue-on-error: true`, so it can never fail a contributor's pull request. It reports and stops there. If you later decide you want a floor, `fail-under: 61` would pin today's score and catch regressions — but I have left that out on purpose, since gating is your call and not mine to assume.

Path filters mirror `test.yaml`, so it only runs when `apps/v4` changes.

## No install step

shadscan-vue reads source files and never starts the app, so the audit runs on a bare checkout. I verified this against a fresh clone of `dev` with no `node_modules` present: complete coverage, 204 files, **61/100 (D)** — matching the number in #1898 exactly.

## Verified before proposing

I ran this workflow on a fork first rather than opening it here untested, and that surfaced a rendering bug in my own action: rule messages name the offending element, so `Routable surface starts at <h2> with no <h1>` was rendered as a literal heading and broke the summary apart. Fixed in shadscan-vue 0.3.1 by escaping messages before they reach the renderer; `@v0` already points at it.

## A note on `actions/checkout@v7`

Your other workflows pin `@v4`, which now runs on Node 20 and logs a deprecation warning on every run. Rather than inherit that in a new file, this uses `@v7`. Happy to change it to `@v4` if you would prefer the pin stay uniform across workflows and handle the bump separately.

## Easy to decline

If this is not something you want in CI, close it — no hard feelings, and #1898 stands on its own as a list of findings you can act on or ignore. I would rather you have the option than assume you want the tool.

Disclosure: I wrote shadscan-vue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated UI accessibility and quality audits for applicable pull requests.
  * Audit results are reported for review without blocking changes from being merged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->