### PR TITLE
feat(cli): resolve registry items from public GitHub repositories

### DIFF
--- a/apps/v4/content/docs/06.cli.md
+++ b/apps/v4/content/docs/06.cli.md
@@ -67,6 +67,20 @@ Use the `add` command to add components and dependencies to your project.
 npx shadcn-vue@latest add [component]
 ```
 
+A component can be named in any of these ways:
+
+| Form | Resolves to |
+| --- | --- |
+| `button` | an item in the default `shadcn-vue` registry |
+| `@acme/button` | an item in a registry configured under `registries` in `components.json` |
+| `https://acme.com/r/button.json` | a registry item fetched directly from that URL |
+| `./button.json` | a registry item on disk |
+| `owner/repo/button` | an item in the root `registry.json` of a public GitHub repository |
+| `owner/repo/button#v1.0.0` | the same, pinned to a branch, tag or commit |
+
+See [Install from GitHub](/docs/registry/getting-started#install-from-github) for
+the GitHub form.
+
 **Options**
 
 ```bash

--- a/apps/v4/content/docs/registry/getting-started.md
+++ b/apps/v4/content/docs/registry/getting-started.md
@@ -239,6 +239,24 @@ the commit it points at.
 npx shadcn-vue@latest search owner/repo
 ```
 
+### Only install from repositories you trust
+
+Adding a registry item runs third-party code on your machine. This is true of
+every registry — hosted, local or GitHub — but the GitHub form is worth calling
+out because it needs no configuration, so a single command from a README is
+enough to install from a repository you have never looked at.
+
+A registry item can list npm `dependencies`, which the CLI installs with your
+package manager, which in turn runs that package's install scripts. It can also
+write files into your project. Treat `npx shadcn-vue@latest add owner/repo/item`
+with the same care as `npm install owner-repo` — read the registry first if you
+do not know who owns it.
+
+The CLI does reject `path` and `target` values that are absolute or use `..` to
+escape the project, both for the item you asked for and at the point files are
+written. That is a guard against mistakes and a hostile item's easiest trick; it
+is not a sandbox.
+
 ### Notes
 
 - **Item names may contain slashes.** `owner/repo/forms/login` installs the item
@@ -250,10 +268,9 @@ npx shadcn-vue@latest search owner/repo
   which is what lets it find the default branch instead of guessing `main`.
 - **`registryDependencies` are resolved the usual way.** A full URL is fetched
   as-is; a bare name such as `button` resolves against the default `shadcn-vue`
-  registry, exactly as it does for any other registry item.
-- **File paths and targets must stay inside the project.** Because this form
-  takes no configuration from the user, the CLI rejects any `path` or `target`
-  that is absolute or uses `..` to escape.
+  registry, exactly as it does for any other registry item. Note that a
+  dependency can point anywhere, so trusting a repository means trusting what it
+  depends on too.
 
 If you would rather not type the repository on every command, register a
 namespace in `components.json` and install by that instead. A namespace maps to

--- a/apps/v4/content/docs/registry/getting-started.md
+++ b/apps/v4/content/docs/registry/getting-started.md
@@ -256,7 +256,9 @@ npx shadcn-vue@latest search owner/repo
   that is absolute or uses `..` to escape.
 
 If you would rather not type the repository on every command, register a
-namespace in `components.json` and install by that instead:
+namespace in `components.json` and install by that instead. A namespace maps to
+a hosted registry URL template — not to a GitHub repository — so this is an
+alternative to the GitHub form above rather than a shorthand for it:
 
 ```json title="components.json"
 {

--- a/apps/v4/content/docs/registry/getting-started.md
+++ b/apps/v4/content/docs/registry/getting-started.md
@@ -204,3 +204,68 @@ To install a registry item using the `shadcn-vue` CLI, use the `add` command fol
 ```bash
 npx shadcn-vue@latest add http://localhost:3000/r/hello-world.json
 ```
+
+## Install from GitHub
+
+If your registry lives in a **public** GitHub repository with a `registry.json`
+at its root, you do not have to build, host or configure anything. The CLI can
+read it directly:
+
+```bash
+npx shadcn-vue@latest add owner/repo/hello-world
+```
+
+The CLI resolves the repository's default branch, reads `registry.json` from the
+root, finds the item by name, and fetches each of its `files[].path` from the
+same commit. Every file of an item comes from one commit, so a branch that moves
+mid-install cannot give you a half-updated component.
+
+### Pinning a branch, tag or commit
+
+Append `#ref` to install from somewhere other than the default branch:
+
+```bash
+npx shadcn-vue@latest add owner/repo/hello-world#main
+npx shadcn-vue@latest add owner/repo/hello-world#v1.2.0
+npx shadcn-vue@latest add owner/repo/hello-world#1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b
+```
+
+Branches win over tags when a name is ambiguous, and an annotated tag resolves to
+the commit it points at.
+
+### Listing what a repository publishes
+
+```bash
+npx shadcn-vue@latest search owner/repo
+```
+
+### Notes
+
+- **Item names may contain slashes.** `owner/repo/forms/login` installs the item
+  *named* `forms/login` from the root `registry.json`. It is not a path to a
+  nested `registry.json`.
+- **The repository must be public.** `raw.githubusercontent.com` does not serve
+  private repositories. Use a hosted registry with [auth](#adding-auth) instead.
+- **Git is required.** The CLI shells out to `git ls-remote` to resolve the ref,
+  which is what lets it find the default branch instead of guessing `main`.
+- **`registryDependencies` are resolved the usual way.** A full URL is fetched
+  as-is; a bare name such as `button` resolves against the default `shadcn-vue`
+  registry, exactly as it does for any other registry item.
+- **File paths and targets must stay inside the project.** Because this form
+  takes no configuration from the user, the CLI rejects any `path` or `target`
+  that is absolute or uses `..` to escape.
+
+If you would rather not type the repository on every command, register a
+namespace in `components.json` and install by that instead:
+
+```json title="components.json"
+{
+  "registries": {
+    "@acme": "https://acme.com/r/{name}.json"
+  }
+}
+```
+
+```bash
+npx shadcn-vue@latest add @acme/hello-world
+```

--- a/packages/cli/src/commands/search.ts
+++ b/packages/cli/src/commands/search.ts
@@ -86,9 +86,16 @@ export const search = new Command()
         // Use shadow config if getConfig fails (partial components.json).
       }
 
+      // Only `@namespace` registries need to be discovered in components.json.
+      // A url or a `owner/repo` GitHub source carries its own location, and
+      // appending "/registry" to one just sends us off to look for an item
+      // literally named "registry" - a wasted round trip whose failure is then
+      // swallowed.
       const { config: updatedConfig, newRegistries }
         = await ensureRegistriesInConfig(
-          registries.map(registry => `${registry}/registry`),
+          registries
+            .filter(registry => registry.startsWith('@'))
+            .map(registry => `${registry}/registry`),
           config,
           {
             silent: true,

--- a/packages/cli/src/registry/address.test.ts
+++ b/packages/cli/src/registry/address.test.ts
@@ -121,6 +121,46 @@ describe("resolveItemAddress", () => {
     },
   )
 
+  it("accepts an owner at the 39 character limit", () => {
+    const owner = `a${"b".repeat(37)}c`
+
+    expect(owner).toHaveLength(39)
+    expect(resolveItemAddress(`${owner}/repo/button`)).toEqual({
+      scheme: "github",
+      owner,
+      repo: "repo",
+      item: "button",
+    })
+  })
+
+  it("rejects an owner over the 39 character limit", () => {
+    const owner = `a${"b".repeat(38)}c`
+
+    expect(owner).toHaveLength(40)
+    expect(resolveItemAddress(`${owner}/repo/button`)).toEqual({
+      scheme: "shadcn",
+      item: `${owner}/repo/button`,
+    })
+  })
+
+  it("does not classify an address with an empty item name as GitHub", () => {
+    expect(resolveItemAddress("owner/repo/")).toEqual({
+      scheme: "shadcn",
+      item: "owner/repo/",
+    })
+  })
+
+  it("keeps an empty path segment in the item name", () => {
+    // The item name is only ever matched against registry.json, never joined
+    // into a path, so this resolves and then fails as an unknown item.
+    expect(resolveItemAddress("owner/repo//button")).toEqual({
+      scheme: "github",
+      owner: "owner",
+      repo: "repo",
+      item: "/button",
+    })
+  })
+
   it("keeps .json addresses classified as file paths", () => {
     expect(resolveItemAddress("owner/repo/data/schema.json")).toEqual({
       scheme: "file",

--- a/packages/cli/src/registry/address.test.ts
+++ b/packages/cli/src/registry/address.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from "vitest"
+import { RegistryValidationError } from "@/src/registry/errors"
+
+import { resolveGitHubRegistrySource, resolveItemAddress } from "./address"
+
+describe("resolveItemAddress", () => {
+  it.each([
+    ["button", { scheme: "shadcn", item: "button" }],
+    ["calendar", { scheme: "shadcn", item: "calendar" }],
+  ])("resolves shadcn item address %s", (input, expected) => {
+    expect(resolveItemAddress(input)).toEqual(expected)
+  })
+
+  it.each([
+    [
+      "@acme/button",
+      { scheme: "namespace", namespace: "@acme", item: "button" },
+    ],
+    [
+      "@acme/ui/button",
+      { scheme: "namespace", namespace: "@acme", item: "ui/button" },
+    ],
+  ])("resolves namespace item address %s", (input, expected) => {
+    expect(resolveItemAddress(input)).toEqual(expected)
+  })
+
+  it.each([
+    [
+      "https://example.com/r/button.json",
+      { scheme: "url", url: "https://example.com/r/button.json" },
+    ],
+    [
+      "https://example.com/r/button.json#fragment",
+      { scheme: "url", url: "https://example.com/r/button.json#fragment" },
+    ],
+  ])("resolves url item address %s", (input, expected) => {
+    expect(resolveItemAddress(input)).toEqual(expected)
+  })
+
+  it.each([
+    ["./button.json", { scheme: "file", path: "./button.json" }],
+    [
+      "../registry/button.json",
+      { scheme: "file", path: "../registry/button.json" },
+    ],
+    [
+      "/Users/me/registry/button.json",
+      { scheme: "file", path: "/Users/me/registry/button.json" },
+    ],
+  ])("resolves file item address %s", (input, expected) => {
+    expect(resolveItemAddress(input)).toEqual(expected)
+  })
+
+  it.each([
+    [
+      "acme/ui/button",
+      {
+        scheme: "github",
+        owner: "acme",
+        repo: "ui",
+        item: "button",
+      },
+    ],
+    [
+      "acme/ui/forms/login",
+      {
+        scheme: "github",
+        owner: "acme",
+        repo: "ui",
+        item: "forms/login",
+      },
+    ],
+    [
+      "acme/ui/button#v1.2.0",
+      {
+        scheme: "github",
+        owner: "acme",
+        repo: "ui",
+        item: "button",
+        ref: "v1.2.0",
+      },
+    ],
+    [
+      "acme/ui/button#feature/login-form",
+      {
+        scheme: "github",
+        owner: "acme",
+        repo: "ui",
+        item: "button",
+        ref: "feature/login-form",
+      },
+    ],
+    [
+      "peter-lewis/lifeline/personal",
+      {
+        scheme: "github",
+        owner: "peter-lewis",
+        repo: "lifeline",
+        item: "personal",
+      },
+    ],
+  ])("resolves GitHub item address %s", (input, expected) => {
+    expect(resolveItemAddress(input)).toEqual(expected)
+  })
+
+  it.each([
+    ["foo/bar", { scheme: "shadcn", item: "foo/bar" }],
+    ["-owner/repo/button", { scheme: "shadcn", item: "-owner/repo/button" }],
+    ["owner-/repo/button", { scheme: "shadcn", item: "owner-/repo/button" }],
+    ["ow--ner/repo/button", { scheme: "shadcn", item: "ow--ner/repo/button" }],
+    ["owner/./button", { scheme: "shadcn", item: "owner/./button" }],
+    ["owner/../button", { scheme: "shadcn", item: "owner/../button" }],
+    [
+      "owner/repo with space/button",
+      { scheme: "shadcn", item: "owner/repo with space/button" },
+    ],
+  ])(
+    "does not classify invalid GitHub addresses as GitHub: %s",
+    (input, expected) => {
+      expect(resolveItemAddress(input)).toEqual(expected)
+    },
+  )
+
+  it("keeps .json addresses classified as file paths", () => {
+    expect(resolveItemAddress("owner/repo/data/schema.json")).toEqual({
+      scheme: "file",
+      path: "owner/repo/data/schema.json",
+    })
+  })
+
+  it("rejects empty GitHub refs", () => {
+    expect(() => resolveItemAddress("acme/ui/button#")).toThrow(
+      RegistryValidationError,
+    )
+  })
+
+  it("rejects GitHub refs with control characters", () => {
+    expect(() => resolveItemAddress("acme/ui/button#bad\nref")).toThrow(
+      RegistryValidationError,
+    )
+  })
+
+  it("rejects GitHub refs with whitespace", () => {
+    expect(() => resolveItemAddress("acme/ui/button#my tag")).toThrow(
+      RegistryValidationError,
+    )
+  })
+
+  it("rejects GitHub refs that look like git options", () => {
+    expect(() =>
+      resolveItemAddress("acme/ui/button#--upload-pack=/bin/false"),
+    ).toThrow(RegistryValidationError)
+  })
+})
+
+describe("resolveGitHubRegistrySource", () => {
+  it.each([
+    ["acme/ui", { owner: "acme", repo: "ui" }],
+    ["acme/ui#v1.0.0", { owner: "acme", repo: "ui", ref: "v1.0.0" }],
+    [
+      "acme/ui#feature/forms",
+      { owner: "acme", repo: "ui", ref: "feature/forms" },
+    ],
+  ])("resolves GitHub registry source %s", (input, expected) => {
+    expect(resolveGitHubRegistrySource(input)).toEqual(expected)
+  })
+
+  it.each([
+    "acme",
+    "acme/ui/button",
+    "@acme/ui",
+    "https://example.com",
+    "owner/.",
+    "owner/..",
+  ])("does not resolve non-GitHub registry source %s", (input) => {
+    expect(resolveGitHubRegistrySource(input)).toBeNull()
+  })
+
+  it("rejects refs that look like git options", () => {
+    expect(() =>
+      resolveGitHubRegistrySource("acme/ui#--upload-pack=/bin/false"),
+    ).toThrow(RegistryValidationError)
+  })
+
+  it("rejects refs with whitespace", () => {
+    expect(() => resolveGitHubRegistrySource("acme/ui#my tag")).toThrow(
+      RegistryValidationError,
+    )
+  })
+})

--- a/packages/cli/src/registry/address.ts
+++ b/packages/cli/src/registry/address.ts
@@ -52,6 +52,18 @@ export type ResolvedGitHubItemAddress = Extract<
 // Classifies an `add` argument into the scheme that should resolve it.
 // The order matters: urls and local files win over the bare `owner/repo/item`
 // form, and a configured `@namespace/item` wins over everything else.
+//
+// Throws RegistryValidationError when the address looks like a GitHub address
+// but carries a malformed ref. That is deliberate: swallowing it would send
+// something like `owner/repo/button#my tag` on to the default registry, where
+// it would fail as an unknown item name and hide the real mistake. Callers on
+// the dependency-resolution path get the same treatment, so a bad ref inside
+// somebody's `registryDependencies` reports itself instead of 404ing later.
+//
+// Tradeoff worth knowing about: a bare name with two or more slashes is read
+// as `owner/repo/item`, so the default registry can never publish an item
+// literally named e.g. "charts/area/stacked". No item name in the shadcn-vue
+// registry contains a slash today, so nothing currently collides.
 export function resolveItemAddress(address: string) {
   if (isUrl(address)) {
     return {
@@ -85,14 +97,6 @@ export function resolveItemAddress(address: string) {
     scheme: "shadcn",
     item: address,
   } satisfies ResolvedItemAddress
-}
-
-// Throws RegistryValidationError when the address is a GitHub address carrying
-// a malformed ref. That is deliberate: swallowing it would send something like
-// `owner/repo/button#my tag` on to the default registry, where it would fail as
-// an unknown item name and hide the real mistake.
-export function isGitHubItemAddress(address: string) {
-  return resolveItemAddress(address).scheme === "github"
 }
 
 // Parses a registry source i.e `owner/repo` or `owner/repo#ref`.
@@ -131,11 +135,6 @@ export function resolveGitHubRegistrySource(source: string) {
     repo,
     ref,
   } satisfies ResolvedGitHubRegistrySource
-}
-
-// Throws on a malformed ref, for the same reason as isGitHubItemAddress.
-export function isGitHubRegistrySource(source: string) {
-  return resolveGitHubRegistrySource(source) !== null
 }
 
 function resolveGitHubItemAddress(address: string) {

--- a/packages/cli/src/registry/address.ts
+++ b/packages/cli/src/registry/address.ts
@@ -1,0 +1,198 @@
+import { RegistryValidationError } from "@/src/registry/errors"
+import { parseRegistryAndItemFromString } from "@/src/registry/parser"
+import { isLocalFile, isUrl } from "@/src/registry/utils"
+
+// https://docs.github.com/en/enterprise-cloud@latest/admin/managing-accounts-and-repositories/managing-users-in-your-enterprise/username-considerations-for-external-authentication
+const GITHUB_OWNER_PATTERN = /^(?!.*--)[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?$/i
+const GITHUB_REPO_PATTERN = /^[\w.-]+$/
+const INVALID_GITHUB_REPO_NAMES = new Set([".", ".."])
+// eslint-disable-next-line no-control-regex
+const CONTROL_CHARACTER_PATTERN = /[\x00-\x1F\x7F]/
+const WHITESPACE_PATTERN = /\s/
+// A ref that starts with a dash would be read by git as a command line option.
+const GITHUB_REF_OPTION_PATTERN = /^-/
+
+export type ResolvedItemAddress
+  = | {
+    scheme: "shadcn"
+    item: string
+  }
+  | {
+    scheme: "namespace"
+    namespace: string
+    item: string
+  }
+  | {
+    scheme: "url"
+    url: string
+  }
+  | {
+    scheme: "file"
+    path: string
+  }
+  | {
+    scheme: "github"
+    owner: string
+    repo: string
+    item: string
+    ref?: string
+  }
+
+export interface ResolvedGitHubRegistrySource {
+  owner: string
+  repo: string
+  ref?: string
+}
+
+export type ResolvedGitHubItemAddress = Extract<
+  ResolvedItemAddress,
+  { scheme: "github" }
+>
+
+// Classifies an `add` argument into the scheme that should resolve it.
+// The order matters: urls and local files win over the bare `owner/repo/item`
+// form, and a configured `@namespace/item` wins over everything else.
+export function resolveItemAddress(address: string) {
+  if (isUrl(address)) {
+    return {
+      scheme: "url",
+      url: address,
+    } satisfies ResolvedItemAddress
+  }
+
+  if (isLocalFile(address)) {
+    return {
+      scheme: "file",
+      path: address,
+    } satisfies ResolvedItemAddress
+  }
+
+  const { registry, item } = parseRegistryAndItemFromString(address)
+  if (registry) {
+    return {
+      scheme: "namespace",
+      namespace: registry,
+      item,
+    } satisfies ResolvedItemAddress
+  }
+
+  const githubAddress = resolveGitHubItemAddress(address)
+  if (githubAddress) {
+    return githubAddress
+  }
+
+  return {
+    scheme: "shadcn",
+    item: address,
+  } satisfies ResolvedItemAddress
+}
+
+export function isGitHubItemAddress(address: string) {
+  return resolveItemAddress(address).scheme === "github"
+}
+
+// Parses a registry source i.e `owner/repo` or `owner/repo#ref`.
+// Unlike an item address this does not carry an item name.
+export function resolveGitHubRegistrySource(source: string) {
+  const hashIndex = source.indexOf("#")
+  const path = hashIndex === -1 ? source : source.slice(0, hashIndex)
+  const ref = hashIndex === -1 ? undefined : source.slice(hashIndex + 1)
+  const parts = path.split("/")
+
+  if (parts.length !== 2) {
+    return null
+  }
+
+  const [owner, repo] = parts
+  if (!isGitHubOwner(owner) || !isGitHubRepo(repo)) {
+    return null
+  }
+
+  if (ref !== undefined && !isValidGitHubRef(ref)) {
+    throw new RegistryValidationError(
+      `Invalid GitHub ref in registry source "${source}".`,
+      {
+        context: {
+          source,
+          ref,
+        },
+        suggestion:
+          "Use a non-empty branch, tag, or commit SHA without whitespace, control characters or leading dashes.",
+      },
+    )
+  }
+
+  return {
+    owner,
+    repo,
+    ref,
+  } satisfies ResolvedGitHubRegistrySource
+}
+
+export function isGitHubRegistrySource(source: string) {
+  return resolveGitHubRegistrySource(source) !== null
+}
+
+function resolveGitHubItemAddress(address: string) {
+  const hashIndex = address.indexOf("#")
+  const source = hashIndex === -1 ? address : address.slice(0, hashIndex)
+  const ref = hashIndex === -1 ? undefined : address.slice(hashIndex + 1)
+  const parts = source.split("/")
+
+  // We need at least owner, repo and item.
+  if (parts.length < 3) {
+    return null
+  }
+
+  const [owner, repo, ...itemParts] = parts
+  if (!isGitHubOwner(owner) || !isGitHubRepo(repo)) {
+    return null
+  }
+
+  // Everything after `owner/repo` is the item name. A nested name like
+  // `owner/repo/forms/login` refers to the item named "forms/login" in the
+  // root registry.json. It is not a path to a nested registry.json.
+  const item = itemParts.join("/")
+  if (!item) {
+    return null
+  }
+
+  if (ref !== undefined && !isValidGitHubRef(ref)) {
+    throw new RegistryValidationError(
+      `Invalid GitHub ref in item address "${address}".`,
+      {
+        context: {
+          address,
+          ref,
+        },
+        suggestion:
+          "Use a non-empty branch, tag, or commit SHA without whitespace, control characters or leading dashes.",
+      },
+    )
+  }
+
+  return {
+    scheme: "github",
+    owner,
+    repo,
+    item,
+    ref,
+  } satisfies ResolvedGitHubItemAddress
+}
+
+function isGitHubOwner(owner: string) {
+  return GITHUB_OWNER_PATTERN.test(owner)
+}
+
+function isGitHubRepo(repo: string) {
+  return GITHUB_REPO_PATTERN.test(repo) && !INVALID_GITHUB_REPO_NAMES.has(repo)
+}
+
+function isValidGitHubRef(ref: string) {
+  return (
+    !!ref
+    && !CONTROL_CHARACTER_PATTERN.test(ref)
+    && !WHITESPACE_PATTERN.test(ref)
+    && !GITHUB_REF_OPTION_PATTERN.test(ref)
+  )
+}

--- a/packages/cli/src/registry/address.ts
+++ b/packages/cli/src/registry/address.ts
@@ -87,6 +87,10 @@ export function resolveItemAddress(address: string) {
   } satisfies ResolvedItemAddress
 }
 
+// Throws RegistryValidationError when the address is a GitHub address carrying
+// a malformed ref. That is deliberate: swallowing it would send something like
+// `owner/repo/button#my tag` on to the default registry, where it would fail as
+// an unknown item name and hide the real mistake.
 export function isGitHubItemAddress(address: string) {
   return resolveItemAddress(address).scheme === "github"
 }
@@ -129,6 +133,7 @@ export function resolveGitHubRegistrySource(source: string) {
   } satisfies ResolvedGitHubRegistrySource
 }
 
+// Throws on a malformed ref, for the same reason as isGitHubItemAddress.
 export function isGitHubRegistrySource(source: string) {
   return resolveGitHubRegistrySource(source) !== null
 }

--- a/packages/cli/src/registry/api.ts
+++ b/packages/cli/src/registry/api.ts
@@ -2,6 +2,7 @@ import type { Config } from "@/src/utils/get-config"
 import path from "pathe"
 import { z } from "zod"
 import { DEFAULT_PRESETS } from "@/src/preset/presets"
+import { resolveGitHubRegistrySource } from "@/src/registry/address"
 import { buildUrlAndHeadersForRegistryItem } from "@/src/registry/builder"
 import { configWithDefaults } from "@/src/registry/config"
 import {
@@ -25,6 +26,7 @@ import {
   RegistryParseError,
 } from "@/src/registry/errors"
 import { fetchRegistry } from "@/src/registry/fetcher"
+import { fetchGitHubRegistryCatalog } from "@/src/registry/github"
 import {
   fetchRegistryItems,
   resolveRegistryTree,
@@ -57,6 +59,20 @@ export async function getRegistry(
     const [result] = await fetchRegistry([name], { useCache })
     try {
       return registrySchema.parse(result)
+    }
+    catch (error) {
+      throw new RegistryParseError(name, error)
+    }
+  }
+
+  // A bare `owner/repo` (optionally `owner/repo#ref`) reads registry.json
+  // from the root of a public GitHub repository.
+  const githubSource = resolveGitHubRegistrySource(name)
+  if (githubSource) {
+    const registry = await fetchGitHubRegistryCatalog(githubSource, { useCache })
+
+    try {
+      return registrySchema.parse(registry)
     }
     catch (error) {
       throw new RegistryParseError(name, error)

--- a/packages/cli/src/registry/errors.ts
+++ b/packages/cli/src/registry/errors.ts
@@ -17,6 +17,7 @@ export const RegistryErrorCode = {
 
   // File system errors
   LOCAL_FILE_ERROR: "LOCAL_FILE_ERROR",
+  SOURCE_FILE_ERROR: "SOURCE_FILE_ERROR",
 
   // Parsing errors
   PARSE_ERROR: "PARSE_ERROR",
@@ -194,6 +195,81 @@ export class RegistryLocalFileError extends RegistryError {
       suggestion: "Check if the file exists and you have read permissions.",
     })
     this.name = "RegistryLocalFileError"
+  }
+}
+
+// Raised when an item name cannot be found inside a resolved registry.
+// Unlike RegistryNotFoundError this is not an HTTP 404 - the registry was
+// fetched and parsed, it just does not declare an item with this name.
+export class RegistryItemNotFoundError extends RegistryError {
+  constructor(
+    public readonly itemName: string,
+    options: {
+      source?: string
+      context?: Record<string, unknown>
+      suggestion?: string
+    } = {},
+  ) {
+    const message = options.source
+      ? `The item "${itemName}" was not found in ${options.source}.`
+      : `The item "${itemName}" was not found in the registry.`
+
+    super(message, {
+      code: RegistryErrorCode.NOT_FOUND,
+      context: { itemName, source: options.source, ...options.context },
+      suggestion:
+        options.suggestion
+        ?? "Check the item name against the items declared in the registry.json file.",
+    })
+    this.name = "RegistryItemNotFoundError"
+  }
+}
+
+// Raised when a registry is structurally invalid: a malformed ref, a file path
+// that escapes the registry root, a duplicate item name, and so on.
+export class RegistryValidationError extends RegistryError {
+  constructor(
+    message: string,
+    options: {
+      registryFile?: string
+      cause?: unknown
+      context?: Record<string, unknown>
+      suggestion?: string
+    } = {},
+  ) {
+    super(message, {
+      code: RegistryErrorCode.VALIDATION_ERROR,
+      cause: options.cause,
+      context: { registryFile: options.registryFile, ...options.context },
+      suggestion:
+        options.suggestion
+        ?? "Update the registry so it matches the registry schema. See https://shadcn-vue.com/schema/registry.json.",
+    })
+    this.name = "RegistryValidationError"
+  }
+}
+
+// Raised when a file backing a registry item cannot be read from its source,
+// e.g. raw.githubusercontent.com returned a non-200 for a declared file path.
+export class RegistrySourceFileError extends RegistryError {
+  constructor(
+    public readonly filePath: string,
+    cause?: unknown,
+    options: {
+      message?: string
+      context?: Record<string, unknown>
+      suggestion?: string
+    } = {},
+  ) {
+    super(options.message ?? `Failed to read source file: ${filePath}`, {
+      code: RegistryErrorCode.SOURCE_FILE_ERROR,
+      cause,
+      context: { filePath, ...options.context },
+      suggestion:
+        options.suggestion
+        ?? "Check that the file exists at the path declared in the registry.json file.",
+    })
+    this.name = "RegistrySourceFileError"
   }
 }
 

--- a/packages/cli/src/registry/fetcher.ts
+++ b/packages/cli/src/registry/fetcher.ts
@@ -3,7 +3,6 @@ import { promises as fs } from "node:fs"
 import { homedir } from "node:os"
 import { ofetch } from "ofetch"
 import path from "pathe"
-import { ProxyAgent } from "undici"
 import { z } from "zod"
 import { resolveRegistryUrl } from "@/src/registry/builder"
 import { getRegistryHeadersFromContext } from "@/src/registry/context"
@@ -15,11 +14,8 @@ import {
   RegistryParseError,
   RegistryUnauthorizedError,
 } from "@/src/registry/errors"
+import { agent } from "@/src/registry/proxy"
 import { registryItemSchema } from "@/src/schema"
-
-const agent = process.env.https_proxy
-  ? new ProxyAgent(process.env.https_proxy)
-  : undefined
 
 const registryCache = new Map<string, Promise<any>>()
 

--- a/packages/cli/src/registry/github-ref.test.ts
+++ b/packages/cli/src/registry/github-ref.test.ts
@@ -160,6 +160,35 @@ describe("gitHub ref resolution", () => {
     })
   })
 
+  it("aborts and reports a timeout when git ls-remote stalls", async () => {
+    vi.useFakeTimers()
+    try {
+      let signal: AbortSignal | undefined
+      vi.mocked(x).mockImplementationOnce(
+        (_command, _args, options: any) =>
+          new Promise((_resolve, reject) => {
+            signal = options?.signal
+            signal?.addEventListener("abort", () =>
+              reject(new Error("aborted")))
+          }) as any,
+      )
+
+      const promise = resolveGitHubRef({ owner: "acme", repo: "ui" })
+      const assertion = expect(promise).rejects.toMatchObject({
+        suggestion:
+          "GitHub ref resolution timed out. Check your network connection and try again.",
+      })
+
+      await vi.advanceTimersByTimeAsync(15_000)
+      await assertion
+
+      expect(signal?.aborted).toBe(true)
+    }
+    finally {
+      vi.useRealTimers()
+    }
+  })
+
   it("points at the public-repository requirement when git fails", async () => {
     vi.mocked(x).mockRejectedValueOnce(new Error("exited with code 128"))
 

--- a/packages/cli/src/registry/github-ref.test.ts
+++ b/packages/cli/src/registry/github-ref.test.ts
@@ -1,0 +1,196 @@
+import { x } from "tinyexec"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import {
+  getGitHubRefCandidates,
+  getPreferredGitHubRefNames,
+  parseGitLsRemote,
+  resolveGitHubRef,
+} from "./github-ref"
+
+vi.mock("tinyexec", () => ({
+  x: vi.fn(),
+}))
+
+describe("gitHub ref resolution", () => {
+  beforeEach(() => {
+    vi.mocked(x).mockReset()
+  })
+
+  it("resolves HEAD through git ls-remote", async () => {
+    vi.mocked(x).mockResolvedValueOnce({
+      stdout: [
+        "ref: refs/heads/main\tHEAD",
+        "1111111111111111111111111111111111111111\tHEAD",
+      ].join("\n"),
+    } as any)
+
+    await expect(resolveGitHubRef({ owner: "acme", repo: "ui" })).resolves.toBe(
+      "1111111111111111111111111111111111111111",
+    )
+    expect(vi.mocked(x)).toHaveBeenCalledWith(
+      "git",
+      ["ls-remote", "--symref", "--", "https://github.com/acme/ui.git", "HEAD"],
+      expect.objectContaining({ throwOnError: true }),
+    )
+  })
+
+  it("never assumes the default branch is main", async () => {
+    vi.mocked(x).mockResolvedValueOnce({
+      stdout: [
+        "ref: refs/heads/master\tHEAD",
+        "3333333333333333333333333333333333333333\tHEAD",
+      ].join("\n"),
+    } as any)
+
+    await expect(resolveGitHubRef({ owner: "acme", repo: "ui" })).resolves.toBe(
+      "3333333333333333333333333333333333333333",
+    )
+  })
+
+  it("disables the interactive git credential prompt", async () => {
+    vi.mocked(x).mockResolvedValueOnce({
+      stdout: "1111111111111111111111111111111111111111\tHEAD",
+    } as any)
+
+    await resolveGitHubRef({ owner: "acme", repo: "ui" })
+
+    expect(vi.mocked(x).mock.calls[0][2]).toMatchObject({
+      nodeOptions: {
+        env: expect.objectContaining({ GIT_TERMINAL_PROMPT: "0" }),
+      },
+    })
+  })
+
+  it("uses a full commit SHA without calling git", async () => {
+    await expect(
+      resolveGitHubRef({
+        owner: "acme",
+        repo: "ui",
+        ref: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      }),
+    ).resolves.toBe("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+    expect(vi.mocked(x)).not.toHaveBeenCalled()
+  })
+
+  it("prefers branch names before tag names for shorthand refs", () => {
+    expect(getPreferredGitHubRefNames("main")).toEqual([
+      "refs/heads/main",
+      "refs/tags/main^{}",
+      "refs/tags/main",
+      "main",
+    ])
+  })
+
+  it("prefers peeled annotated tags over tag objects", async () => {
+    vi.mocked(x).mockResolvedValueOnce({
+      stdout: [
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\trefs/tags/v1.0.0",
+        "2222222222222222222222222222222222222222\trefs/tags/v1.0.0^{}",
+      ].join("\n"),
+    } as any)
+
+    await expect(
+      resolveGitHubRef({ owner: "acme", repo: "ui", ref: "v1.0.0" }),
+    ).resolves.toBe("2222222222222222222222222222222222222222")
+  })
+
+  it("treats short SHAs as refs", async () => {
+    vi.mocked(x).mockResolvedValueOnce({ stdout: "" } as any)
+
+    await expect(
+      resolveGitHubRef({ owner: "acme", repo: "ui", ref: "abc1234" }),
+    ).rejects.toThrow("Could not resolve GitHub ref \"abc1234\"")
+    expect(vi.mocked(x)).toHaveBeenCalledWith(
+      "git",
+      [
+        "ls-remote",
+        "--symref",
+        "--",
+        "https://github.com/acme/ui.git",
+        "refs/heads/abc1234",
+        "refs/tags/abc1234^{}",
+        "refs/tags/abc1234",
+        "abc1234",
+      ],
+      expect.any(Object),
+    )
+  })
+
+  it("reuses the command-local ref cache", async () => {
+    const cache = new Map<string, Promise<string>>()
+    vi.mocked(x).mockResolvedValueOnce({
+      stdout: "1111111111111111111111111111111111111111\tHEAD",
+    } as any)
+
+    await resolveGitHubRef({ owner: "acme", repo: "ui" }, { cache })
+    await resolveGitHubRef({ owner: "acme", repo: "ui" }, { cache })
+
+    expect(vi.mocked(x)).toHaveBeenCalledTimes(1)
+  })
+
+  it("removes failed ref resolutions from the command-local cache", async () => {
+    const cache = new Map<string, Promise<string>>()
+    vi.mocked(x)
+      .mockRejectedValueOnce(new Error("exited with code 128"))
+      .mockResolvedValueOnce({
+        stdout: "1111111111111111111111111111111111111111\tHEAD",
+      } as any)
+
+    await expect(
+      resolveGitHubRef({ owner: "acme", repo: "ui" }, { cache }),
+    ).rejects.toThrow("Failed to resolve GitHub ref \"HEAD\"")
+    await expect(
+      resolveGitHubRef({ owner: "acme", repo: "ui" }, { cache }),
+    ).resolves.toBe("1111111111111111111111111111111111111111")
+
+    expect(vi.mocked(x)).toHaveBeenCalledTimes(2)
+  })
+
+  it("returns a clear missing git suggestion", async () => {
+    vi.mocked(x).mockRejectedValueOnce(
+      Object.assign(new Error("spawn git ENOENT"), { code: "ENOENT" }),
+    )
+
+    await expect(
+      resolveGitHubRef({ owner: "acme", repo: "ui" }),
+    ).rejects.toMatchObject({
+      suggestion:
+        "Install Git and try again. Git is required to resolve GitHub registry refs.",
+    })
+  })
+
+  it("points at the public-repository requirement when git fails", async () => {
+    vi.mocked(x).mockRejectedValueOnce(new Error("exited with code 128"))
+
+    await expect(
+      resolveGitHubRef({ owner: "acme", repo: "private" }),
+    ).rejects.toMatchObject({
+      suggestion:
+        "Check that the public GitHub repository exists and the ref is accessible. Private repositories are not supported.",
+    })
+  })
+})
+
+describe("gitHub ls-remote parsing", () => {
+  it("parses advertised refs and skips symref lines", () => {
+    const refs = parseGitLsRemote(
+      [
+        "ref: refs/heads/main\tHEAD",
+        "1111111111111111111111111111111111111111\tHEAD",
+        "2222222222222222222222222222222222222222\trefs/heads/main",
+      ].join("\n"),
+    )
+
+    expect(Object.fromEntries(refs)).toEqual({
+      "HEAD": "1111111111111111111111111111111111111111",
+      "refs/heads/main": "2222222222222222222222222222222222222222",
+    })
+  })
+
+  it("deduplicates ref candidates", () => {
+    expect(getGitHubRefCandidates("refs/heads/main")).toEqual([
+      "refs/heads/main",
+    ])
+  })
+})

--- a/packages/cli/src/registry/github-ref.test.ts
+++ b/packages/cli/src/registry/github-ref.test.ts
@@ -2,7 +2,6 @@ import { x } from "tinyexec"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import {
-  getGitHubRefCandidates,
   getPreferredGitHubRefNames,
   parseGitLsRemote,
   resolveGitHubRef,
@@ -195,8 +194,19 @@ describe("gitHub ref resolution", () => {
     await expect(
       resolveGitHubRef({ owner: "acme", repo: "private" }),
     ).rejects.toMatchObject({
-      suggestion:
+      suggestion: expect.stringContaining(
         "Check that the public GitHub repository exists and the ref is accessible. Private repositories are not supported.",
+      ),
+    })
+  })
+
+  it("points at the @namespace form when a repository lookup fails", async () => {
+    vi.mocked(x).mockRejectedValueOnce(new Error("exited with code 128"))
+
+    await expect(
+      resolveGitHubRef({ owner: "acme", repo: "registry" }),
+    ).rejects.toMatchObject({
+      suggestion: expect.stringContaining("prefix it with \"@\""),
     })
   })
 })
@@ -217,9 +227,16 @@ describe("gitHub ls-remote parsing", () => {
     })
   })
 
-  it("deduplicates ref candidates", () => {
-    expect(getGitHubRefCandidates("refs/heads/main")).toEqual([
+  it("asks for a fully qualified ref exactly as given", () => {
+    expect(getPreferredGitHubRefNames("refs/heads/main")).toEqual([
       "refs/heads/main",
     ])
+  })
+
+  it("never produces duplicate candidates", () => {
+    for (const ref of ["HEAD", "main", "refs/heads/main", "refs/tags/v1"]) {
+      const candidates = getPreferredGitHubRefNames(ref)
+      expect(new Set(candidates).size).toBe(candidates.length)
+    }
   })
 })

--- a/packages/cli/src/registry/github-ref.ts
+++ b/packages/cli/src/registry/github-ref.ts
@@ -6,6 +6,9 @@ import { x } from "tinyexec"
 import { RegistrySourceFileError } from "@/src/registry/errors"
 
 const GITHUB_URL = "https://github.com"
+// SHA-1 object ids only. GitHub does not serve SHA-256 repositories yet; if it
+// ever does, parseGitLsRemote will silently drop the 64-character ids and a ref
+// will look missing rather than unsupported.
 const GITHUB_SHA_PATTERN = /^[a-f0-9]{40}$/i
 const GITHUB_REF_RESOLUTION_TIMEOUT = 15_000
 
@@ -48,7 +51,7 @@ export async function resolveGitHubRef(
 
 async function resolveGitHubRefUncached(address: GitHubSource, ref: string) {
   const repoUrl = `${GITHUB_URL}/${address.owner}/${address.repo}.git`
-  const candidates = getGitHubRefCandidates(ref)
+  const candidates = getPreferredGitHubRefNames(ref)
 
   let stdout: string
   let timedOut = false
@@ -107,12 +110,9 @@ async function resolveGitHubRefUncached(address: GitHubSource, ref: string) {
   })
 }
 
-export function getGitHubRefCandidates(ref: string) {
-  return Array.from(new Set(getPreferredGitHubRefNames(ref)))
-}
-
 // Branches win over tags, and an annotated tag resolves to the commit it
-// points at (`^{}`) rather than to the tag object.
+// points at (`^{}`) rather than to the tag object. Every branch returns
+// distinct names, so this doubles as the `ls-remote` argument list.
 export function getPreferredGitHubRefNames(ref: string) {
   if (ref === "HEAD") {
     return ["HEAD"]
@@ -176,7 +176,7 @@ function getGitHubRefResolutionSuggestion(error: unknown, timedOut: boolean) {
     return "GitHub ref resolution timed out. Check your network connection and try again."
   }
 
-  return "Check that the public GitHub repository exists and the ref is accessible. Private repositories are not supported."
+  return "Check that the public GitHub repository exists and the ref is accessible. Private repositories are not supported. If you meant a registry configured in components.json, prefix it with \"@\" instead."
 }
 
 function isGitNotFoundError(error: unknown) {

--- a/packages/cli/src/registry/github-ref.ts
+++ b/packages/cli/src/registry/github-ref.ts
@@ -1,0 +1,203 @@
+import type {
+  ResolvedGitHubItemAddress,
+  ResolvedGitHubRegistrySource,
+} from "@/src/registry/address"
+import { x } from "tinyexec"
+import { RegistrySourceFileError } from "@/src/registry/errors"
+
+const GITHUB_URL = "https://github.com"
+const GITHUB_SHA_PATTERN = /^[a-f0-9]{40}$/i
+const GITHUB_REF_RESOLUTION_TIMEOUT = 15_000
+
+export type GitHubSource = ResolvedGitHubItemAddress | ResolvedGitHubRegistrySource
+
+export interface GitHubRefResolverOptions {
+  cache?: Map<string, Promise<string>>
+}
+
+// Resolves a ref to a commit SHA. When no ref is given we ask the remote for
+// HEAD, which is the repository's default branch - we never assume "main",
+// since plenty of registries still sit on "master" and a wrong guess would
+// surface as a confusing 404 on raw.githubusercontent.com.
+export async function resolveGitHubRef(
+  address: GitHubSource,
+  options: GitHubRefResolverOptions = {},
+) {
+  const ref = address.ref ?? "HEAD"
+
+  // A full SHA is already what we want to pin to.
+  if (GITHUB_SHA_PATTERN.test(ref)) {
+    return ref.toLowerCase()
+  }
+
+  const cacheKey = `${address.owner}/${address.repo}#${ref}`
+  const cached = options.cache?.get(cacheKey)
+  if (cached) {
+    return cached
+  }
+
+  const promise = resolveGitHubRefUncached(address, ref).catch((error) => {
+    // Do not cache a failure - a later attempt may succeed.
+    options.cache?.delete(cacheKey)
+    throw error
+  })
+  options.cache?.set(cacheKey, promise)
+
+  return promise
+}
+
+async function resolveGitHubRefUncached(address: GitHubSource, ref: string) {
+  const repoUrl = `${GITHUB_URL}/${address.owner}/${address.repo}.git`
+  const candidates = getGitHubRefCandidates(ref)
+
+  let stdout: string
+  let timedOut = false
+  const controller = new AbortController()
+  const timeout = setTimeout(() => {
+    timedOut = true
+    controller.abort()
+  }, GITHUB_REF_RESOLUTION_TIMEOUT)
+
+  try {
+    // `--` keeps a hostile ref from being read as a git option. The ref is
+    // validated in address.ts as well, this is the second lock on the door.
+    const result = await x(
+      "git",
+      ["ls-remote", "--symref", "--", repoUrl, ...candidates],
+      {
+        nodeOptions: {
+          env: {
+            ...process.env,
+            // Never sit at an interactive credential prompt. A private repo
+            // should fail fast rather than hang the CLI.
+            GIT_TERMINAL_PROMPT: "0",
+          },
+        },
+        signal: controller.signal,
+        throwOnError: true,
+      },
+    )
+    stdout = result.stdout
+  }
+  catch (error) {
+    throw createGitHubRefResolutionError(address, ref, repoUrl, error, timedOut)
+  }
+  finally {
+    clearTimeout(timeout)
+  }
+
+  const refs = parseGitLsRemote(stdout)
+  for (const candidate of getPreferredGitHubRefNames(ref)) {
+    const sha = refs.get(candidate)
+    if (sha) {
+      return sha
+    }
+  }
+
+  throw new RegistrySourceFileError("registry.json", undefined, {
+    message: `Could not resolve GitHub ref "${ref}" for ${address.owner}/${address.repo}.`,
+    context: {
+      reason: "github-ref-resolution",
+      source: formatGitHubSource(address),
+      ref,
+      repoUrl,
+    },
+    suggestion:
+      "Use an existing branch, tag, or full commit SHA. For example: \"owner/repo/item#main\" or \"owner/repo/item#v1.0.0\".",
+  })
+}
+
+export function getGitHubRefCandidates(ref: string) {
+  return Array.from(new Set(getPreferredGitHubRefNames(ref)))
+}
+
+// Branches win over tags, and an annotated tag resolves to the commit it
+// points at (`^{}`) rather than to the tag object.
+export function getPreferredGitHubRefNames(ref: string) {
+  if (ref === "HEAD") {
+    return ["HEAD"]
+  }
+
+  if (ref.startsWith("refs/tags/")) {
+    return [`${ref}^{}`, ref]
+  }
+
+  if (ref.startsWith("refs/")) {
+    return [ref]
+  }
+
+  return [`refs/heads/${ref}`, `refs/tags/${ref}^{}`, `refs/tags/${ref}`, ref]
+}
+
+export function parseGitLsRemote(stdout: string) {
+  const refs = new Map<string, string>()
+
+  for (const line of stdout.split("\n")) {
+    const trimmed = line.trim()
+    // `--symref` prints a `ref: refs/heads/main\tHEAD` line we do not need.
+    if (!trimmed || trimmed.startsWith("ref:")) {
+      continue
+    }
+
+    const [sha, ref] = trimmed.split(/\s+/)
+    if (sha && ref && GITHUB_SHA_PATTERN.test(sha)) {
+      refs.set(ref, sha.toLowerCase())
+    }
+  }
+
+  return refs
+}
+
+function createGitHubRefResolutionError(
+  address: GitHubSource,
+  ref: string,
+  repoUrl: string,
+  error: unknown,
+  timedOut: boolean,
+) {
+  return new RegistrySourceFileError("registry.json", error, {
+    message: `Failed to resolve GitHub ref "${ref}" for ${address.owner}/${address.repo}.`,
+    context: {
+      reason: "github-ref-resolution",
+      source: formatGitHubSource(address),
+      ref,
+      repoUrl,
+    },
+    suggestion: getGitHubRefResolutionSuggestion(error, timedOut),
+  })
+}
+
+function getGitHubRefResolutionSuggestion(error: unknown, timedOut: boolean) {
+  if (isGitNotFoundError(error)) {
+    return "Install Git and try again. Git is required to resolve GitHub registry refs."
+  }
+
+  if (timedOut) {
+    return "GitHub ref resolution timed out. Check your network connection and try again."
+  }
+
+  return "Check that the public GitHub repository exists and the ref is accessible. Private repositories are not supported."
+}
+
+function isGitNotFoundError(error: unknown) {
+  if (typeof error !== "object" || error === null) {
+    return false
+  }
+
+  if ("code" in error && error.code === "ENOENT") {
+    return true
+  }
+
+  // tinyexec surfaces the spawn failure on `cause` when throwOnError is set.
+  return (
+    "cause" in error
+    && typeof error.cause === "object"
+    && error.cause !== null
+    && "code" in error.cause
+    && error.cause.code === "ENOENT"
+  )
+}
+
+function formatGitHubSource(address: GitHubSource) {
+  return `${address.owner}/${address.repo}#${address.ref ?? "HEAD"}`
+}

--- a/packages/cli/src/registry/github.test.ts
+++ b/packages/cli/src/registry/github.test.ts
@@ -1,0 +1,351 @@
+import { http, HttpResponse } from "msw"
+import { setupServer } from "msw/node"
+import { x } from "tinyexec"
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest"
+import {
+  RegistryItemNotFoundError,
+  RegistrySourceFileError,
+  RegistryValidationError,
+} from "@/src/registry/errors"
+
+import {
+  clearGitHubSourceCache,
+  fetchGitHubRegistryCatalog,
+  fetchGitHubRegistryItem,
+} from "./github"
+
+vi.mock("tinyexec", () => ({
+  x: vi.fn(),
+}))
+
+const SHA = "1111111111111111111111111111111111111111"
+const RAW = "https://raw.githubusercontent.com"
+
+const server = setupServer()
+
+function rawUrl(filePath: string, sha = SHA) {
+  return `${RAW}/acme/ui/${sha}/${filePath}`
+}
+
+function mockFiles(files: Record<string, string>, sha = SHA) {
+  server.use(
+    ...Object.entries(files).map(([filePath, body]) =>
+      http.get(rawUrl(filePath, sha), () => HttpResponse.text(body)),
+    ),
+    http.get(`${RAW}/acme/ui/${sha}/*`, () =>
+      HttpResponse.text("Not Found", { status: 404 })),
+  )
+}
+
+function registryJson(items: unknown[]) {
+  return JSON.stringify({
+    name: "acme",
+    homepage: "https://acme.com",
+    items,
+  })
+}
+
+const BUTTON_ITEM = {
+  name: "button",
+  type: "registry:ui",
+  files: [
+    {
+      path: "registry/ui/Button.vue",
+      type: "registry:ui",
+      target: "components/ui/Button.vue",
+    },
+  ],
+}
+
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }))
+
+beforeEach(() => {
+  clearGitHubSourceCache()
+  vi.mocked(x).mockReset()
+  vi.mocked(x).mockResolvedValue({ stdout: `${SHA}\tHEAD` } as any)
+})
+
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
+
+describe("fetchGitHubRegistryItem", () => {
+  it("resolves an item from the root registry.json and inlines file content", async () => {
+    mockFiles({
+      "registry.json": registryJson([BUTTON_ITEM]),
+      "registry/ui/Button.vue": "<template><button /></template>",
+    })
+
+    const item = await fetchGitHubRegistryItem({
+      scheme: "github",
+      owner: "acme",
+      repo: "ui",
+      item: "button",
+    })
+
+    expect(item).toMatchObject({
+      name: "button",
+      type: "registry:ui",
+      files: [
+        {
+          path: "registry/ui/Button.vue",
+          target: "components/ui/Button.vue",
+          content: "<template><button /></template>",
+        },
+      ],
+    })
+  })
+
+  it("resolves an item name that contains a slash", async () => {
+    mockFiles({
+      "registry.json": registryJson([
+        { ...BUTTON_ITEM, name: "forms/login" },
+      ]),
+      "registry/ui/Button.vue": "<template><button /></template>",
+    })
+
+    const item = await fetchGitHubRegistryItem({
+      scheme: "github",
+      owner: "acme",
+      repo: "ui",
+      item: "forms/login",
+    })
+
+    expect(item.name).toBe("forms/login")
+  })
+
+  it("pins every file of an item to the resolved commit", async () => {
+    const tagSha = "2222222222222222222222222222222222222222"
+    vi.mocked(x).mockResolvedValue({
+      stdout: `${tagSha}\trefs/tags/v1.0.0^{}`,
+    } as any)
+    mockFiles(
+      {
+        "registry.json": registryJson([BUTTON_ITEM]),
+        "registry/ui/Button.vue": "pinned",
+      },
+      tagSha,
+    )
+
+    const item = await fetchGitHubRegistryItem({
+      scheme: "github",
+      owner: "acme",
+      repo: "ui",
+      item: "button",
+      ref: "v1.0.0",
+    })
+
+    expect(item.files?.[0].content).toBe("pinned")
+  })
+
+  it("passes absolute registryDependencies through untouched", async () => {
+    mockFiles({
+      "registry.json": registryJson([
+        {
+          ...BUTTON_ITEM,
+          registryDependencies: [
+            "https://lifeline-peter-lewis.vercel.app/r/lifeline.json",
+          ],
+        },
+      ]),
+      "registry/ui/Button.vue": "<template><button /></template>",
+    })
+
+    const item = await fetchGitHubRegistryItem({
+      scheme: "github",
+      owner: "acme",
+      repo: "ui",
+      item: "button",
+    })
+
+    expect(item.registryDependencies).toEqual([
+      "https://lifeline-peter-lewis.vercel.app/r/lifeline.json",
+    ])
+  })
+
+  it("explains a missing root registry.json rather than surfacing a bare 404", async () => {
+    server.use(
+      http.get(`${RAW}/acme/ui/${SHA}/*`, () =>
+        HttpResponse.text("404: Not Found", { status: 404 })),
+    )
+
+    await expect(
+      fetchGitHubRegistryItem({
+        scheme: "github",
+        owner: "acme",
+        repo: "ui",
+        item: "button",
+      }),
+    ).rejects.toMatchObject({
+      suggestion: expect.stringContaining("the repository is public"),
+    })
+  })
+
+  it("reports a missing item name against the registry it read", async () => {
+    mockFiles({ "registry.json": registryJson([BUTTON_ITEM]) })
+
+    await expect(
+      fetchGitHubRegistryItem({
+        scheme: "github",
+        owner: "acme",
+        repo: "ui",
+        item: "calendar",
+      }),
+    ).rejects.toThrow(RegistryItemNotFoundError)
+  })
+
+  it("reports a file that the registry declares but the repository lacks", async () => {
+    mockFiles({ "registry.json": registryJson([BUTTON_ITEM]) })
+
+    await expect(
+      fetchGitHubRegistryItem({
+        scheme: "github",
+        owner: "acme",
+        repo: "ui",
+        item: "button",
+      }),
+    ).rejects.toThrow(RegistrySourceFileError)
+  })
+
+  it.each([
+    ["../../../etc/passwd", "file paths cannot use parent-directory traversal"],
+    ["/etc/passwd", "file paths must be relative"],
+  ])("rejects a traversing file path %s", async (path, message) => {
+    mockFiles({
+      "registry.json": registryJson([
+        { ...BUTTON_ITEM, files: [{ path, type: "registry:ui" }] },
+      ]),
+    })
+
+    await expect(
+      fetchGitHubRegistryItem({
+        scheme: "github",
+        owner: "acme",
+        repo: "ui",
+        item: "button",
+      }),
+    ).rejects.toThrow(message)
+  })
+
+  it.each([
+    "../../.ssh/authorized_keys",
+    "/etc/passwd",
+    "~/../../.bashrc",
+  ])("rejects a file target that writes outside the project: %s", async (target) => {
+    mockFiles({
+      "registry.json": registryJson([
+        {
+          ...BUTTON_ITEM,
+          files: [
+            { path: "registry/ui/Button.vue", type: "registry:file", target },
+          ],
+        },
+      ]),
+      "registry/ui/Button.vue": "<template><button /></template>",
+    })
+
+    await expect(
+      fetchGitHubRegistryItem({
+        scheme: "github",
+        owner: "acme",
+        repo: "ui",
+        item: "button",
+      }),
+    ).rejects.toThrow(RegistryValidationError)
+  })
+
+  it("allows a ~/ target", async () => {
+    mockFiles({
+      "registry.json": registryJson([
+        {
+          ...BUTTON_ITEM,
+          files: [
+            {
+              path: "registry/ui/Button.vue",
+              type: "registry:file",
+              target: "~/components/ui/Button.vue",
+            },
+          ],
+        },
+      ]),
+      "registry/ui/Button.vue": "<template><button /></template>",
+    })
+
+    const item = await fetchGitHubRegistryItem({
+      scheme: "github",
+      owner: "acme",
+      repo: "ui",
+      item: "button",
+    })
+
+    expect(item.files?.[0].target).toBe("~/components/ui/Button.vue")
+  })
+
+  it("rejects duplicate item names", async () => {
+    mockFiles({
+      "registry.json": registryJson([BUTTON_ITEM, BUTTON_ITEM]),
+    })
+
+    await expect(
+      fetchGitHubRegistryItem({
+        scheme: "github",
+        owner: "acme",
+        repo: "ui",
+        item: "button",
+      }),
+    ).rejects.toThrow("Duplicate registry item name \"button\"")
+  })
+
+  it("resolves the ref once per repository across items", async () => {
+    mockFiles({
+      "registry.json": registryJson([
+        BUTTON_ITEM,
+        { ...BUTTON_ITEM, name: "card" },
+      ]),
+      "registry/ui/Button.vue": "<template><button /></template>",
+    })
+
+    await fetchGitHubRegistryItem({
+      scheme: "github",
+      owner: "acme",
+      repo: "ui",
+      item: "button",
+    })
+    await fetchGitHubRegistryItem({
+      scheme: "github",
+      owner: "acme",
+      repo: "ui",
+      item: "card",
+    })
+
+    expect(vi.mocked(x)).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe("fetchGitHubRegistryCatalog", () => {
+  it("lists the items a repository publishes without file content", async () => {
+    mockFiles({
+      "registry.json": registryJson([
+        BUTTON_ITEM,
+        { ...BUTTON_ITEM, name: "card" },
+      ]),
+    })
+
+    const registry = await fetchGitHubRegistryCatalog({
+      owner: "acme",
+      repo: "ui",
+    })
+
+    expect(registry.name).toBe("acme")
+    expect(registry.items.map(item => item.name)).toEqual(["button", "card"])
+    expect(registry.items[0].files?.[0]).not.toHaveProperty("content")
+  })
+})

--- a/packages/cli/src/registry/github.test.ts
+++ b/packages/cli/src/registry/github.test.ts
@@ -304,6 +304,38 @@ describe("fetchGitHubRegistryItem", () => {
     ).rejects.toThrow("Duplicate registry item name \"button\"")
   })
 
+  it("does not cache a failed file read", async () => {
+    let attempt = 0
+    server.use(
+      http.get(rawUrl("registry.json"), () =>
+        HttpResponse.text(registryJson([BUTTON_ITEM]))),
+      http.get(rawUrl("registry/ui/Button.vue"), () => {
+        attempt++
+        // 404 rather than 5xx: ofetch retries retryStatusCodes on GET, which
+        // would paper over the first failure before the cache ever saw it.
+        return attempt === 1
+          ? HttpResponse.text("404: Not Found", { status: 404 })
+          : HttpResponse.text("<template><button /></template>")
+      }),
+    )
+
+    const address = {
+      scheme: "github",
+      owner: "acme",
+      repo: "ui",
+      item: "button",
+    } as const
+
+    // A transient failure must not be replayed for the rest of the run.
+    await expect(fetchGitHubRegistryItem(address)).rejects.toThrow(
+      RegistrySourceFileError,
+    )
+
+    const item = await fetchGitHubRegistryItem(address)
+    expect(item.files?.[0].content).toBe("<template><button /></template>")
+    expect(attempt).toBe(2)
+  })
+
   it("resolves the ref once per repository across items", async () => {
     mockFiles({
       "registry.json": registryJson([

--- a/packages/cli/src/registry/github.test.ts
+++ b/packages/cli/src/registry/github.test.ts
@@ -289,7 +289,7 @@ describe("fetchGitHubRegistryItem", () => {
     expect(item.files?.[0].target).toBe("~/components/ui/Button.vue")
   })
 
-  it("rejects duplicate item names", async () => {
+  it("rejects a duplicate of the item that was asked for", async () => {
     mockFiles({
       "registry.json": registryJson([BUTTON_ITEM, BUTTON_ITEM]),
     })
@@ -302,6 +302,78 @@ describe("fetchGitHubRegistryItem", () => {
         item: "button",
       }),
     ).rejects.toThrow("Duplicate registry item name \"button\"")
+  })
+
+  it("ignores a duplicate of some other item", async () => {
+    mockFiles({
+      "registry.json": registryJson([
+        BUTTON_ITEM,
+        { ...BUTTON_ITEM, name: "card" },
+        { ...BUTTON_ITEM, name: "card" },
+      ]),
+      "registry/ui/Button.vue": "<template><button /></template>",
+    })
+
+    const item = await fetchGitHubRegistryItem({
+      scheme: "github",
+      owner: "acme",
+      repo: "ui",
+      item: "button",
+    })
+
+    expect(item.name).toBe("button")
+  })
+
+  it("ignores a malformed file path on some other item", async () => {
+    mockFiles({
+      "registry.json": registryJson([
+        BUTTON_ITEM,
+        {
+          ...BUTTON_ITEM,
+          name: "evil",
+          files: [{ path: "../../../etc/passwd", type: "registry:ui" }],
+        },
+      ]),
+      "registry/ui/Button.vue": "<template><button /></template>",
+    })
+
+    // One bad item must not make the whole repository uninstallable.
+    const item = await fetchGitHubRegistryItem({
+      scheme: "github",
+      owner: "acme",
+      repo: "ui",
+      item: "button",
+    })
+
+    expect(item.name).toBe("button")
+  })
+
+  it("reuses a fetched file even when useCache is false", async () => {
+    let attempt = 0
+    server.use(
+      http.get(rawUrl("registry.json"), () =>
+        HttpResponse.text(registryJson([BUTTON_ITEM]))),
+      http.get(rawUrl("registry/ui/Button.vue"), () => {
+        attempt++
+        return HttpResponse.text("<template><button /></template>")
+      }),
+    )
+
+    const address = {
+      scheme: "github",
+      owner: "acme",
+      repo: "ui",
+      item: "button",
+    } as const
+
+    // The raw url is pinned to a resolved commit sha, so its body cannot go
+    // stale and `useCache: false` has nothing to invalidate. Namespace
+    // discovery loads every item once before the install does, so refetching
+    // here would double the request count against raw.githubusercontent.com.
+    await fetchGitHubRegistryItem(address, { useCache: false })
+    await fetchGitHubRegistryItem(address, { useCache: false })
+
+    expect(attempt).toBe(1)
   })
 
   it("does not cache a failed file read", async () => {

--- a/packages/cli/src/registry/github.ts
+++ b/packages/cli/src/registry/github.ts
@@ -1,0 +1,162 @@
+import type { FetchError } from "ofetch"
+import type {
+  ResolvedGitHubItemAddress,
+  ResolvedGitHubRegistrySource,
+} from "@/src/registry/address"
+import type { GitHubSource } from "@/src/registry/github-ref"
+import type { RegistrySourceReader } from "@/src/registry/source"
+import { ofetch } from "ofetch"
+import { RegistrySourceFileError } from "@/src/registry/errors"
+import { resolveGitHubRef } from "@/src/registry/github-ref"
+import { agent } from "@/src/registry/proxy"
+import {
+  loadRegistryCatalogFromSource,
+  loadRegistryItemFromSource,
+} from "@/src/registry/source"
+
+const GITHUB_RAW_URL = "https://raw.githubusercontent.com"
+
+export interface GitHubSourceOptions {
+  useCache?: boolean
+  sourceCache?: Map<string, Promise<string>>
+}
+
+// Resolved refs are kept for the lifetime of the process regardless of
+// `useCache`: a `git ls-remote` per (owner, repo, ref) is the expensive part,
+// and re-resolving mid-run could pin two files of the same item to two
+// different commits.
+const githubRefCache = new Map<string, Promise<string>>()
+
+// File bodies, keyed by their fully resolved raw URL.
+const githubFileCache = new Map<string, Promise<string>>()
+
+export function clearGitHubSourceCache() {
+  githubRefCache.clear()
+  githubFileCache.clear()
+}
+
+export async function fetchGitHubRegistryItem(
+  address: ResolvedGitHubItemAddress,
+  options: GitHubSourceOptions = {},
+) {
+  const reader = createGitHubRegistrySourceReader(address, options)
+
+  return loadRegistryItemFromSource(address.item, reader, {
+    source: formatGitHubSource(address),
+  })
+}
+
+export async function fetchGitHubRegistryCatalog(
+  source: ResolvedGitHubRegistrySource,
+  options: GitHubSourceOptions = {},
+) {
+  const reader = createGitHubRegistrySourceReader(source, options)
+
+  return loadRegistryCatalogFromSource(reader, {
+    source: formatGitHubSource(source),
+  })
+}
+
+function createGitHubRegistrySourceReader(
+  address: GitHubSource,
+  options: GitHubSourceOptions,
+) {
+  const fileCache = options.sourceCache ?? githubFileCache
+  // Resolve the ref once for the whole reader, so every file of an item is
+  // read at the same commit even if the branch moves mid-install.
+  const shaPromise = resolveGitHubRef(address, { cache: githubRefCache })
+
+  return {
+    async readText(filePath: string) {
+      const sha = await shaPromise
+      const url = buildGitHubRawUrl(address, sha, filePath)
+
+      const cached = fileCache.get(url)
+      if (options.useCache !== false && cached) {
+        return cached
+      }
+
+      const promise = fetchGitHubSourceFile(url, filePath, address)
+
+      if (options.useCache !== false) {
+        fileCache.set(url, promise)
+      }
+
+      return promise
+    },
+  } satisfies RegistrySourceReader
+}
+
+async function fetchGitHubSourceFile(
+  url: string,
+  filePath: string,
+  address: GitHubSource,
+) {
+  try {
+    return await ofetch<string, "text">(url, {
+      agent,
+      dispatcher: agent,
+      responseType: "text",
+      headers: {
+        "Accept-Encoding": "identity",
+        "User-Agent": "shadcn-vue",
+      },
+    })
+  }
+  catch (error) {
+    const status = (error as FetchError)?.response?.status
+
+    throw new RegistrySourceFileError(filePath, error, {
+      message: `Failed to read GitHub source file "${filePath}" from ${formatGitHubSource(
+        address,
+      )}.`,
+      context: {
+        reason: "github-source-file",
+        url,
+        statusCode: status,
+        source: formatGitHubSource(address),
+        filePath,
+      },
+      suggestion: getGitHubSourceFileSuggestion(filePath, status),
+    })
+  }
+}
+
+function getGitHubSourceFileSuggestion(filePath: string, status?: number) {
+  if (status === undefined) {
+    return "GitHub ref resolution succeeded, but the CLI could not fetch from raw.githubusercontent.com. Check that raw.githubusercontent.com is accessible from this network."
+  }
+
+  if (status === 404 && filePath === "registry.json") {
+    // raw.githubusercontent.com does not serve private repositories, so a 404
+    // here is just as likely to mean "private" as "missing".
+    return "The GitHub repository and ref were resolved, but raw.githubusercontent.com did not return a root registry.json file. Check that the repository is public and has registry.json at its root."
+  }
+
+  if (status === 404) {
+    return "Check that the file path exists in the public GitHub repository. Private repositories are not supported."
+  }
+
+  if (status === 403 || status === 429) {
+    return "raw.githubusercontent.com rate limited this request. Wait a moment and try again."
+  }
+
+  return "Check that the file path exists in the public GitHub repository."
+}
+
+function buildGitHubRawUrl(
+  address: GitHubSource,
+  resolvedSha: string,
+  filePath: string,
+) {
+  const file = filePath
+    .split("/")
+    .map(part => encodeURIComponent(part))
+    .join("/")
+
+  return `${GITHUB_RAW_URL}/${address.owner}/${address.repo}/${resolvedSha}/${file}`
+}
+
+function formatGitHubSource(address: GitHubSource) {
+  return `${address.owner}/${address.repo}#${address.ref ?? "HEAD"}`
+}

--- a/packages/cli/src/registry/github.ts
+++ b/packages/cli/src/registry/github.ts
@@ -19,6 +19,9 @@ const GITHUB_RAW_URL = "https://raw.githubusercontent.com"
 const GITHUB_FILE_FETCH_TIMEOUT = 15_000
 
 export interface GitHubSourceOptions {
+  // Accepted so callers can pass their usual fetch options through, but
+  // ignored: everything this reader fetches is addressed by commit SHA and
+  // therefore immutable. See githubFileCache below.
   useCache?: boolean
   sourceCache?: Map<string, Promise<string>>
 }
@@ -29,7 +32,12 @@ export interface GitHubSourceOptions {
 // different commits.
 const githubRefCache = new Map<string, Promise<string>>()
 
-// File bodies, keyed by their fully resolved raw URL.
+// File bodies, keyed by their fully resolved raw URL. Kept for the lifetime of
+// the process regardless of `useCache` for the same reason as the ref cache:
+// the URL contains a resolved commit SHA, so its content is immutable by
+// construction and there is no such thing as a stale entry. This matters more
+// than it looks - namespace discovery loads every item once before the install
+// does, so without it every file of every item is fetched twice.
 const githubFileCache = new Map<string, Promise<string>>()
 
 export function clearGitHubSourceCache() {
@@ -72,10 +80,6 @@ function createGitHubRegistrySourceReader(
     async readText(filePath: string) {
       const sha = await shaPromise
       const url = buildGitHubRawUrl(address, sha, filePath)
-
-      if (options.useCache === false) {
-        return fetchGitHubSourceFile(url, filePath, address)
-      }
 
       const cached = fileCache.get(url)
       if (cached) {

--- a/packages/cli/src/registry/github.ts
+++ b/packages/cli/src/registry/github.ts
@@ -15,6 +15,8 @@ import {
 } from "@/src/registry/source"
 
 const GITHUB_RAW_URL = "https://raw.githubusercontent.com"
+// Nothing else bounds this request, so a stalled read would hang the install.
+const GITHUB_FILE_FETCH_TIMEOUT = 15_000
 
 export interface GitHubSourceOptions {
   useCache?: boolean
@@ -71,16 +73,25 @@ function createGitHubRegistrySourceReader(
       const sha = await shaPromise
       const url = buildGitHubRawUrl(address, sha, filePath)
 
+      if (options.useCache === false) {
+        return fetchGitHubSourceFile(url, filePath, address)
+      }
+
       const cached = fileCache.get(url)
-      if (options.useCache !== false && cached) {
+      if (cached) {
         return cached
       }
 
-      const promise = fetchGitHubSourceFile(url, filePath, address)
-
-      if (options.useCache !== false) {
-        fileCache.set(url, promise)
-      }
+      const promise = fetchGitHubSourceFile(url, filePath, address).catch(
+        (error) => {
+          // Do not cache a failure - a later attempt may succeed. Without this
+          // a single transient network error would be replayed for the rest of
+          // the run, the same way resolveGitHubRef evicts its own failures.
+          fileCache.delete(url)
+          throw error
+        },
+      )
+      fileCache.set(url, promise)
 
       return promise
     },
@@ -97,6 +108,7 @@ async function fetchGitHubSourceFile(
       agent,
       dispatcher: agent,
       responseType: "text",
+      timeout: GITHUB_FILE_FETCH_TIMEOUT,
       headers: {
         "Accept-Encoding": "identity",
         "User-Agent": "shadcn-vue",

--- a/packages/cli/src/registry/index.ts
+++ b/packages/cli/src/registry/index.ts
@@ -1,3 +1,16 @@
+export type {
+  ResolvedGitHubItemAddress,
+  ResolvedGitHubRegistrySource,
+  ResolvedItemAddress,
+} from "./address"
+
+export {
+  isGitHubItemAddress,
+  isGitHubRegistrySource,
+  resolveGitHubRegistrySource,
+  resolveItemAddress,
+} from "./address"
+
 export {
   getRegistriesIndex,
   getRegistry,
@@ -11,12 +24,21 @@ export {
   RegistryFetchError,
   RegistryForbiddenError,
   RegistryInvalidNamespaceError,
+  RegistryItemNotFoundError,
   RegistryLocalFileError,
   RegistryMissingEnvironmentVariablesError,
   RegistryNotConfiguredError,
   RegistryNotFoundError,
   RegistryParseError,
+  RegistrySourceFileError,
   RegistryUnauthorizedError,
+  RegistryValidationError,
 } from "./errors"
+
+export {
+  clearGitHubSourceCache,
+  fetchGitHubRegistryCatalog,
+  fetchGitHubRegistryItem,
+} from "./github"
 
 export { searchRegistries } from "./search"

--- a/packages/cli/src/registry/index.ts
+++ b/packages/cli/src/registry/index.ts
@@ -5,8 +5,6 @@ export type {
 } from "./address"
 
 export {
-  isGitHubItemAddress,
-  isGitHubRegistrySource,
   resolveGitHubRegistrySource,
   resolveItemAddress,
 } from "./address"

--- a/packages/cli/src/registry/proxy.ts
+++ b/packages/cli/src/registry/proxy.ts
@@ -1,0 +1,6 @@
+import { ProxyAgent } from "undici"
+
+// Shared by every registry fetch so we only build one agent per process.
+export const agent = process.env.https_proxy
+  ? new ProxyAgent(process.env.https_proxy)
+  : undefined

--- a/packages/cli/src/registry/resolver.ts
+++ b/packages/cli/src/registry/resolver.ts
@@ -3,10 +3,7 @@ import { createHash } from "node:crypto"
 import deepmerge from "deepmerge"
 import path from "pathe"
 import { z } from "zod"
-import {
-  isGitHubItemAddress,
-  resolveItemAddress,
-} from "@/src/registry/address"
+import { resolveItemAddress } from "@/src/registry/address"
 import {
   getRegistryBaseColor,
   getShadcnRegistryIndex,
@@ -53,7 +50,7 @@ export function resolveRegistryItemsFromRegistries(
   for (let i = 0; i < resolvedItems.length; i++) {
     // GitHub addresses carry their own location. They are never looked up in
     // the configured registries.
-    if (isGitHubItemAddress(resolvedItems[i])) {
+    if (resolveItemAddress(resolvedItems[i]).scheme === "github") {
       continue
     }
 
@@ -395,7 +392,11 @@ async function resolveDependenciesRecursively(
     visited.add(dep)
 
     // Handle GitHub addresses, URLs and local files directly.
-    if (isGitHubItemAddress(dep) || isUrl(dep) || isLocalFile(dep)) {
+    if (
+      resolveItemAddress(dep).scheme === "github"
+      || isUrl(dep)
+      || isLocalFile(dep)
+    ) {
       const [item] = await fetchRegistryItems([dep], config, options)
       if (item) {
         items.push(item)

--- a/packages/cli/src/registry/resolver.ts
+++ b/packages/cli/src/registry/resolver.ts
@@ -4,6 +4,10 @@ import deepmerge from "deepmerge"
 import path from "pathe"
 import { z } from "zod"
 import {
+  isGitHubItemAddress,
+  resolveItemAddress,
+} from "@/src/registry/address"
+import {
   getRegistryBaseColor,
   getShadcnRegistryIndex,
 } from "@/src/registry/api"
@@ -18,6 +22,7 @@ import {
   RegistryParseError,
 } from "@/src/registry/errors"
 import { fetchRegistry, fetchRegistryLocal } from "@/src/registry/fetcher"
+import { fetchGitHubRegistryItem } from "@/src/registry/github"
 import { parseRegistryAndItemFromString } from "@/src/registry/parser"
 import {
   deduplicateFilesByTarget,
@@ -46,6 +51,12 @@ export function resolveRegistryItemsFromRegistries(
   }
 
   for (let i = 0; i < resolvedItems.length; i++) {
+    // GitHub addresses carry their own location. They are never looked up in
+    // the configured registries.
+    if (isGitHubItemAddress(resolvedItems[i])) {
+      continue
+    }
+
     const resolved = buildUrlAndHeadersForRegistryItem(resolvedItems[i], config)
 
     if (resolved) {
@@ -71,6 +82,12 @@ export async function fetchRegistryItems(
 ) {
   const results = await Promise.all(
     items.map(async (item) => {
+      const address = resolveItemAddress(item)
+
+      if (address.scheme === "github") {
+        return fetchGitHubRegistryItem(address, options)
+      }
+
       if (isLocalFile(item)) {
         return fetchRegistryLocal(item)
       }
@@ -377,8 +394,8 @@ async function resolveDependenciesRecursively(
     }
     visited.add(dep)
 
-    // Handle URLs and local files directly.
-    if (isUrl(dep) || isLocalFile(dep)) {
+    // Handle GitHub addresses, URLs and local files directly.
+    if (isGitHubItemAddress(dep) || isUrl(dep) || isLocalFile(dep)) {
       const [item] = await fetchRegistryItems([dep], config, options)
       if (item) {
         items.push(item)
@@ -592,6 +609,15 @@ function computeItemHash(
 }
 
 function extractItemIdentifierFromDependency(dependency: string) {
+  const address = resolveItemAddress(dependency)
+
+  if (address.scheme === "github") {
+    return {
+      name: address.item,
+      hash: computeItemHash({ name: address.item }, dependency),
+    }
+  }
+
   if (isUrl(dependency)) {
     const url = new URL(dependency)
     const pathname = url.pathname

--- a/packages/cli/src/registry/source.ts
+++ b/packages/cli/src/registry/source.ts
@@ -1,0 +1,447 @@
+import type { z } from "zod"
+import type { Registry, RegistryItem } from "@/src/schema"
+import path from "pathe"
+import {
+  RegistryItemNotFoundError,
+  RegistryParseError,
+  RegistrySourceFileError,
+  RegistryValidationError,
+} from "@/src/registry/errors"
+import { isUrl } from "@/src/registry/utils"
+import { registryItemSchema, registrySchema } from "@/src/schema"
+
+const REGISTRY_ITEM_SCHEMA_URL
+  = "https://shadcn-vue.com/schema/registry-item.json"
+
+// A registry item can declare dozens of files. Reading them all at once is a
+// good way to get rate limited by a remote source, so cap the fan-out.
+const REGISTRY_SOURCE_READ_CONCURRENCY = 8
+
+// A registry source is anything that can hand us the text of a file by its
+// path relative to the registry root. The GitHub reader is the first
+// implementation; a local directory reader would be another.
+export interface RegistrySourceReader {
+  readText: (filePath: string) => Promise<string>
+}
+
+interface RegistryItemSource {
+  registryFile: string
+  registryDir: string
+  itemIndex: number
+}
+
+interface SourceRegistryLoadResult {
+  registry: Registry
+  itemSources: Map<RegistryItem, RegistryItemSource>
+}
+
+// Reads the registry.json at the source root, finds the named item, and
+// inlines the content of every file the item declares.
+export async function loadRegistryItemFromSource(
+  itemName: string,
+  reader: RegistrySourceReader,
+  options: {
+    registryFile?: string
+    source?: string
+  } = {},
+) {
+  const result = await readSourceRegistry(reader, options)
+  const item = result.registry.items.find(item => item.name === itemName)
+
+  if (!item) {
+    throw new RegistryItemNotFoundError(itemName, {
+      source: options.source,
+      suggestion: `Available items: ${
+        result.registry.items.map(item => item.name).join(", ") || "none"
+      }.`,
+    })
+  }
+
+  return createRegistryItemFromSource(item, result, reader)
+}
+
+// Reads the registry.json at the source root and returns the catalog of items
+// it declares, without file content.
+export async function loadRegistryCatalogFromSource(
+  reader: RegistrySourceReader,
+  options: {
+    registryFile?: string
+    source?: string
+  } = {},
+) {
+  const result = await readSourceRegistry(reader, options)
+
+  return {
+    ...result.registry,
+    items: result.registry.items.map(item =>
+      stripRegistryItemFileContent(
+        rewriteRegistryItemFilePaths(item, result.itemSources),
+      ),
+    ),
+  }
+}
+
+async function readSourceRegistry(
+  reader: RegistrySourceReader,
+  options: {
+    registryFile?: string
+    source?: string
+  } = {},
+): Promise<SourceRegistryLoadResult> {
+  const registryFile = normalizeSourcePath(
+    options.registryFile ?? "registry.json",
+  )
+  const content = await readRegistryJson(registryFile, reader, options)
+  const registry = parseRegistry(content, registryFile)
+  const registryDir = getSourceDir(registryFile)
+  const itemSources = new Map<RegistryItem, RegistryItemSource>()
+
+  registry.items.forEach((item, itemIndex) => {
+    validateRegistryItemFiles(item, registryFile, registryDir)
+    itemSources.set(item, { registryFile, registryDir, itemIndex })
+  })
+
+  validateDuplicateItems(registry.items, itemSources)
+
+  return { registry, itemSources }
+}
+
+async function createRegistryItemFromSource(
+  item: RegistryItem,
+  result: SourceRegistryLoadResult,
+  reader: RegistrySourceReader,
+) {
+  const registryItem = {
+    ...rewriteRegistryItemFilePaths(item, result.itemSources),
+    $schema: REGISTRY_ITEM_SCHEMA_URL,
+  }
+
+  await mapWithConcurrency(
+    item.files ?? [],
+    REGISTRY_SOURCE_READ_CONCURRENCY,
+    async (sourceFile, index) => {
+      const file = registryItem.files?.[index]
+      if (!file) {
+        return
+      }
+
+      const source = result.itemSources.get(item)
+      const sourcePath = joinSourcePath(
+        source?.registryDir ?? ".",
+        sourceFile.path,
+      )
+      file.content = await readRegistryItemFileContent(
+        item.name,
+        sourceFile.path,
+        sourcePath,
+        source,
+        reader,
+      )
+    },
+  )
+
+  try {
+    return registryItemSchema.parse(registryItem)
+  }
+  catch (error) {
+    throw new RegistryParseError(item.name, error)
+  }
+}
+
+async function readRegistryItemFileContent(
+  itemName: string,
+  filePath: string,
+  sourcePath: string,
+  source: RegistryItemSource | undefined,
+  reader: RegistrySourceReader,
+) {
+  try {
+    return await reader.readText(sourcePath)
+  }
+  catch (error) {
+    const isSourceFileError
+      = error instanceof RegistrySourceFileError
+        && error.context?.reason === "github-source-file"
+
+    throw new RegistrySourceFileError(sourcePath, error, {
+      message: `Failed to read file "${filePath}" for registry item "${itemName}" (${formatItemSource(
+        source,
+      )}). Expected file at ${sourcePath}.`,
+      context: {
+        registryFile: source?.registryFile,
+        itemIndex: source?.itemIndex,
+        itemName,
+        itemFilePath: filePath,
+        sourcePath,
+      },
+      suggestion:
+        isSourceFileError && error.suggestion
+          ? error.suggestion
+          : "Make sure the file path is relative to the registry.json file that declares the item.",
+    })
+  }
+}
+
+async function readRegistryJson(
+  registryFile: string,
+  reader: RegistrySourceReader,
+  options: {
+    source?: string
+  } = {},
+) {
+  try {
+    return await reader.readText(registryFile)
+  }
+  catch (error) {
+    // The GitHub reader already produces a precise message for these.
+    if (
+      error instanceof RegistrySourceFileError
+      && (error.context?.reason === "github-ref-resolution"
+        || error.context?.reason === "github-source-file")
+    ) {
+      throw error
+    }
+
+    throw new RegistrySourceFileError(registryFile, error, {
+      message: `Failed to read source registry file at ${
+        options.source ? `${options.source}/${registryFile}` : registryFile
+      }.`,
+      context: { registryFile, source: options.source },
+      suggestion:
+        "Check that the repository has a registry.json file at its root.",
+    })
+  }
+}
+
+function parseRegistry(content: string, registryFile: string) {
+  let json: unknown
+  try {
+    json = JSON.parse(content)
+  }
+  catch (error) {
+    throw new RegistryParseError(registryFile, error)
+  }
+
+  const result = registrySchema.safeParse(json)
+  if (!result.success) {
+    throw new RegistryValidationError(
+      `Invalid registry file at ${registryFile}:\n${formatZodIssues(
+        result.error,
+      )}`,
+      {
+        registryFile,
+        cause: result.error,
+        suggestion:
+          "Update the registry.json file so it matches the registry schema. See https://shadcn-vue.com/schema/registry.json.",
+      },
+    )
+  }
+
+  return result.data
+}
+
+function rewriteRegistryItemFilePaths(
+  item: RegistryItem,
+  itemSources: Map<RegistryItem, RegistryItemSource>,
+) {
+  const registryDir = itemSources.get(item)?.registryDir ?? "."
+
+  return {
+    ...item,
+    files: item.files?.map(file => ({
+      ...file,
+      // Paths in the returned item are relative to the registry root so the
+      // rest of the CLI can treat them like any other registry item.
+      path: relativeSourcePath(".", joinSourcePath(registryDir, file.path)),
+    })),
+  }
+}
+
+function stripRegistryItemFileContent(item: RegistryItem) {
+  return {
+    ...item,
+    files: item.files?.map(({ content, ...file }) => file),
+  }
+}
+
+// A registry item can write a file anywhere its `target` points. For a URL the
+// user pasted deliberately that is their call, but the bare `owner/repo/item`
+// form is zero-configuration, so a hostile registry must not be able to reach
+// outside the project. Reject traversal on both ends: the path we read from
+// and the target we would write to.
+function validateRegistryItemFiles(
+  item: RegistryItem,
+  registryFile: string,
+  registryDir: string,
+) {
+  for (const file of item.files ?? []) {
+    if (isUrl(file.path)) {
+      throw new RegistryValidationError(
+        `Invalid file path "${file.path}" for item "${item.name}" in ${registryFile}: remote file paths are not supported.`,
+        {
+          registryFile,
+          context: { itemName: item.name, filePath: file.path },
+        },
+      )
+    }
+
+    if (path.isAbsolute(file.path)) {
+      throw new RegistryValidationError(
+        `Invalid file path "${file.path}" for item "${item.name}" in ${registryFile}: file paths must be relative.`,
+        {
+          registryFile,
+          context: { itemName: item.name, filePath: file.path },
+        },
+      )
+    }
+
+    if (hasParentTraversal(file.path)) {
+      throw new RegistryValidationError(
+        `Invalid file path "${file.path}" for item "${item.name}" in ${registryFile}: file paths cannot use parent-directory traversal.`,
+        {
+          registryFile,
+          context: { itemName: item.name, filePath: file.path },
+        },
+      )
+    }
+
+    if (!isSourcePathInsideRoot(joinSourcePath(registryDir, file.path))) {
+      throw new RegistryValidationError(
+        `Invalid file path "${file.path}" for item "${item.name}" in ${registryFile}: file paths must stay inside the registry root.`,
+        {
+          registryFile,
+          context: { itemName: item.name, filePath: file.path },
+        },
+      )
+    }
+
+    validateRegistryItemFileTarget(item, file.target, registryFile)
+  }
+}
+
+function validateRegistryItemFileTarget(
+  item: RegistryItem,
+  target: string | undefined,
+  registryFile: string,
+) {
+  if (!target) {
+    return
+  }
+
+  // `~/` is the documented way to target the project root.
+  const normalizedTarget = target.startsWith("~/") ? target.slice(2) : target
+
+  if (path.isAbsolute(normalizedTarget)) {
+    throw new RegistryValidationError(
+      `Invalid file target "${target}" for item "${item.name}" in ${registryFile}: file targets must be relative to the project.`,
+      {
+        registryFile,
+        context: { itemName: item.name, target },
+      },
+    )
+  }
+
+  if (
+    hasParentTraversal(normalizedTarget)
+    || !isSourcePathInsideRoot(joinSourcePath(".", normalizedTarget))
+  ) {
+    throw new RegistryValidationError(
+      `Invalid file target "${target}" for item "${item.name}" in ${registryFile}: file targets cannot write outside the project.`,
+      {
+        registryFile,
+        context: { itemName: item.name, target },
+      },
+    )
+  }
+}
+
+function validateDuplicateItems(
+  items: RegistryItem[],
+  itemSources: Map<RegistryItem, RegistryItemSource>,
+) {
+  const seen = new Map<string, RegistryItem>()
+
+  for (const item of items) {
+    const existing = seen.get(item.name)
+    if (!existing) {
+      seen.set(item.name, item)
+      continue
+    }
+
+    throw new RegistryValidationError(
+      `Duplicate registry item name "${item.name}". Registry item names must be unique.\n`
+      + `  - ${formatItemSource(itemSources.get(existing))}\n`
+      + `  - ${formatItemSource(itemSources.get(item))}`,
+      {
+        context: { itemName: item.name },
+        suggestion:
+          "Rename one of these items so each name is unique across the registry.",
+      },
+    )
+  }
+}
+
+async function mapWithConcurrency<T>(
+  items: T[],
+  concurrency: number,
+  mapper: (item: T, index: number) => Promise<void>,
+) {
+  let nextIndex = 0
+  const workerCount = Math.min(concurrency, items.length)
+  const workers = Array.from({ length: workerCount }, async () => {
+    while (nextIndex < items.length) {
+      const itemIndex = nextIndex++
+      await mapper(items[itemIndex]!, itemIndex)
+    }
+  })
+
+  await Promise.all(workers)
+}
+
+function getSourceDir(filePath: string) {
+  const dirname = path.dirname(filePath)
+  return dirname === "." ? "." : dirname
+}
+
+function joinSourcePath(...segments: string[]) {
+  const normalized = path.normalize(path.join(...segments))
+  return normalized === "." ? "" : normalized
+}
+
+function normalizeSourcePath(filePath: string) {
+  const normalized = path.normalize(filePath)
+  return normalized.startsWith("./") ? normalized.slice(2) : normalized
+}
+
+function relativeSourcePath(from: string, to: string) {
+  const relative = path.relative(from, to)
+  return relative || path.basename(to)
+}
+
+function isSourcePathInsideRoot(filePath: string, root = ".") {
+  const relative = path.relative(root, filePath)
+  return (
+    !!relative && !relative.startsWith("..") && !path.isAbsolute(relative)
+  )
+}
+
+function hasParentTraversal(filePath: string) {
+  return filePath.split(/[/\\]+/).includes("..")
+}
+
+function formatItemSource(source: RegistryItemSource | undefined) {
+  if (!source) {
+    return "unknown source"
+  }
+
+  return `${source.registryFile} items[${source.itemIndex}]`
+}
+
+function formatZodIssues(error: z.ZodError) {
+  return error.errors
+    .map((issue) => {
+      const issuePath = issue.path.length ? issue.path.join(".") : "(root)"
+      return `  - ${issuePath}: ${issue.message}`
+    })
+    .join("\n")
+}

--- a/packages/cli/src/registry/source.ts
+++ b/packages/cli/src/registry/source.ts
@@ -46,9 +46,9 @@ export async function loadRegistryItemFromSource(
   } = {},
 ) {
   const result = await readSourceRegistry(reader, options)
-  const item = result.registry.items.find(item => item.name === itemName)
+  const matches = result.registry.items.filter(item => item.name === itemName)
 
-  if (!item) {
+  if (matches.length === 0) {
     throw new RegistryItemNotFoundError(itemName, {
       source: options.source,
       suggestion: `Available items: ${
@@ -56,6 +56,34 @@ export async function loadRegistryItemFromSource(
       }.`,
     })
   }
+
+  // Only the name we were actually asked for has to be unambiguous. A
+  // duplicate elsewhere in the file is the registry author's problem, not a
+  // reason to refuse the item in front of us.
+  if (matches.length > 1) {
+    throw new RegistryValidationError(
+      `Duplicate registry item name "${itemName}". Registry item names must be unique.\n${matches
+        .map(item => `  - ${formatItemSource(result.itemSources.get(item))}`)
+        .join("\n")}`,
+      {
+        context: { itemName },
+        suggestion:
+          "Rename one of these items so each name is unique across the registry.",
+      },
+    )
+  }
+
+  const [item] = matches
+  const source = result.itemSources.get(item)
+
+  // Validate only the item we are about to read and write. Walking every item
+  // in the file would let one malformed entry make the whole repository
+  // uninstallable.
+  validateRegistryItemFiles(
+    item,
+    source?.registryFile ?? "registry.json",
+    source?.registryDir ?? ".",
+  )
 
   return createRegistryItemFromSource(item, result, reader)
 }
@@ -97,12 +125,12 @@ async function readSourceRegistry(
   const itemSources = new Map<RegistryItem, RegistryItemSource>()
 
   registry.items.forEach((item, itemIndex) => {
-    validateRegistryItemFiles(item, registryFile, registryDir)
     itemSources.set(item, { registryFile, registryDir, itemIndex })
   })
 
-  validateDuplicateItems(registry.items, itemSources)
-
+  // File paths and duplicate names are validated per item, at the point an
+  // item is actually loaded. Listing a catalog reads nothing and writes
+  // nothing, so it does not need either check.
   return { registry, itemSources }
 }
 
@@ -355,43 +383,26 @@ function validateRegistryItemFileTarget(
   }
 }
 
-function validateDuplicateItems(
-  items: RegistryItem[],
-  itemSources: Map<RegistryItem, RegistryItemSource>,
-) {
-  const seen = new Map<string, RegistryItem>()
-
-  for (const item of items) {
-    const existing = seen.get(item.name)
-    if (!existing) {
-      seen.set(item.name, item)
-      continue
-    }
-
-    throw new RegistryValidationError(
-      `Duplicate registry item name "${item.name}". Registry item names must be unique.\n`
-      + `  - ${formatItemSource(itemSources.get(existing))}\n`
-      + `  - ${formatItemSource(itemSources.get(item))}`,
-      {
-        context: { itemName: item.name },
-        suggestion:
-          "Rename one of these items so each name is unique across the registry.",
-      },
-    )
-  }
-}
-
 async function mapWithConcurrency<T>(
   items: T[],
   concurrency: number,
   mapper: (item: T, index: number) => Promise<void>,
 ) {
   let nextIndex = 0
+  // The first failure fails the whole item, so stop handing out work instead
+  // of letting the other workers finish fetching files nobody will use.
+  let failed = false
   const workerCount = Math.min(concurrency, items.length)
   const workers = Array.from({ length: workerCount }, async () => {
-    while (nextIndex < items.length) {
+    while (nextIndex < items.length && !failed) {
       const itemIndex = nextIndex++
-      await mapper(items[itemIndex]!, itemIndex)
+      try {
+        await mapper(items[itemIndex]!, itemIndex)
+      }
+      catch (error) {
+        failed = true
+        throw error
+      }
     }
   })
 

--- a/packages/cli/src/utils/updaters/update-files.ts
+++ b/packages/cli/src/utils/updaters/update-files.ts
@@ -9,6 +9,7 @@ import path, { basename } from 'pathe'
 import prompts from 'prompts'
 import { transform as metaTransform } from 'vue-metamorph'
 import { getRegistryBaseColor } from '@/src/registry/api'
+import { RegistryValidationError } from '@/src/registry/errors'
 import { isContentSame } from '@/src/utils/compare'
 import {
   findExistingEnvFile,
@@ -336,7 +337,11 @@ export function resolveFilePath(
 
   if (file.target) {
     if (file.target.startsWith('~/')) {
-      return path.join(config.resolvedPaths.cwd, file.target.replace('~/', ''))
+      return assertPathWithin(
+        path.join(config.resolvedPaths.cwd, file.target.replace('~/', '')),
+        config.resolvedPaths.cwd,
+        file,
+      )
     }
 
     let target = file.target
@@ -352,13 +357,53 @@ export function resolveFilePath(
     //   ? path.join(config.resolvedPaths.cwd, 'src', target.replace('src/', ''))
     //   : path.join(config.resolvedPaths.cwd, target.replace('src/', ''))
 
-    return path.join(config.resolvedPaths.cwd, target.replace('src/', ''))
+    return assertPathWithin(
+      path.join(config.resolvedPaths.cwd, target.replace('src/', '')),
+      config.resolvedPaths.cwd,
+      file,
+    )
   }
 
   const targetDir = resolveFileTargetDirectory(file, config)
 
   const relativePath = resolveNestedFilePath(file.path, options.commonRoot, config)
-  return path.join(targetDir!, relativePath)
+  return assertPathWithin(path.join(targetDir!, relativePath), targetDir!, file)
+}
+
+// `path` and `target` come from whatever registry the user installed from, and
+// the CLI joins them onto a directory it trusts. A `..` in either one would let
+// a registry write outside the project, so refuse before we ever open a file
+// handle. The `--path` branch above is deliberately exempt: an absolute path
+// there is the user's own instruction, not the registry's.
+function assertPathWithin(
+  resolvedPath: string,
+  root: string,
+  file: z.infer<typeof registryItemFileSchema>,
+) {
+  const relative = path.relative(root, resolvedPath)
+  const escapes
+    = !relative
+      || relative === '..'
+      || relative.startsWith('../')
+      || path.isAbsolute(relative)
+
+  if (escapes) {
+    throw new RegistryValidationError(
+      `Invalid file target for "${file.path}": resolves to "${resolvedPath}", outside "${root}".`,
+      {
+        context: {
+          filePath: file.path,
+          target: file.target,
+          resolvedPath,
+          root,
+        },
+        suggestion:
+          'A registry item can only write files inside the project. Report this to the author of the registry you installed from.',
+      },
+    )
+  }
+
+  return resolvedPath
 }
 
 function resolveFileTargetDirectory(

--- a/packages/cli/test/utils/updaters/update-files.test.ts
+++ b/packages/cli/test/utils/updaters/update-files.test.ts
@@ -1,6 +1,11 @@
+import type { Config } from '../../../src/utils/get-config'
 import { describe, expect, it } from 'vitest'
 
-import { resolveTargetDir } from '../../../src/utils/updaters/update-files'
+import { RegistryValidationError } from '../../../src/registry/errors'
+import {
+  resolveFilePath,
+  resolveTargetDir,
+} from '../../../src/utils/updaters/update-files'
 
 // TODO: `isSrcDir` is not being use yet
 describe.todo('resolveTargetDir', () => {
@@ -62,5 +67,89 @@ describe.todo('resolveTargetDir', () => {
       './components/ui/button.ts',
     )
     expect(targetDir).toBe('/foo/bar/components/ui/button.ts')
+  })
+})
+
+describe('resolveFilePath containment', () => {
+  const config = {
+    typescript: true,
+    aliases: {
+      components: '@/components',
+      ui: '@/components/ui',
+      lib: '@/lib',
+      composables: '@/composables',
+      utils: '@/lib/utils',
+    },
+    resolvedPaths: {
+      cwd: '/project',
+      ui: '/project/components/ui',
+      lib: '/project/lib',
+      components: '/project/components',
+      composables: '/project/composables',
+    },
+  } as unknown as Config
+
+  it('resolves an ordinary target inside the project', () => {
+    expect(
+      resolveFilePath(
+        { path: 'ui/Button.vue', type: 'registry:file', target: 'components/ui/Button.vue' },
+        config,
+        { commonRoot: '' },
+      ),
+    ).toBe('/project/components/ui/Button.vue')
+  })
+
+  it('resolves a ~/ target against the project root', () => {
+    expect(
+      resolveFilePath(
+        { path: 'env', type: 'registry:file', target: '~/.env.local' },
+        config,
+        { commonRoot: '' },
+      ),
+    ).toBe('/project/.env.local')
+  })
+
+  it.each([
+    '../../../.bashrc',
+    '../outside.txt',
+    '~/../../.ssh/authorized_keys',
+  ])('rejects a target that escapes the project: %s', (target) => {
+    expect(() =>
+      resolveFilePath(
+        { path: 'ui/Button.vue', type: 'registry:file', target },
+        config,
+        { commonRoot: '' },
+      ),
+    ).toThrow(RegistryValidationError)
+  })
+
+  it('rejects a traversing path when the item declares no target', () => {
+    expect(() =>
+      resolveFilePath(
+        { path: '../../../etc/passwd', type: 'registry:ui' },
+        config,
+        { commonRoot: '' },
+      ),
+    ).toThrow(RegistryValidationError)
+  })
+
+  it('allows a leading-dots file name that does not actually escape', () => {
+    expect(
+      resolveFilePath(
+        { path: 'x', type: 'registry:file', target: '..config.json' },
+        config,
+        { commonRoot: '' },
+      ),
+    ).toBe('/project/..config.json')
+  })
+
+  it('does not constrain an explicit --path given by the user', () => {
+    expect(
+      resolveFilePath(
+        { path: 'ui/Button.vue', type: 'registry:file' },
+        config,
+        { commonRoot: '', path: '/somewhere/else', fileIndex: 0 },
+      ),
+    ).toBe('/somewhere/else/Button.vue')
   })
 })


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #1911

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Adds a third `add` specifier alongside URLs and `@namespace/item`, so a registry in a public GitHub repository installs with no configuration at all:

```bash
npx shadcn-vue@latest add owner/repo/item
npx shadcn-vue@latest add owner/repo/item#v1.0.0
npx shadcn-vue@latest search owner/repo          # list what a repo publishes
```

The CLI resolves the repository's default branch, reads `registry.json` from the root over `raw.githubusercontent.com`, finds the item by name, and fetches its files from that same commit. This mirrors the resolution scheme in `shadcn` (`packages/shadcn/src/registry/{address,github,github-ref,source}.ts`), so a registry that works with the React CLI works here unchanged.

**New files** (`packages/cli/src/registry/`)

| File | |
| --- | --- |
| `address.ts` | classifies a specifier; validates owner/repo/ref before any network call |
| `github-ref.ts` | resolves a ref to a commit SHA via `git ls-remote`, cached per repository |
| `source.ts` | reads a `registry.json` through a reader abstraction and inlines item file content |
| `github.ts` | the `raw.githubusercontent.com` reader |
| `proxy.ts` | the shared `undici` agent, lifted out of `fetcher.ts` so both fetchers use one |

**Wired into** `resolver.ts` (routing), `api.ts` (`getRegistry` accepts `owner/repo`), `errors.ts` (three new error types), `index.ts` (exports).

#### Notes for review

- **The default branch is resolved, never assumed.** `git ls-remote --symref` gives us `HEAD`, so registries on `master` work. This does mean Git is required for this scheme — it is also what keeps us off the GitHub API and its 60-requests/hour unauthenticated limit. Branches win over tags when a name is ambiguous, and annotated tags resolve to the commit they point at.
- **Every file of an item comes from one commit.** The ref is resolved once per reader, so a branch that moves mid-install cannot produce a half-updated component.
- **Path traversal is rejected.** `resolveFilePath` in `update-files.ts` joins `files[].target` onto the project root with no traversal check. For a URL someone pasted deliberately that is their call, but this form takes no configuration from the user, so absolute and `..`-traversing values in both `path` and `target` are rejected for source-loaded items.
- **Caching.** Resolved refs are kept for the process (a `git ls-remote` per repo is the expensive part); file bodies are cached by resolved raw URL and honour `useCache`. Item file reads are capped at 8 concurrent requests.
- **`registryDependencies` are unchanged.** A full URL is fetched as-is; a bare name resolves against the default registry, exactly as for any other item. Matching the React CLI here rather than resolving bare names within the same repo.
- **Nested item names.** `owner/repo/forms/login` is the item *named* `forms/login` in the root `registry.json`, not a path to a nested one. Documented.
- **Not included:** `validateGitHubRegistrySource` from the reference, since `shadcn-vue` has no `registry validate` command to call it. Easy to add if one lands.

#### Testing

66 new tests across `address.test.ts`, `github-ref.test.ts`, and `github.test.ts` — the last drives the whole path end to end with `msw`, covering ref pinning, a missing root `registry.json`, an unknown item name, duplicate item names, and traversal rejection.

Also verified live against a real registry (39 files, two-level `registryDependencies` chain, no `components.json` entry):

```bash
npx shadcn-vue add peter-lewis/lifeline/personal
```

and confirmed the existing `@namespace/item` and URL forms still install correctly.

`pnpm test` passes from the root. No dependency or lockfile changes.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for installing registry components directly from public GitHub repositories.
  * Added optional branch, tag, or commit references, including automatic default-branch resolution.
  * Added support for GitHub catalogs, dependencies, namespaced items, and direct component paths.
  * Added validation for repository references, file paths, registry contents, and missing items with clearer error guidance.

* **Documentation**
  * Expanded CLI and registry documentation with GitHub installation formats, requirements, dependency handling, and safety restrictions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->