### PR TITLE
docs: use componentField in vee-validate examples

### DIFF
--- a/apps/v4/components/demo/NativeSelectFormDemo.vue
+++ b/apps/v4/components/demo/NativeSelectFormDemo.vue
@@ -1,18 +1,17 @@
 <script setup lang="ts">
 import { toTypedSchema } from '@vee-validate/zod'
-import { useForm } from 'vee-validate'
+import { useForm, Field as VeeField } from 'vee-validate'
 import { toast } from 'vue-sonner'
 
 import { z } from 'zod'
 import { Button } from '@/registry/new-york-v4/ui/button'
 import {
-  FormControl,
-  FormDescription,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-} from '@/registry/new-york-v4/ui/form'
+  Field,
+  FieldDescription,
+  FieldError,
+  FieldGroup,
+  FieldLabel,
+} from '@/registry/new-york-v4/ui/field'
 import {
   NativeSelect,
   NativeSelectOption,
@@ -37,12 +36,18 @@ const onSubmit = form.handleSubmit((values) => {
 </script>
 
 <template>
-  <form class="w-full max-w-sm space-y-6" @submit="onSubmit">
-    <FormField v-slot="{ componentField }" name="country">
-      <FormItem>
-        <FormLabel>Country</FormLabel>
-        <FormControl>
-          <NativeSelect v-bind="(componentField as any)">
+  <form class="w-full max-w-sm" @submit="onSubmit">
+    <FieldGroup>
+      <VeeField v-slot="{ componentField, errors }" name="country">
+        <Field :data-invalid="!!errors.length">
+          <FieldLabel for="form-native-select-country">
+            Country
+          </FieldLabel>
+          <NativeSelect
+            id="form-native-select-country"
+            v-bind="(componentField as any)"
+            :aria-invalid="!!errors.length"
+          >
             <NativeSelectOption value="">
               Select a country
             </NativeSelectOption>
@@ -56,16 +61,18 @@ const onSubmit = form.handleSubmit((values) => {
               Canada
             </NativeSelectOption>
           </NativeSelect>
-        </FormControl>
-        <FormDescription>
-          Select a country
-        </FormDescription>
-        <FormMessage />
-      </FormItem>
-    </FormField>
+          <FieldDescription>
+            Select a country
+          </FieldDescription>
+          <FieldError v-if="errors.length" :errors="errors" />
+        </Field>
+      </VeeField>
 
-    <Button type="submit" class="w-full">
-      Submit
-    </Button>
+      <Field>
+        <Button type="submit" class="w-full">
+          Submit
+        </Button>
+      </Field>
+    </FieldGroup>
   </form>
 </template>

--- a/apps/v4/components/demo/StepperForm.vue
+++ b/apps/v4/components/demo/StepperForm.vue
@@ -1,11 +1,17 @@
 <script setup lang="ts">
 import { Check, Circle, Dot } from '@lucide/vue'
 import { toTypedSchema } from '@vee-validate/zod'
+import { Field as VeeField, Form as VeeForm } from 'vee-validate'
 import { h, ref } from 'vue'
 import { toast } from 'vue-sonner'
 import * as z from 'zod'
 import { Button } from '@/registry/new-york-v4/ui/button'
-import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/registry/new-york-v4/ui/form'
+import {
+  Field,
+  FieldError,
+  FieldGroup,
+  FieldLabel,
+} from '@/registry/new-york-v4/ui/field'
 import { Input } from '@/registry/new-york-v4/ui/input'
 import {
   Select,
@@ -66,7 +72,7 @@ function onSubmit(values: any) {
 </script>
 
 <template>
-  <Form
+  <VeeForm
     v-slot="{ meta, values, validate }"
     as="" keep-values :validation-schema="toTypedSchema(formSchema[stepIndex - 1]!)"
   >
@@ -125,62 +131,85 @@ function onSubmit(values: any) {
           </StepperItem>
         </div>
 
-        <div class="flex flex-col gap-4 mt-4">
+        <FieldGroup class="mt-4">
           <template v-if="stepIndex === 1">
-            <FormField v-slot="{ componentField }" name="fullName">
-              <FormItem>
-                <FormLabel>Full Name</FormLabel>
-                <FormControl>
-                  <Input type="text" v-bind="componentField" />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            </FormField>
+            <VeeField v-slot="{ componentField, errors }" name="fullName">
+              <Field :data-invalid="!!errors.length">
+                <FieldLabel for="form-stepper-fullName">
+                  Full Name
+                </FieldLabel>
+                <Input
+                  id="form-stepper-fullName"
+                  v-bind="componentField"
+                  type="text"
+                  :aria-invalid="!!errors.length"
+                />
+                <FieldError v-if="errors.length" :errors="errors" />
+              </Field>
+            </VeeField>
 
-            <FormField v-slot="{ componentField }" name="email">
-              <FormItem>
-                <FormLabel>Email</FormLabel>
-                <FormControl>
-                  <Input type="email " v-bind="componentField" />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            </FormField>
+            <VeeField v-slot="{ componentField, errors }" name="email">
+              <Field :data-invalid="!!errors.length">
+                <FieldLabel for="form-stepper-email">
+                  Email
+                </FieldLabel>
+                <Input
+                  id="form-stepper-email"
+                  v-bind="componentField"
+                  type="email"
+                  :aria-invalid="!!errors.length"
+                />
+                <FieldError v-if="errors.length" :errors="errors" />
+              </Field>
+            </VeeField>
           </template>
 
           <template v-if="stepIndex === 2">
-            <FormField v-slot="{ componentField }" name="password">
-              <FormItem>
-                <FormLabel>Password</FormLabel>
-                <FormControl>
-                  <Input type="password" v-bind="componentField" />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            </FormField>
+            <VeeField v-slot="{ componentField, errors }" name="password">
+              <Field :data-invalid="!!errors.length">
+                <FieldLabel for="form-stepper-password">
+                  Password
+                </FieldLabel>
+                <Input
+                  id="form-stepper-password"
+                  v-bind="componentField"
+                  type="password"
+                  :aria-invalid="!!errors.length"
+                />
+                <FieldError v-if="errors.length" :errors="errors" />
+              </Field>
+            </VeeField>
 
-            <FormField v-slot="{ componentField }" name="confirmPassword">
-              <FormItem>
-                <FormLabel>Confirm Password</FormLabel>
-                <FormControl>
-                  <Input type="password" v-bind="componentField" />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            </FormField>
+            <VeeField v-slot="{ componentField, errors }" name="confirmPassword">
+              <Field :data-invalid="!!errors.length">
+                <FieldLabel for="form-stepper-confirmPassword">
+                  Confirm Password
+                </FieldLabel>
+                <Input
+                  id="form-stepper-confirmPassword"
+                  v-bind="componentField"
+                  type="password"
+                  :aria-invalid="!!errors.length"
+                />
+                <FieldError v-if="errors.length" :errors="errors" />
+              </Field>
+            </VeeField>
           </template>
 
           <template v-if="stepIndex === 3">
-            <FormField v-slot="{ componentField }" name="favoriteDrink">
-              <FormItem>
-                <FormLabel>Drink</FormLabel>
-
+            <VeeField v-slot="{ componentField, errors }" name="favoriteDrink">
+              <Field :data-invalid="!!errors.length">
+                <FieldLabel for="form-stepper-favoriteDrink">
+                  Drink
+                </FieldLabel>
                 <Select v-bind="componentField">
-                  <FormControl>
-                    <SelectTrigger class="w-full!">
-                      <SelectValue placeholder="Select a drink" />
-                    </SelectTrigger>
-                  </FormControl>
+                  <SelectTrigger
+                    id="form-stepper-favoriteDrink"
+                    class="w-full!"
+                    :aria-invalid="!!errors.length"
+                  >
+                    <SelectValue placeholder="Select a drink" />
+                  </SelectTrigger>
                   <SelectContent>
                     <SelectGroup>
                       <SelectItem value="coffee">
@@ -195,11 +224,11 @@ function onSubmit(values: any) {
                     </SelectGroup>
                   </SelectContent>
                 </Select>
-                <FormMessage />
-              </FormItem>
-            </FormField>
+                <FieldError v-if="errors.length" :errors="errors" />
+              </Field>
+            </VeeField>
           </template>
-        </div>
+        </FieldGroup>
 
         <div class="flex items-center justify-between mt-4">
           <Button :disabled="isPrevDisabled" variant="outline" size="sm" @click="prevStep()">
@@ -218,5 +247,5 @@ function onSubmit(values: any) {
         </div>
       </form>
     </Stepper>
-  </Form>
+  </VeeForm>
 </template>

--- a/apps/v4/components/demo/VeeValidateArrayDemo.vue
+++ b/apps/v4/components/demo/VeeValidateArrayDemo.vue
@@ -87,7 +87,7 @@ const onSubmit = handleSubmit((data) => {
             <VeeField
               v-for="(field, index) in fields"
               :key="field.key"
-              v-slot="{ field: fieldProps, errors: fieldErrors }"
+              v-slot="{ componentField: fieldProps, errors: fieldErrors }"
               :name="`emails[${index}].address`"
             >
               <Field

--- a/apps/v4/components/demo/VeeValidateCheckboxDemo.vue
+++ b/apps/v4/components/demo/VeeValidateCheckboxDemo.vue
@@ -80,7 +80,7 @@ const onSubmit = handleSubmit((data) => {
     <CardContent>
       <form id="form-vee-checkbox" @submit="onSubmit">
         <FieldGroup>
-          <VeeField v-slot="{ field, errors }" name="responses" type="checkbox">
+          <VeeField v-slot="{ componentField, errors }" name="responses" type="checkbox">
             <FieldSet :data-invalid="!!errors.length">
               <FieldLegend variant="label">
                 Responses
@@ -93,10 +93,8 @@ const onSubmit = handleSubmit((data) => {
                 <Field orientation="horizontal">
                   <Checkbox
                     id="form-vee-checkbox-responses"
-                    :name="field.name"
-                    :model-value="field.value"
+                    v-bind="componentField"
                     disabled
-                    @update:model-value="field.onChange"
                   />
                   <FieldLabel
                     for="form-vee-checkbox-responses"
@@ -110,7 +108,7 @@ const onSubmit = handleSubmit((data) => {
             </FieldSet>
           </VeeField>
           <FieldSeparator />
-          <VeeField v-slot="{ field, errors }" name="tasks">
+          <VeeField v-slot="{ value, handleChange, errors }" name="tasks">
             <FieldSet :data-invalid="!!errors.length">
               <FieldLegend variant="label">
                 Tasks
@@ -127,17 +125,15 @@ const onSubmit = handleSubmit((data) => {
                 >
                   <Checkbox
                     :id="`form-vee-checkbox-${task.id}`"
-                    :name="field.name"
                     :aria-invalid="!!errors.length"
-                    :model-value="field.value?.includes(task.id)"
+                    :model-value="value?.includes(task.id)"
                     @update:model-value="
                       (checked: boolean | 'indeterminate') => {
-                        const newValue = checked
-                          ? [...(field.value || []), task.id]
-                          : (field.value || []).filter(
-                            (value: string) => value !== task.id,
-                          );
-                        field.onChange(newValue);
+                        handleChange(
+                          checked
+                            ? [...(value || []), task.id]
+                            : (value || []).filter((id: string) => id !== task.id),
+                        );
                       }
                     "
                   />

--- a/apps/v4/components/demo/VeeValidateComplexDemo.vue
+++ b/apps/v4/components/demo/VeeValidateComplexDemo.vue
@@ -119,7 +119,7 @@ const onSubmit = handleSubmit((data) => {
     <CardContent>
       <form id="form-vee-complex" @submit="onSubmit">
         <FieldGroup>
-          <VeeField v-slot="{ field, errors }" name="plan">
+          <VeeField v-slot="{ componentField, errors }" name="plan">
             <FieldSet :data-invalid="!!errors.length">
               <FieldLegend variant="label">
                 Subscription Plan
@@ -128,10 +128,8 @@ const onSubmit = handleSubmit((data) => {
                 Choose your subscription plan.
               </FieldDescription>
               <RadioGroup
-                :name="field.name"
-                :model-value="field.value"
+                v-bind="componentField"
                 :aria-invalid="!!errors.length"
-                @update:model-value="field.onChange"
               >
                 <FieldLabel for="form-vee-complex-basic">
                   <Field orientation="horizontal">
@@ -166,16 +164,12 @@ const onSubmit = handleSubmit((data) => {
             </FieldSet>
           </VeeField>
           <FieldSeparator />
-          <VeeField v-slot="{ field, errors }" name="billingPeriod">
+          <VeeField v-slot="{ componentField, errors }" name="billingPeriod">
             <Field :data-invalid="!!errors.length">
               <FieldLabel for="form-vee-complex-billingPeriod">
                 Billing Period
               </FieldLabel>
-              <Select
-                :name="field.name"
-                :model-value="field.value"
-                @update:model-value="field.onChange"
-              >
+              <Select v-bind="componentField">
                 <SelectTrigger
                   id="form-vee-complex-billingPeriod"
                   :aria-invalid="!!errors.length"
@@ -198,7 +192,7 @@ const onSubmit = handleSubmit((data) => {
             </Field>
           </VeeField>
           <FieldSeparator />
-          <VeeField v-slot="{ field, errors }" name="addons">
+          <VeeField v-slot="{ value, handleChange, errors }" name="addons">
             <FieldSet>
               <FieldLegend>Add-ons</FieldLegend>
               <FieldDescription>
@@ -213,14 +207,12 @@ const onSubmit = handleSubmit((data) => {
                 >
                   <Checkbox
                     :id="`form-vee-complex-${addon.id}`"
-                    :name="field.name"
                     :aria-invalid="!!errors.length"
-                    :model-value="field.value?.includes(addon.id)"
+                    :model-value="value?.includes(addon.id)"
                     @update:model-value="(checked: boolean | 'indeterminate') => {
-                      const newValue = checked
-                        ? [...(field.value || []), addon.id]
-                        : (field.value || []).filter((value: string) => value !== addon.id)
-                      field.onChange(newValue)
+                      handleChange(checked
+                        ? [...(value || []), addon.id]
+                        : (value || []).filter((id: string) => id !== addon.id))
                     }"
                   />
                   <FieldContent>
@@ -238,7 +230,7 @@ const onSubmit = handleSubmit((data) => {
           </VeeField>
           <FieldSeparator />
           <VeeField
-            v-slot="{ field, errors }"
+            v-slot="{ componentField, errors }"
             name="emailNotifications"
             type="checkbox"
           >
@@ -256,10 +248,8 @@ const onSubmit = handleSubmit((data) => {
               </FieldContent>
               <Switch
                 id="form-vee-complex-emailNotifications"
-                :name="field.name"
-                :model-value="field.value"
+                v-bind="componentField"
                 :aria-invalid="!!errors.length"
-                @update:model-value="field.onChange"
               />
               <FieldError v-if="errors.length" :errors="errors" />
             </Field>

--- a/apps/v4/components/demo/VeeValidateDemo.vue
+++ b/apps/v4/components/demo/VeeValidateDemo.vue
@@ -72,14 +72,14 @@ const onSubmit = handleSubmit((data) => {
     <CardContent>
       <form id="form-vee-demo" @submit="onSubmit">
         <FieldGroup>
-          <VeeField v-slot="{ field, errors }" name="title">
+          <VeeField v-slot="{ componentField, errors }" name="title">
             <Field :data-invalid="!!errors.length">
               <FieldLabel for="form-vee-demo-title">
                 Bug Title
               </FieldLabel>
               <Input
                 id="form-vee-demo-title"
-                v-bind="field"
+                v-bind="componentField"
                 placeholder="Login button not working on mobile"
                 autocomplete="off"
                 :aria-invalid="!!errors.length"
@@ -88,7 +88,7 @@ const onSubmit = handleSubmit((data) => {
             </Field>
           </VeeField>
 
-          <VeeField v-slot="{ field, errors }" name="description">
+          <VeeField v-slot="{ componentField, value, errors }" name="description">
             <Field :data-invalid="!!errors.length">
               <FieldLabel for="form-vee-demo-description">
                 Description
@@ -96,7 +96,7 @@ const onSubmit = handleSubmit((data) => {
               <InputGroup>
                 <InputGroupTextarea
                   id="form-vee-demo-description"
-                  v-bind="field"
+                  v-bind="componentField"
                   placeholder="I'm having an issue with the login button on mobile."
                   :rows="6"
                   class="min-h-24 resize-none"
@@ -104,7 +104,7 @@ const onSubmit = handleSubmit((data) => {
                 />
                 <InputGroupAddon align="block-end">
                   <InputGroupText class="tabular-nums">
-                    {{ field.value?.length || 0 }}/100 characters
+                    {{ value?.length || 0 }}/100 characters
                   </InputGroupText>
                 </InputGroupAddon>
               </InputGroup>

--- a/apps/v4/components/demo/VeeValidateInputDemo.vue
+++ b/apps/v4/components/demo/VeeValidateInputDemo.vue
@@ -65,14 +65,14 @@ const onSubmit = handleSubmit((data) => {
     <CardContent>
       <form id="form-vee-input" @submit="onSubmit">
         <FieldGroup>
-          <VeeField v-slot="{ field, errors }" name="username">
+          <VeeField v-slot="{ componentField, errors }" name="username">
             <Field :data-invalid="!!errors.length">
               <FieldLabel for="form-vee-input-username">
                 Username
               </FieldLabel>
               <Input
                 id="form-vee-input-username"
-                v-bind="field"
+                v-bind="componentField"
                 :aria-invalid="!!errors.length"
                 placeholder="shadcn"
                 autocomplete="username"

--- a/apps/v4/components/demo/VeeValidatePasswordDemo.vue
+++ b/apps/v4/components/demo/VeeValidatePasswordDemo.vue
@@ -130,7 +130,7 @@ const onSubmit = handleSubmit((data) => {
     <CardContent>
       <form id="form-vee-password" @submit="onSubmit">
         <FieldGroup>
-          <VeeField v-slot="{ field, errors }" name="password">
+          <VeeField v-slot="{ componentField, errors }" name="password">
             <Field :data-invalid="!!errors.length">
               <FieldLabel for="form-vee-password-input">
                 Password
@@ -138,7 +138,7 @@ const onSubmit = handleSubmit((data) => {
               <InputGroup>
                 <InputGroupInput
                   id="form-vee-password-input"
-                  v-bind="field"
+                  v-bind="componentField"
                   type="password"
                   placeholder="Enter your password"
                   :aria-invalid="!!errors.length"

--- a/apps/v4/components/demo/VeeValidateRadioGroupDemo.vue
+++ b/apps/v4/components/demo/VeeValidateRadioGroupDemo.vue
@@ -83,17 +83,15 @@ const onSubmit = handleSubmit((data) => {
     <CardContent>
       <form id="form-vee-radiogroup" @submit="onSubmit">
         <FieldGroup>
-          <VeeField v-slot="{ field, errors }" name="plan">
+          <VeeField v-slot="{ componentField, errors }" name="plan">
             <FieldSet :data-invalid="!!errors.length">
               <FieldLegend>Plan</FieldLegend>
               <FieldDescription>
                 You can upgrade or downgrade your plan at any time.
               </FieldDescription>
               <RadioGroup
-                :name="field.name"
-                :model-value="field.value"
+                v-bind="componentField"
                 :aria-invalid="!!errors.length"
-                @update:model-value="field.onChange"
               >
                 <FieldLabel
                   v-for="plan in plans"

--- a/apps/v4/components/demo/VeeValidateSelectDemo.vue
+++ b/apps/v4/components/demo/VeeValidateSelectDemo.vue
@@ -82,7 +82,7 @@ const onSubmit = handleSubmit((data) => {
     <CardContent>
       <form id="form-vee-select" @submit="onSubmit">
         <FieldGroup>
-          <VeeField v-slot="{ field, errors }" name="language">
+          <VeeField v-slot="{ componentField, errors }" name="language">
             <Field
               orientation="responsive"
               :data-invalid="!!errors.length"
@@ -96,11 +96,7 @@ const onSubmit = handleSubmit((data) => {
                 </FieldDescription>
                 <FieldError v-if="errors.length" :errors="errors" />
               </FieldContent>
-              <Select
-                :name="field.name"
-                :model-value="field.value"
-                @update:model-value="field.onChange"
-              >
+              <Select v-bind="componentField">
                 <SelectTrigger
                   id="form-vee-select-language"
                   :aria-invalid="!!errors.length"

--- a/apps/v4/components/demo/VeeValidateSwitchDemo.vue
+++ b/apps/v4/components/demo/VeeValidateSwitchDemo.vue
@@ -61,7 +61,7 @@ const onSubmit = handleSubmit((data) => {
     <CardContent>
       <form id="form-vee-switch" @submit="onSubmit">
         <FieldGroup>
-          <VeeField v-slot="{ field, errors }" name="twoFactor" type="checkbox">
+          <VeeField v-slot="{ componentField, errors }" name="twoFactor" type="checkbox">
             <Field
               orientation="horizontal"
               :data-invalid="!!errors.length"
@@ -77,10 +77,8 @@ const onSubmit = handleSubmit((data) => {
               </FieldContent>
               <Switch
                 id="form-vee-switch-twoFactor"
-                :name="field.name"
-                :model-value="field.value"
+                v-bind="componentField"
                 :aria-invalid="!!errors.length"
-                @update:model-value="field.onChange"
               />
             </Field>
           </VeeField>

--- a/apps/v4/components/demo/VeeValidateTextareaDemo.vue
+++ b/apps/v4/components/demo/VeeValidateTextareaDemo.vue
@@ -61,14 +61,14 @@ const onSubmit = handleSubmit((data) => {
     <CardContent>
       <form id="form-vee-textarea" @submit="onSubmit">
         <FieldGroup>
-          <VeeField v-slot="{ field, errors }" name="about">
+          <VeeField v-slot="{ componentField, errors }" name="about">
             <Field :data-invalid="!!errors.length">
               <FieldLabel for="form-vee-textarea-about">
                 More about you
               </FieldLabel>
               <Textarea
                 id="form-vee-textarea-about"
-                v-bind="field"
+                v-bind="componentField"
                 :aria-invalid="!!errors.length"
                 placeholder="I'm a software engineer..."
                 class="min-h-[120px]"

--- a/apps/v4/content/docs/forms/01.vee-validate.md
+++ b/apps/v4/content/docs/forms/01.vee-validate.md
@@ -43,28 +43,82 @@ This form leverages VeeValidate for performant, flexible form handling. We'll bu
 
 Here's a basic example of a form using VeeValidate's `<Field />` component with scoped slots and shadcn-vue `<Field />` components.
 
-```vue showLineNumbers {2-19}
-<template>
-  <VeeField v-slot="{ field, errors }" name="title">
-    <Field :data-invalid="!!errors.length">
-      <FieldLabel for="title">
-        Bug Title
-      </FieldLabel>
-      <Input
-        id="title"
-        v-bind="field"
-        placeholder="Login button not working on mobile"
-        autocomplete="off"
-        :aria-invalid="!!errors.length"
-      />
-      <FieldDescription>
-        Provide a concise title for your bug report.
-      </FieldDescription>
-      <FieldError v-if="errors.length" :errors="errors" />
-    </Field>
-  </VeeField>
-</template>
-```
+Bind `componentField` when the control is a Vue component with `v-model`, such as shadcn-vue's `<Input />`. Bind `field` when the control is a native element. `field` binds `value`, which a `v-model` component ignores, so `initialValues` never render.
+
+<br />
+
+::::tabs{default-value="component"}
+
+  :::tabs-list
+
+    ::tabs-trigger{value="component"}
+    Component
+    ::
+
+    ::tabs-trigger{value="native"}
+    Native
+    ::
+
+  :::
+
+  ::tabs-content{value="component"}
+
+  #### `Input` Component
+
+  ```vue showLineNumbers {2,9}
+  <template>
+    <VeeField v-slot="{ componentField, errors }" name="title">
+      <Field :data-invalid="!!errors.length">
+        <FieldLabel for="title">
+          Bug Title
+        </FieldLabel>
+        <Input
+          id="title"
+          v-bind="componentField"
+          placeholder="Login button not working on mobile"
+          autocomplete="off"
+          :aria-invalid="!!errors.length"
+        />
+        <FieldDescription>
+          Provide a concise title for your bug report.
+        </FieldDescription>
+        <FieldError v-if="errors.length" :errors="errors" />
+      </Field>
+    </VeeField>
+  </template>
+  ```
+
+  ::
+
+  ::tabs-content{value="native"}
+
+  #### native `input` element
+
+  ```vue showLineNumbers {2,9}
+  <template>
+    <VeeField v-slot="{ field, errors }" name="title">
+      <Field :data-invalid="!!errors.length">
+        <FieldLabel for="title">
+          Bug Title
+        </FieldLabel>
+        <input
+          id="title"
+          v-bind="field"
+          placeholder="Login button not working on mobile"
+          autocomplete="off"
+          :aria-invalid="!!errors.length"
+        >
+        <FieldDescription>
+          Provide a concise title for your bug report.
+        </FieldDescription>
+        <FieldError v-if="errors.length" :errors="errors" />
+      </Field>
+    </VeeField>
+  </template>
+  ```
+
+  ::
+::::
 
 ## Form
 
@@ -185,7 +239,7 @@ VeeValidate supports different validation strategies through the `Field` compone
 
 ```vue showLineNumbers title="Form.vue" {4}
 <VeeField
-  v-slot="{ field, errors }"
+  v-slot="{ componentField, errors }"
   name="title"
   :validate-on-input="true"
 >
@@ -209,14 +263,14 @@ Display errors next to the field using `<FieldError />`. For styling and accessi
 
 ```vue showLineNumbers title="Form.vue" {2,9,11}
 <template>
-  <VeeField v-slot="{ field, errors }" name="email">
+  <VeeField v-slot="{ componentField, errors }" name="email">
     <Field :data-invalid="!!errors.length">
       <FieldLabel for="email">
         Email
       </FieldLabel>
       <Input
         id="email"
-        v-bind="field"
+        v-bind="componentField"
         type="email"
         :aria-invalid="!!errors.length"
       />
@@ -230,7 +284,7 @@ Display errors next to the field using `<FieldError />`. For styling and accessi
 
 ### Input
 
-- For input fields, use `v-bind="field"` to bind VeeValidate's field object to the input.
+- For input fields, use `v-bind="componentField"` to bind VeeValidate's field object to the input.
 - To show errors, add the `:aria-invalid` prop to the `<Input />` component and the `:data-invalid` prop to the shadcn-vue `<Field />` component.
 
 ::component-preview
@@ -245,14 +299,14 @@ For simple text inputs, use VeeValidate's `Field` component with scoped slots.
 
 ```vue showLineNumbers title="Form.vue" {3,9,11}
 <template>
-  <VeeField v-slot="{ field, errors }" name="name">
+  <VeeField v-slot="{ componentField, errors }" name="name">
     <Field :data-invalid="!!errors.length">
       <FieldLabel for="name">
         Name
       </FieldLabel>
       <Input
         id="name"
-        v-bind="field"
+        v-bind="componentField"
         placeholder="Enter your name"
         :aria-invalid="!!errors.length"
       />
@@ -264,7 +318,7 @@ For simple text inputs, use VeeValidate's `Field` component with scoped slots.
 
 ### Textarea
 
-- For textarea fields, use `v-bind="field"` to bind VeeValidate's field object to the textarea.
+- For textarea fields, use `v-bind="componentField"` to bind VeeValidate's field object to the textarea.
 - To show errors, add the `:aria-invalid` prop to the `<Textarea />` component and the `:data-invalid` prop to the shadcn-vue `<Field />` component.
 
 ::component-preview
@@ -277,16 +331,16 @@ chromeLessOnMobile: true
 
 For textarea fields, use VeeValidate's `Field` component with scoped slots.
 
-```vue showLineNumbers title="Form.vue" {3,12,16}
+```vue showLineNumbers title="Form.vue" {3,9,12}
 <template>
-  <VeeField v-slot="{ field, errors }" name="about">
+  <VeeField v-slot="{ componentField, errors }" name="about">
     <Field :data-invalid="!!errors.length">
       <FieldLabel for="about">
         More about you
       </FieldLabel>
       <Textarea
         id="about"
-        v-bind="field"
+        v-bind="componentField"
         placeholder="I'm a software engineer..."
         class="min-h-[120px]"
         :aria-invalid="!!errors.length"
@@ -302,7 +356,7 @@ For textarea fields, use VeeValidate's `Field` component with scoped slots.
 
 ### Select
 
-- For select components, use `field.value` and `@update:model-value="field.onChange"` for proper binding.
+- For select components, use `v-bind="componentField"` on `<Select />`. It binds `modelValue`, `update:modelValue` and `name` in one go.
 - To show errors, add the `:aria-invalid` prop to the `<SelectTrigger />` component and the `:data-invalid` prop to the shadcn-vue `<Field />` component.
 
 ::component-preview
@@ -313,9 +367,9 @@ chromeLessOnMobile: true
 ---
 ::
 
-```vue showLineNumbers title="Form.vue" {3,9,19}
+```vue showLineNumbers title="Form.vue" {2,11,15}
 <template>
-  <VeeField v-slot="{ field, errors }" name="language">
+  <VeeField v-slot="{ componentField, errors }" name="language">
     <Field orientation="responsive" :data-invalid="!!errors.length">
       <FieldContent>
         <FieldLabel for="language">
@@ -324,11 +378,7 @@ chromeLessOnMobile: true
         <FieldDescription>For best results, select the language you speak.</FieldDescription>
         <FieldError v-if="errors.length" :errors="errors" />
       </FieldContent>
-      <Select
-        :model-value="field.value"
-        @update:model-value="field.onChange"
-        @blur="field.onBlur"
-      >
+      <Select v-bind="componentField">
         <SelectTrigger
           id="language"
           class="min-w-[120px]"
@@ -352,7 +402,8 @@ chromeLessOnMobile: true
 
 ### Checkbox
 
-- For checkbox arrays, use VeeValidate's `Field` component with a custom handler to manage array state.
+- For a single boolean checkbox, use `v-bind="componentField"` and set `type="checkbox"` on VeeValidate's `<Field />`.
+- For checkbox arrays, one field holds the whole array, so bind the `value` and `handleChange` slot props by hand instead.
 - To show errors, add the `:aria-invalid` prop to the `<Checkbox />` component and the `:data-invalid` prop to the shadcn-vue `<Field />` component.
 - Remember to add `data-slot="checkbox-group"` to the `<FieldGroup />` component for proper styling and spacing.
 
@@ -364,10 +415,38 @@ chromeLessOnMobile: true
 ---
 ::
 
-```vue showLineNumbers title="Form.vue" {13,16-25,32}
+```vue showLineNumbers title="Form.vue" {2,12}
 <template>
-  <VeeField v-slot="{ field, errors }" name="tasks">
-    <FieldSet>
+  <VeeField v-slot="{ componentField, errors }" name="responses" type="checkbox">
+    <FieldSet :data-invalid="!!errors.length">
+      <FieldLegend variant="label">
+        Responses
+      </FieldLegend>
+      <FieldDescription>Get notified for requests that take time.</FieldDescription>
+      <FieldGroup data-slot="checkbox-group">
+        <Field orientation="horizontal">
+          <Checkbox
+            id="responses"
+            v-bind="componentField"
+            :aria-invalid="!!errors.length"
+          />
+          <FieldLabel for="responses" class="font-normal">
+            Push notifications
+          </FieldLabel>
+        </Field>
+      </FieldGroup>
+      <FieldError v-if="errors.length" :errors="errors" />
+    </FieldSet>
+  </VeeField>
+</template>
+```
+
+For an array field, read the current selection from `value` and write the next one with `handleChange`.
+
+```vue showLineNumbers title="Form.vue" {2,17,19-23}
+<template>
+  <VeeField v-slot="{ value, handleChange, errors }" name="tasks">
+    <FieldSet :data-invalid="!!errors.length">
       <FieldLegend variant="label">
         Tasks
       </FieldLegend>
@@ -381,14 +460,12 @@ chromeLessOnMobile: true
         >
           <Checkbox
             :id="`task-${task.id}`"
-            :model-value="field.value?.includes(task.id) ?? false"
+            :model-value="value?.includes(task.id)"
             :aria-invalid="!!errors.length"
-            @update:model-value="(checked | 'indeterminate') => {
-              const currentTasks = field.value || []
-              const newValue = checked
-                ? [...currentTasks, task.id]
-                : currentTasks.filter(id => id !== task.id)
-              field.onChange(newValue)
+            @update:model-value="(checked: boolean | 'indeterminate') => {
+              handleChange(checked
+                ? [...(value || []), task.id]
+                : (value || []).filter((id: string) => id !== task.id))
             }"
           />
           <FieldLabel :for="`task-${task.id}`" class="font-normal">
@@ -404,8 +481,8 @@ chromeLessOnMobile: true
 
 ### Radio Group
 
-- For radio groups, use `field.value` and `@update:model-value="field.onChange"` for proper binding.
-- To show errors, add the `:aria-invalid` prop to the `<RadioGroupItem />` component and the `:data-invalid` prop to the shadcn-vue `<Field />` component.
+- For radio groups, use `v-bind="componentField"` on `<RadioGroup />`. Each `<RadioGroupItem />` only needs its own `value`.
+- To show errors, add the `:aria-invalid` prop to the `<RadioGroup />` component and the `:data-invalid` prop to the shadcn-vue `<Field />` component.
 
 ::component-preview
 ---
@@ -415,17 +492,17 @@ chromeLessOnMobile: true
 ---
 ::
 
-```vue showLineNumbers title="Form.vue" {9-10,13,21,26}
+```vue showLineNumbers title="Form.vue" {2,8-11}
 <template>
-  <VeeField v-slot="{ field, errors }" name="plan">
-    <FieldSet>
+  <VeeField v-slot="{ componentField, errors }" name="plan">
+    <FieldSet :data-invalid="!!errors.length">
       <FieldLegend>Plan</FieldLegend>
       <FieldDescription>
         You can upgrade or downgrade your plan at any time.
       </FieldDescription>
       <RadioGroup
-        :model-value="field.value"
-        @update:model-value="field.onChange"
+        v-bind="componentField"
+        :aria-invalid="!!errors.length"
       >
         <FieldLabel v-for="planOption in plans" :key="planOption.id" :for="`plan-${planOption.id}`">
           <Field orientation="horizontal" :data-invalid="!!errors.length">
@@ -436,7 +513,6 @@ chromeLessOnMobile: true
             <RadioGroupItem
               :id="`plan-${planOption.id}`"
               :value="planOption.id"
-              :aria-invalid="!!errors.length"
             />
           </Field>
         </FieldLabel>
@@ -449,7 +525,7 @@ chromeLessOnMobile: true
 
 ### Switch
 
-- For switches, use `:model-value="field.value"` and `@update:model-value="field.onChange"` for proper binding.
+- For switches, use `v-bind="componentField"` and set `type="checkbox"` on VeeValidate's `<Field />` so the value is treated as a boolean.
 - To show errors, add the `:aria-invalid` prop to the `<Switch />` component and the `:data-invalid` prop to the shadcn-vue `<Field />` component.
 
 ::component-preview
@@ -460,9 +536,9 @@ chromeLessOnMobile: true
 ---
 ::
 
-```vue showLineNumbers title="Form.vue" {3,11,15-17}
+```vue showLineNumbers title="Form.vue" {2,15}
 <template>
-  <VeeField v-slot="{ field, errors }" name="twoFactor">
+  <VeeField v-slot="{ componentField, errors }" name="twoFactor" type="checkbox">
     <Field orientation="horizontal" :data-invalid="!!errors.length">
       <FieldContent>
         <FieldLabel for="two-factor">
@@ -475,9 +551,8 @@ chromeLessOnMobile: true
       </FieldContent>
       <Switch
         id="two-factor"
-        :model-value="field.value"
+        v-bind="componentField"
         :aria-invalid="!!errors.length"
-        @update:model-value="field.onChange"
       />
     </Field>
   </VeeField>
@@ -573,7 +648,7 @@ Map over the `fields` array and create fields for each item. **Make sure to use 
     <VeeField
       v-for="(field, index) in fields"
       :key="field.key"
-      v-slot="{ field: controllerField, errors }"
+      v-slot="{ componentField: controllerField, errors }"
       :name="`emails[${index}].address`"
     >
       <Field orientation="horizontal" :data-invalid="!!errors.length">


### PR DESCRIPTION
### 🔗 Linked issue

Close #1638
Close #1640

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Clarify the vee-validate usage for Vue form components

### 📸 Screenshots (if appropriate)

### 📝 Checklist


- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated form demos with clearer validation feedback, field descriptions, error messages, and invalid-state accessibility attributes.
  - Improved checkbox, select, radio, switch, textarea, password, and array-field interactions across validation examples.
  - Enhanced multi-step form validation and field identification.

- **Documentation**
  - Clarified when to use component bindings versus native field bindings.
  - Added guidance and examples for boolean checkboxes and checkbox arrays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->