### PR TITLE
docs: add Formisch guide to forms docs

### DIFF
--- a/apps/v4/components/demo/FormischArray.vue
+++ b/apps/v4/components/demo/FormischArray.vue
@@ -1,0 +1,166 @@
+<script setup lang="ts">
+import type { SubmitHandler } from '@formisch/vue'
+import {
+  FieldArray,
+  Form,
+  Field as FormischField,
+  insert,
+  remove,
+  reset,
+  useForm,
+} from '@formisch/vue'
+import { XIcon } from '@lucide/vue'
+import * as v from 'valibot'
+import { toast } from 'vue-sonner'
+
+import { Button } from '@/registry/new-york-v4/ui/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/registry/new-york-v4/ui/card'
+import {
+  Field,
+  FieldContent,
+  FieldDescription,
+  FieldError,
+  FieldGroup,
+  FieldLegend,
+  FieldSet,
+} from '@/registry/new-york-v4/ui/field'
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput,
+} from '@/registry/new-york-v4/ui/input-group'
+
+const FormSchema = v.object({
+  emails: v.pipe(
+    v.array(
+      v.object({
+        address: v.pipe(
+          v.string(),
+          v.nonEmpty('Enter an email address.'),
+          v.email('Enter a valid email address.'),
+        ),
+      }),
+    ),
+    v.minLength(1, 'Add at least one email address.'),
+    v.maxLength(5, 'You can add up to 5 email addresses.'),
+  ),
+})
+
+const form = useForm({
+  schema: FormSchema,
+  initialInput: {
+    emails: [{ address: '' }, { address: '' }],
+  },
+})
+
+const handleSubmit: SubmitHandler<typeof FormSchema> = (output) => {
+  toast('You submitted the following values:', {
+    description: h('pre', { class: 'bg-code text-code-foreground mt-2 w-[320px] overflow-x-auto rounded-md p-4' }, h('code', JSON.stringify(output, null, 2))),
+    position: 'bottom-right',
+    class: 'flex flex-col gap-2',
+    style: {
+      '--border-radius': 'calc(var(--radius)  + 4px)',
+    },
+  })
+}
+</script>
+
+<template>
+  <Card class="w-full sm:max-w-md">
+    <CardHeader class="border-b">
+      <CardTitle>Contact Emails</CardTitle>
+      <CardDescription>Manage your contact email addresses.</CardDescription>
+    </CardHeader>
+    <CardContent>
+      <Form id="form-formisch-array" :of="form" @submit="handleSubmit">
+        <FieldArray v-slot="fieldArray" :of="form" :path="['emails']">
+          <FieldSet class="gap-4">
+            <FieldLegend variant="label">
+              Email Addresses
+            </FieldLegend>
+            <FieldDescription>
+              Add up to 5 email addresses where we can contact you.
+            </FieldDescription>
+            <FieldGroup class="gap-4">
+              <FormischField
+                v-for="(item, index) in fieldArray.items"
+                :key="item"
+                v-slot="field"
+                :of="form"
+                :path="['emails', index, 'address']"
+              >
+                <Field
+                  orientation="horizontal"
+                  :data-invalid="field.errors !== null"
+                >
+                  <FieldContent>
+                    <InputGroup>
+                      <InputGroupInput
+                        :id="`form-formisch-array-email-${index}`"
+                        v-model="field.input"
+                        v-bind="field.props"
+                        :aria-invalid="field.errors !== null"
+                        placeholder="name@example.com"
+                        type="email"
+                        autocomplete="email"
+                      />
+                      <InputGroupAddon
+                        v-if="fieldArray.items.length > 1"
+                        align="inline-end"
+                      >
+                        <InputGroupButton
+                          type="button"
+                          variant="ghost"
+                          size="icon-xs"
+                          :aria-label="`Remove email ${index + 1}`"
+                          @click="remove(form, { path: ['emails'], at: index })"
+                        >
+                          <XIcon />
+                        </InputGroupButton>
+                      </InputGroupAddon>
+                    </InputGroup>
+                    <FieldError
+                      v-if="field.errors"
+                      :errors="field.errors.map(message => ({ message }))"
+                    />
+                  </FieldContent>
+                </Field>
+              </FormischField>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                :disabled="fieldArray.items.length >= 5"
+                @click="insert(form, { path: ['emails'], initialInput: { address: '' } })"
+              >
+                Add Email Address
+              </Button>
+            </FieldGroup>
+            <FieldError
+              v-if="fieldArray.errors"
+              :errors="fieldArray.errors.map(message => ({ message }))"
+            />
+          </FieldSet>
+        </FieldArray>
+      </Form>
+    </CardContent>
+    <CardFooter class="border-t">
+      <Field orientation="horizontal">
+        <Button type="button" variant="outline" @click="reset(form)">
+          Reset
+        </Button>
+        <Button type="submit" form="form-formisch-array">
+          Save
+        </Button>
+      </Field>
+    </CardFooter>
+  </Card>
+</template>

--- a/apps/v4/components/demo/FormischCheckbox.vue
+++ b/apps/v4/components/demo/FormischCheckbox.vue
@@ -1,0 +1,169 @@
+<script setup lang="ts">
+import type { SubmitHandler } from '@formisch/vue'
+import { Form, Field as FormischField, reset, useForm } from '@formisch/vue'
+import * as v from 'valibot'
+import { toast } from 'vue-sonner'
+
+import { Button } from '@/registry/new-york-v4/ui/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/registry/new-york-v4/ui/card'
+import { Checkbox } from '@/registry/new-york-v4/ui/checkbox'
+import {
+  Field,
+  FieldDescription,
+  FieldError,
+  FieldGroup,
+  FieldLabel,
+  FieldLegend,
+  FieldSeparator,
+  FieldSet,
+} from '@/registry/new-york-v4/ui/field'
+
+const tasks = [
+  {
+    id: 'push',
+    label: 'Push notifications',
+  },
+  {
+    id: 'email',
+    label: 'Email notifications',
+  },
+] as const
+
+const FormSchema = v.object({
+  responses: v.boolean(),
+  tasks: v.pipe(
+    v.array(v.string()),
+    v.minLength(1, 'Please select at least one notification type.'),
+    v.check(
+      value => value.every(task => tasks.some(t => t.id === task)),
+      'Invalid notification type selected.',
+    ),
+  ),
+})
+
+const form = useForm({
+  schema: FormSchema,
+  initialInput: {
+    responses: true,
+    tasks: [],
+  },
+})
+
+const handleSubmit: SubmitHandler<typeof FormSchema> = (output) => {
+  toast('You submitted the following values:', {
+    description: h('pre', { class: 'bg-code text-code-foreground mt-2 w-[320px] overflow-x-auto rounded-md p-4' }, h('code', JSON.stringify(output, null, 2))),
+    position: 'bottom-right',
+    class: 'flex flex-col gap-2',
+    style: {
+      '--border-radius': 'calc(var(--radius)  + 4px)',
+    },
+  })
+}
+</script>
+
+<template>
+  <Card class="w-full sm:max-w-md">
+    <CardHeader>
+      <CardTitle>Notifications</CardTitle>
+      <CardDescription>Manage your notification preferences.</CardDescription>
+    </CardHeader>
+    <CardContent>
+      <Form id="form-formisch-checkbox" :of="form" @submit="handleSubmit">
+        <FieldGroup>
+          <FormischField v-slot="field" :of="form" :path="['responses']">
+            <div>
+              <FieldSet :data-invalid="field.errors !== null">
+                <FieldLegend variant="label">
+                  Responses
+                </FieldLegend>
+                <FieldDescription>
+                  Get notified for requests that take time, like research or
+                  image generation.
+                </FieldDescription>
+                <FieldGroup data-slot="checkbox-group">
+                  <Field orientation="horizontal">
+                    <Checkbox
+                      id="form-formisch-checkbox-responses"
+                      :model-value="field.input ?? false"
+                      disabled
+                      @update:model-value="(checked) => field.input = checked === true"
+                    />
+                    <FieldLabel
+                      for="form-formisch-checkbox-responses"
+                      class="font-normal"
+                    >
+                      Push notifications
+                    </FieldLabel>
+                  </Field>
+                </FieldGroup>
+              </FieldSet>
+              <FieldError
+                v-if="field.errors"
+                :errors="field.errors.map(message => ({ message }))"
+              />
+            </div>
+          </FormischField>
+          <FieldSeparator />
+          <FormischField v-slot="field" :of="form" :path="['tasks']">
+            <FieldGroup>
+              <FieldSet :data-invalid="field.errors !== null">
+                <FieldLegend variant="label">
+                  Tasks
+                </FieldLegend>
+                <FieldDescription>
+                  Get notified when tasks you've created have updates.
+                </FieldDescription>
+                <FieldGroup data-slot="checkbox-group">
+                  <Field
+                    v-for="task in tasks"
+                    :key="task.id"
+                    orientation="horizontal"
+                    :data-invalid="field.errors !== null"
+                  >
+                    <Checkbox
+                      :id="`form-formisch-checkbox-${task.id}`"
+                      :aria-invalid="field.errors !== null"
+                      :model-value="(field.input ?? []).includes(task.id)"
+                      @update:model-value="(checked) => {
+                        field.input = checked === true
+                          ? [...(field.input ?? []), task.id]
+                          : (field.input ?? []).filter(value => value !== task.id)
+                      }"
+                    />
+                    <FieldLabel
+                      :for="`form-formisch-checkbox-${task.id}`"
+                      class="font-normal"
+                    >
+                      {{ task.label }}
+                    </FieldLabel>
+                  </Field>
+                </FieldGroup>
+              </FieldSet>
+              <FieldError
+                v-if="field.errors"
+                :errors="field.errors.map(message => ({ message }))"
+              />
+            </FieldGroup>
+          </FormischField>
+        </FieldGroup>
+      </Form>
+    </CardContent>
+    <CardFooter>
+      <Field orientation="horizontal">
+        <Button type="button" variant="outline" @click="reset(form)">
+          Reset
+        </Button>
+        <Button type="submit" form="form-formisch-checkbox">
+          Save
+        </Button>
+      </Field>
+    </CardFooter>
+  </Card>
+</template>

--- a/apps/v4/components/demo/FormischComplex.vue
+++ b/apps/v4/components/demo/FormischComplex.vue
@@ -1,0 +1,279 @@
+<script setup lang="ts">
+import type { SubmitHandler } from '@formisch/vue'
+import { Form, Field as FormischField, reset, useForm } from '@formisch/vue'
+import * as v from 'valibot'
+import { toast } from 'vue-sonner'
+
+import { Button } from '@/registry/new-york-v4/ui/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/registry/new-york-v4/ui/card'
+import { Checkbox } from '@/registry/new-york-v4/ui/checkbox'
+import {
+  Field,
+  FieldContent,
+  FieldDescription,
+  FieldError,
+  FieldGroup,
+  FieldLabel,
+  FieldLegend,
+  FieldSeparator,
+  FieldSet,
+  FieldTitle,
+} from '@/registry/new-york-v4/ui/field'
+import {
+  RadioGroup,
+  RadioGroupItem,
+} from '@/registry/new-york-v4/ui/radio-group'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/registry/new-york-v4/ui/select'
+import { Switch } from '@/registry/new-york-v4/ui/switch'
+
+const addons = [
+  {
+    id: 'analytics',
+    title: 'Analytics',
+    description: 'Advanced analytics and reporting',
+  },
+  {
+    id: 'backup',
+    title: 'Backup',
+    description: 'Automated daily backups',
+  },
+  {
+    id: 'support',
+    title: 'Priority Support',
+    description: '24/7 premium customer support',
+  },
+] as const
+
+const FormSchema = v.object({
+  plan: v.pipe(
+    v.string(),
+    v.minLength(1, 'Please select a subscription plan'),
+    v.check(
+      value => value === 'basic' || value === 'pro',
+      'Invalid plan selection. Please choose Basic or Pro',
+    ),
+  ),
+  billingPeriod: v.pipe(
+    v.string(),
+    v.minLength(1, 'Please select a billing period'),
+  ),
+  addons: v.pipe(
+    v.array(v.string()),
+    v.minLength(1, 'Please select at least one add-on'),
+    v.maxLength(3, 'You can select up to 3 add-ons'),
+    v.check(
+      value => value.every(addon => addons.some(a => a.id === addon)),
+      'You selected an invalid add-on',
+    ),
+  ),
+  emailNotifications: v.boolean(),
+})
+
+const form = useForm({
+  schema: FormSchema,
+  initialInput: {
+    plan: 'basic',
+    billingPeriod: '',
+    addons: [],
+    emailNotifications: false,
+  },
+})
+
+const handleSubmit: SubmitHandler<typeof FormSchema> = (output) => {
+  toast('You submitted the following values:', {
+    description: h('pre', { class: 'bg-code text-code-foreground mt-2 w-[320px] overflow-x-auto rounded-md p-4' }, h('code', JSON.stringify(output, null, 2))),
+    position: 'bottom-right',
+    class: 'flex flex-col gap-2',
+    style: {
+      '--border-radius': 'calc(var(--radius)  + 4px)',
+    },
+  })
+}
+</script>
+
+<template>
+  <Card class="w-full max-w-sm">
+    <CardHeader class="border-b">
+      <CardTitle>You're almost there!</CardTitle>
+      <CardDescription>
+        Choose your subscription plan and billing period.
+      </CardDescription>
+    </CardHeader>
+    <CardContent>
+      <Form id="form-formisch-complex" :of="form" @submit="handleSubmit">
+        <FieldGroup>
+          <FormischField v-slot="field" :of="form" :path="['plan']">
+            <FieldSet :data-invalid="field.errors !== null">
+              <FieldLegend variant="label">
+                Subscription Plan
+              </FieldLegend>
+              <FieldDescription>
+                Choose your subscription plan.
+              </FieldDescription>
+              <RadioGroup
+                v-model="field.input"
+                :aria-invalid="field.errors !== null"
+              >
+                <FieldLabel for="form-formisch-complex-basic">
+                  <Field orientation="horizontal">
+                    <FieldContent>
+                      <FieldTitle>Basic</FieldTitle>
+                      <FieldDescription>
+                        For individuals and small teams
+                      </FieldDescription>
+                    </FieldContent>
+                    <RadioGroupItem
+                      id="form-formisch-complex-basic"
+                      value="basic"
+                    />
+                  </Field>
+                </FieldLabel>
+                <FieldLabel for="form-formisch-complex-pro">
+                  <Field orientation="horizontal">
+                    <FieldContent>
+                      <FieldTitle>Pro</FieldTitle>
+                      <FieldDescription>
+                        For businesses with higher demands
+                      </FieldDescription>
+                    </FieldContent>
+                    <RadioGroupItem
+                      id="form-formisch-complex-pro"
+                      value="pro"
+                    />
+                  </Field>
+                </FieldLabel>
+              </RadioGroup>
+              <FieldError
+                v-if="field.errors"
+                :errors="field.errors.map(message => ({ message }))"
+              />
+            </FieldSet>
+          </FormischField>
+          <FieldSeparator />
+          <FormischField v-slot="field" :of="form" :path="['billingPeriod']">
+            <Field :data-invalid="field.errors !== null">
+              <FieldLabel for="form-formisch-complex-billingPeriod">
+                Billing Period
+              </FieldLabel>
+              <Select v-model="field.input">
+                <SelectTrigger
+                  id="form-formisch-complex-billingPeriod"
+                  :aria-invalid="field.errors !== null"
+                >
+                  <SelectValue placeholder="Select" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="monthly">
+                    Monthly
+                  </SelectItem>
+                  <SelectItem value="yearly">
+                    Yearly
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+              <FieldDescription>
+                Choose how often you want to be billed.
+              </FieldDescription>
+              <FieldError
+                v-if="field.errors"
+                :errors="field.errors.map(message => ({ message }))"
+              />
+            </Field>
+          </FormischField>
+          <FieldSeparator />
+          <FormischField v-slot="field" :of="form" :path="['addons']">
+            <FieldSet>
+              <FieldLegend>Add-ons</FieldLegend>
+              <FieldDescription>
+                Select additional features you'd like to include.
+              </FieldDescription>
+              <FieldGroup data-slot="checkbox-group">
+                <Field
+                  v-for="addon in addons"
+                  :key="addon.id"
+                  orientation="horizontal"
+                  :data-invalid="field.errors !== null"
+                >
+                  <Checkbox
+                    :id="`form-formisch-complex-${addon.id}`"
+                    :aria-invalid="field.errors !== null"
+                    :model-value="(field.input ?? []).includes(addon.id)"
+                    @update:model-value="(checked) => {
+                      field.input = checked === true
+                        ? [...(field.input ?? []), addon.id]
+                        : (field.input ?? []).filter(value => value !== addon.id)
+                    }"
+                  />
+                  <FieldContent>
+                    <FieldLabel :for="`form-formisch-complex-${addon.id}`">
+                      {{ addon.title }}
+                    </FieldLabel>
+                    <FieldDescription>
+                      {{ addon.description }}
+                    </FieldDescription>
+                  </FieldContent>
+                </Field>
+              </FieldGroup>
+              <FieldError
+                v-if="field.errors"
+                :errors="field.errors.map(message => ({ message }))"
+              />
+            </FieldSet>
+          </FormischField>
+          <FieldSeparator />
+          <FormischField
+            v-slot="field"
+            :of="form"
+            :path="['emailNotifications']"
+          >
+            <Field
+              orientation="horizontal"
+              :data-invalid="field.errors !== null"
+            >
+              <FieldContent>
+                <FieldLabel for="form-formisch-complex-emailNotifications">
+                  Email Notifications
+                </FieldLabel>
+                <FieldDescription>
+                  Receive email updates about your subscription
+                </FieldDescription>
+              </FieldContent>
+              <Switch
+                id="form-formisch-complex-emailNotifications"
+                v-model="field.input"
+                :aria-invalid="field.errors !== null"
+              />
+              <FieldError
+                v-if="field.errors"
+                :errors="field.errors.map(message => ({ message }))"
+              />
+            </Field>
+          </FormischField>
+        </FieldGroup>
+      </Form>
+    </CardContent>
+    <CardFooter class="border-t">
+      <Field>
+        <Button type="submit" form="form-formisch-complex">
+          Save Preferences
+        </Button>
+        <Button type="button" variant="outline" @click="reset(form)">
+          Reset
+        </Button>
+      </Field>
+    </CardFooter>
+  </Card>
+</template>

--- a/apps/v4/components/demo/FormischDemo.vue
+++ b/apps/v4/components/demo/FormischDemo.vue
@@ -1,0 +1,147 @@
+<script setup lang="ts">
+import type { SubmitHandler } from '@formisch/vue'
+import { Form, Field as FormischField, reset, useForm } from '@formisch/vue'
+import * as v from 'valibot'
+import { toast } from 'vue-sonner'
+
+import { Button } from '@/registry/new-york-v4/ui/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/registry/new-york-v4/ui/card'
+import {
+  Field,
+  FieldDescription,
+  FieldError,
+  FieldGroup,
+  FieldLabel,
+} from '@/registry/new-york-v4/ui/field'
+import { Input } from '@/registry/new-york-v4/ui/input'
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupText,
+  InputGroupTextarea,
+} from '@/registry/new-york-v4/ui/input-group'
+
+const FormSchema = v.object({
+  title: v.pipe(
+    v.string(),
+    v.minLength(5, 'Bug title must be at least 5 characters.'),
+    v.maxLength(32, 'Bug title must be at most 32 characters.'),
+  ),
+  description: v.pipe(
+    v.string(),
+    v.minLength(20, 'Description must be at least 20 characters.'),
+    v.maxLength(100, 'Description must be at most 100 characters.'),
+  ),
+})
+
+const form = useForm({
+  schema: FormSchema,
+  initialInput: {
+    title: '',
+    description: '',
+  },
+})
+
+const handleSubmit: SubmitHandler<typeof FormSchema> = (output) => {
+  toast('You submitted the following values:', {
+    description: h(
+      'pre',
+      {
+        class:
+          'bg-code text-code-foreground mt-2 w-[320px] overflow-x-auto rounded-md p-4',
+      },
+      h('code', JSON.stringify(output, null, 2)),
+    ),
+    position: 'bottom-right',
+    class: 'flex flex-col gap-2',
+    style: {
+      '--border-radius': 'calc(var(--radius)  + 4px)',
+    },
+  })
+}
+</script>
+
+<template>
+  <Card class="w-full sm:max-w-md">
+    <CardHeader>
+      <CardTitle>Bug Report</CardTitle>
+      <CardDescription>
+        Help us improve by reporting bugs you encounter.
+      </CardDescription>
+    </CardHeader>
+    <CardContent>
+      <Form id="form-formisch-demo" :of="form" @submit="handleSubmit">
+        <FieldGroup>
+          <FormischField v-slot="field" :of="form" :path="['title']">
+            <Field :data-invalid="field.errors !== null">
+              <FieldLabel for="form-formisch-demo-title">
+                Bug Title
+              </FieldLabel>
+              <Input
+                id="form-formisch-demo-title"
+                v-model="field.input"
+                v-bind="field.props"
+                :aria-invalid="field.errors !== null"
+                placeholder="Login button not working on mobile"
+                autocomplete="off"
+              />
+              <FieldError
+                v-if="field.errors"
+                :errors="field.errors.map(message => ({ message }))"
+              />
+            </Field>
+          </FormischField>
+
+          <FormischField v-slot="field" :of="form" :path="['description']">
+            <Field :data-invalid="field.errors !== null">
+              <FieldLabel for="form-formisch-demo-description">
+                Description
+              </FieldLabel>
+              <InputGroup>
+                <InputGroupTextarea
+                  id="form-formisch-demo-description"
+                  v-model="field.input"
+                  v-bind="field.props"
+                  placeholder="I'm having an issue with the login button on mobile."
+                  :rows="6"
+                  class="min-h-24 resize-none"
+                  :aria-invalid="field.errors !== null"
+                />
+                <InputGroupAddon align="block-end">
+                  <InputGroupText class="tabular-nums">
+                    {{ (field.input ?? '').length }}/100 characters
+                  </InputGroupText>
+                </InputGroupAddon>
+              </InputGroup>
+              <FieldDescription>
+                Include steps to reproduce, expected behavior, and what
+                actually happened.
+              </FieldDescription>
+              <FieldError
+                v-if="field.errors"
+                :errors="field.errors.map(message => ({ message }))"
+              />
+            </Field>
+          </FormischField>
+        </FieldGroup>
+      </Form>
+    </CardContent>
+    <CardFooter>
+      <Field orientation="horizontal">
+        <Button type="button" variant="outline" @click="reset(form)">
+          Reset
+        </Button>
+        <Button type="submit" form="form-formisch-demo">
+          Submit
+        </Button>
+      </Field>
+    </CardFooter>
+  </Card>
+</template>

--- a/apps/v4/components/demo/FormischInput.vue
+++ b/apps/v4/components/demo/FormischInput.vue
@@ -1,0 +1,105 @@
+<script setup lang="ts">
+import type { SubmitHandler } from '@formisch/vue'
+import { Form, Field as FormischField, reset, useForm } from '@formisch/vue'
+import * as v from 'valibot'
+import { toast } from 'vue-sonner'
+
+import { Button } from '@/registry/new-york-v4/ui/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/registry/new-york-v4/ui/card'
+import {
+  Field,
+  FieldDescription,
+  FieldError,
+  FieldGroup,
+  FieldLabel,
+} from '@/registry/new-york-v4/ui/field'
+import { Input } from '@/registry/new-york-v4/ui/input'
+
+const FormSchema = v.object({
+  username: v.pipe(
+    v.string(),
+    v.minLength(3, 'Username must be at least 3 characters.'),
+    v.maxLength(10, 'Username must be at most 10 characters.'),
+    v.regex(
+      /^\w+$/,
+      'Username can only contain letters, numbers, and underscores.',
+    ),
+  ),
+})
+
+const form = useForm({
+  schema: FormSchema,
+  initialInput: {
+    username: '',
+  },
+})
+
+const handleSubmit: SubmitHandler<typeof FormSchema> = (output) => {
+  toast('You submitted the following values:', {
+    description: h('pre', { class: 'bg-code text-code-foreground mt-2 w-[320px] overflow-x-auto rounded-md p-4' }, h('code', JSON.stringify(output, null, 2))),
+    position: 'bottom-right',
+    class: 'flex flex-col gap-2',
+    style: {
+      '--border-radius': 'calc(var(--radius)  + 4px)',
+    },
+  })
+}
+</script>
+
+<template>
+  <Card class="w-full sm:max-w-md">
+    <CardHeader>
+      <CardTitle>Profile Settings</CardTitle>
+      <CardDescription>
+        Update your profile information below.
+      </CardDescription>
+    </CardHeader>
+    <CardContent>
+      <Form id="form-formisch-input" :of="form" @submit="handleSubmit">
+        <FieldGroup>
+          <FormischField v-slot="field" :of="form" :path="['username']">
+            <Field :data-invalid="field.errors !== null">
+              <FieldLabel for="form-formisch-input-username">
+                Username
+              </FieldLabel>
+              <Input
+                id="form-formisch-input-username"
+                v-model="field.input"
+                v-bind="field.props"
+                :aria-invalid="field.errors !== null"
+                placeholder="shadcn"
+                autocomplete="username"
+              />
+              <FieldDescription>
+                This is your public display name. Must be between 3 and 10
+                characters. Must only contain letters, numbers, and
+                underscores.
+              </FieldDescription>
+              <FieldError
+                v-if="field.errors"
+                :errors="field.errors.map(message => ({ message }))"
+              />
+            </Field>
+          </FormischField>
+        </FieldGroup>
+      </Form>
+    </CardContent>
+    <CardFooter>
+      <Field orientation="horizontal">
+        <Button type="button" variant="outline" @click="reset(form)">
+          Reset
+        </Button>
+        <Button type="submit" form="form-formisch-input">
+          Save
+        </Button>
+      </Field>
+    </CardFooter>
+  </Card>
+</template>

--- a/apps/v4/components/demo/FormischRadioGroup.vue
+++ b/apps/v4/components/demo/FormischRadioGroup.vue
@@ -1,0 +1,140 @@
+<script setup lang="ts">
+import type { SubmitHandler } from '@formisch/vue'
+import { Form, Field as FormischField, reset, useForm } from '@formisch/vue'
+import * as v from 'valibot'
+import { toast } from 'vue-sonner'
+
+import { Button } from '@/registry/new-york-v4/ui/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/registry/new-york-v4/ui/card'
+import {
+  Field,
+  FieldContent,
+  FieldDescription,
+  FieldError,
+  FieldGroup,
+  FieldLabel,
+  FieldLegend,
+  FieldSet,
+  FieldTitle,
+} from '@/registry/new-york-v4/ui/field'
+import {
+  RadioGroup,
+  RadioGroupItem,
+} from '@/registry/new-york-v4/ui/radio-group'
+
+const plans = [
+  {
+    id: 'starter',
+    title: 'Starter (100K tokens/month)',
+    description: 'For everyday use with basic features.',
+  },
+  {
+    id: 'pro',
+    title: 'Pro (1M tokens/month)',
+    description: 'For advanced AI usage with more features.',
+  },
+  {
+    id: 'enterprise',
+    title: 'Enterprise (Unlimited tokens)',
+    description: 'For large teams and heavy usage.',
+  },
+] as const
+
+const FormSchema = v.object({
+  plan: v.pipe(
+    v.string(),
+    v.minLength(1, 'You must select a subscription plan to continue.'),
+  ),
+})
+
+const form = useForm({
+  schema: FormSchema,
+  initialInput: {
+    plan: '',
+  },
+})
+
+const handleSubmit: SubmitHandler<typeof FormSchema> = (output) => {
+  toast('You submitted the following values:', {
+    description: h('pre', { class: 'bg-code text-code-foreground mt-2 w-[320px] overflow-x-auto rounded-md p-4' }, h('code', JSON.stringify(output, null, 2))),
+    position: 'bottom-right',
+    class: 'flex flex-col gap-2',
+    style: {
+      '--border-radius': 'calc(var(--radius)  + 4px)',
+    },
+  })
+}
+</script>
+
+<template>
+  <Card class="w-full sm:max-w-md">
+    <CardHeader>
+      <CardTitle>Subscription Plan</CardTitle>
+      <CardDescription>
+        See pricing and features for each plan.
+      </CardDescription>
+    </CardHeader>
+    <CardContent>
+      <Form id="form-formisch-radiogroup" :of="form" @submit="handleSubmit">
+        <FieldGroup>
+          <FormischField v-slot="field" :of="form" :path="['plan']">
+            <FieldSet :data-invalid="field.errors !== null">
+              <FieldLegend>Plan</FieldLegend>
+              <FieldDescription>
+                You can upgrade or downgrade your plan at any time.
+              </FieldDescription>
+              <RadioGroup
+                v-model="field.input"
+                :aria-invalid="field.errors !== null"
+              >
+                <FieldLabel
+                  v-for="plan in plans"
+                  :key="plan.id"
+                  :for="`form-formisch-radiogroup-${plan.id}`"
+                >
+                  <Field
+                    orientation="horizontal"
+                    :data-invalid="field.errors !== null"
+                  >
+                    <FieldContent>
+                      <FieldTitle>{{ plan.title }}</FieldTitle>
+                      <FieldDescription>
+                        {{ plan.description }}
+                      </FieldDescription>
+                    </FieldContent>
+                    <RadioGroupItem
+                      :id="`form-formisch-radiogroup-${plan.id}`"
+                      :value="plan.id"
+                      :aria-invalid="field.errors !== null"
+                    />
+                  </Field>
+                </FieldLabel>
+              </RadioGroup>
+              <FieldError
+                v-if="field.errors"
+                :errors="field.errors.map(message => ({ message }))"
+              />
+            </FieldSet>
+          </FormischField>
+        </FieldGroup>
+      </Form>
+    </CardContent>
+    <CardFooter>
+      <Field orientation="horizontal">
+        <Button type="button" variant="outline" @click="reset(form)">
+          Reset
+        </Button>
+        <Button type="submit" form="form-formisch-radiogroup">
+          Save
+        </Button>
+      </Field>
+    </CardFooter>
+  </Card>
+</template>

--- a/apps/v4/components/demo/FormischSelect.vue
+++ b/apps/v4/components/demo/FormischSelect.vue
@@ -1,0 +1,139 @@
+<script setup lang="ts">
+import type { SubmitHandler } from '@formisch/vue'
+import { Form, Field as FormischField, reset, useForm } from '@formisch/vue'
+import * as v from 'valibot'
+import { toast } from 'vue-sonner'
+
+import { Button } from '@/registry/new-york-v4/ui/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/registry/new-york-v4/ui/card'
+import {
+  Field,
+  FieldContent,
+  FieldDescription,
+  FieldError,
+  FieldGroup,
+  FieldLabel,
+} from '@/registry/new-york-v4/ui/field'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+} from '@/registry/new-york-v4/ui/select'
+
+const spokenLanguages = [
+  { label: 'English', value: 'en' },
+  { label: 'Spanish', value: 'es' },
+  { label: 'French', value: 'fr' },
+  { label: 'German', value: 'de' },
+  { label: 'Italian', value: 'it' },
+  { label: 'Chinese', value: 'zh' },
+  { label: 'Japanese', value: 'ja' },
+] as const
+
+const FormSchema = v.object({
+  language: v.pipe(
+    v.string(),
+    v.minLength(1, 'Please select your spoken language.'),
+    v.check(
+      value => value !== 'auto',
+      'Auto-detection is not allowed. Please select a specific language.',
+    ),
+  ),
+})
+
+const form = useForm({
+  schema: FormSchema,
+  initialInput: {
+    language: '',
+  },
+})
+
+const handleSubmit: SubmitHandler<typeof FormSchema> = (output) => {
+  toast('You submitted the following values:', {
+    description: h('pre', { class: 'bg-code text-code-foreground mt-2 w-[320px] overflow-x-auto rounded-md p-4' }, h('code', JSON.stringify(output, null, 2))),
+    position: 'bottom-right',
+    class: 'flex flex-col gap-2',
+    style: {
+      '--border-radius': 'calc(var(--radius)  + 4px)',
+    },
+  })
+}
+</script>
+
+<template>
+  <Card class="w-full sm:max-w-lg">
+    <CardHeader>
+      <CardTitle>Language Preferences</CardTitle>
+      <CardDescription>
+        Select your preferred spoken language.
+      </CardDescription>
+    </CardHeader>
+    <CardContent>
+      <Form id="form-formisch-select" :of="form" @submit="handleSubmit">
+        <FieldGroup>
+          <FormischField v-slot="field" :of="form" :path="['language']">
+            <Field
+              orientation="responsive"
+              :data-invalid="field.errors !== null"
+            >
+              <FieldContent>
+                <FieldLabel for="form-formisch-select-language">
+                  Spoken Language
+                </FieldLabel>
+                <FieldDescription>
+                  For best results, select the language you speak.
+                </FieldDescription>
+                <FieldError
+                  v-if="field.errors"
+                  :errors="field.errors.map(message => ({ message }))"
+                />
+              </FieldContent>
+              <Select v-model="field.input">
+                <SelectTrigger
+                  id="form-formisch-select-language"
+                  :aria-invalid="field.errors !== null"
+                  class="min-w-[120px]"
+                >
+                  <SelectValue placeholder="Select" />
+                </SelectTrigger>
+                <SelectContent position="item-aligned">
+                  <SelectItem value="auto">
+                    Auto
+                  </SelectItem>
+                  <SelectSeparator />
+                  <SelectItem
+                    v-for="language in spokenLanguages"
+                    :key="language.value"
+                    :value="language.value"
+                  >
+                    {{ language.label }}
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+            </Field>
+          </FormischField>
+        </FieldGroup>
+      </Form>
+    </CardContent>
+    <CardFooter>
+      <Field orientation="horizontal">
+        <Button type="button" variant="outline" @click="reset(form)">
+          Reset
+        </Button>
+        <Button type="submit" form="form-formisch-select">
+          Save
+        </Button>
+      </Field>
+    </CardFooter>
+  </Card>
+</template>

--- a/apps/v4/components/demo/FormischSwitch.vue
+++ b/apps/v4/components/demo/FormischSwitch.vue
@@ -1,0 +1,104 @@
+<script setup lang="ts">
+import type { SubmitHandler } from '@formisch/vue'
+import { Form, Field as FormischField, reset, useForm } from '@formisch/vue'
+import * as v from 'valibot'
+import { toast } from 'vue-sonner'
+
+import { Button } from '@/registry/new-york-v4/ui/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/registry/new-york-v4/ui/card'
+import {
+  Field,
+  FieldContent,
+  FieldDescription,
+  FieldError,
+  FieldGroup,
+  FieldLabel,
+} from '@/registry/new-york-v4/ui/field'
+import { Switch } from '@/registry/new-york-v4/ui/switch'
+
+const FormSchema = v.object({
+  twoFactor: v.pipe(
+    v.boolean(),
+    v.check(
+      value => value === true,
+      'It is highly recommended to enable two-factor authentication.',
+    ),
+  ),
+})
+
+const form = useForm({
+  schema: FormSchema,
+  initialInput: {
+    twoFactor: false,
+  },
+})
+
+const handleSubmit: SubmitHandler<typeof FormSchema> = (output) => {
+  toast('You submitted the following values:', {
+    description: h('pre', { class: 'bg-code text-code-foreground mt-2 w-[320px] overflow-x-auto rounded-md p-4' }, h('code', JSON.stringify(output, null, 2))),
+    position: 'bottom-right',
+    class: 'flex flex-col gap-2',
+    style: {
+      '--border-radius': 'calc(var(--radius)  + 4px)',
+    },
+  })
+}
+</script>
+
+<template>
+  <Card class="w-full sm:max-w-md">
+    <CardHeader>
+      <CardTitle>Security Settings</CardTitle>
+      <CardDescription>
+        Manage your account security preferences.
+      </CardDescription>
+    </CardHeader>
+    <CardContent>
+      <Form id="form-formisch-switch" :of="form" @submit="handleSubmit">
+        <FieldGroup>
+          <FormischField v-slot="field" :of="form" :path="['twoFactor']">
+            <Field
+              orientation="horizontal"
+              :data-invalid="field.errors !== null"
+            >
+              <FieldContent>
+                <FieldLabel for="form-formisch-switch-twoFactor">
+                  Multi-factor authentication
+                </FieldLabel>
+                <FieldDescription>
+                  Enable multi-factor authentication to secure your account.
+                </FieldDescription>
+                <FieldError
+                  v-if="field.errors"
+                  :errors="field.errors.map(message => ({ message }))"
+                />
+              </FieldContent>
+              <Switch
+                id="form-formisch-switch-twoFactor"
+                v-model="field.input"
+                :aria-invalid="field.errors !== null"
+              />
+            </Field>
+          </FormischField>
+        </FieldGroup>
+      </Form>
+    </CardContent>
+    <CardFooter>
+      <Field orientation="horizontal">
+        <Button type="button" variant="outline" @click="reset(form)">
+          Reset
+        </Button>
+        <Button type="submit" form="form-formisch-switch">
+          Save
+        </Button>
+      </Field>
+    </CardFooter>
+  </Card>
+</template>

--- a/apps/v4/components/demo/FormischTextarea.vue
+++ b/apps/v4/components/demo/FormischTextarea.vue
@@ -1,0 +1,100 @@
+<script setup lang="ts">
+import type { SubmitHandler } from '@formisch/vue'
+import { Form, Field as FormischField, reset, useForm } from '@formisch/vue'
+import * as v from 'valibot'
+import { toast } from 'vue-sonner'
+
+import { Button } from '@/registry/new-york-v4/ui/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/registry/new-york-v4/ui/card'
+import {
+  Field,
+  FieldDescription,
+  FieldError,
+  FieldGroup,
+  FieldLabel,
+} from '@/registry/new-york-v4/ui/field'
+import { Textarea } from '@/registry/new-york-v4/ui/textarea'
+
+const FormSchema = v.object({
+  about: v.pipe(
+    v.string(),
+    v.minLength(10, 'Please provide at least 10 characters.'),
+    v.maxLength(200, 'Please keep it under 200 characters.'),
+  ),
+})
+
+const form = useForm({
+  schema: FormSchema,
+  initialInput: {
+    about: '',
+  },
+})
+
+const handleSubmit: SubmitHandler<typeof FormSchema> = (output) => {
+  toast('You submitted the following values:', {
+    description: h('pre', { class: 'bg-code text-code-foreground mt-2 w-[320px] overflow-x-auto rounded-md p-4' }, h('code', JSON.stringify(output, null, 2))),
+    position: 'bottom-right',
+    class: 'flex flex-col gap-2',
+    style: {
+      '--border-radius': 'calc(var(--radius)  + 4px)',
+    },
+  })
+}
+</script>
+
+<template>
+  <Card class="w-full sm:max-w-md">
+    <CardHeader>
+      <CardTitle>Personalization</CardTitle>
+      <CardDescription>
+        Customize your experience by telling us more about yourself.
+      </CardDescription>
+    </CardHeader>
+    <CardContent>
+      <Form id="form-formisch-textarea" :of="form" @submit="handleSubmit">
+        <FieldGroup>
+          <FormischField v-slot="field" :of="form" :path="['about']">
+            <Field :data-invalid="field.errors !== null">
+              <FieldLabel for="form-formisch-textarea-about">
+                More about you
+              </FieldLabel>
+              <Textarea
+                id="form-formisch-textarea-about"
+                v-model="field.input"
+                v-bind="field.props"
+                :aria-invalid="field.errors !== null"
+                placeholder="I'm a software engineer..."
+                class="min-h-[120px]"
+              />
+              <FieldDescription>
+                Tell us more about yourself. This will be used to help us
+                personalize your experience.
+              </FieldDescription>
+              <FieldError
+                v-if="field.errors"
+                :errors="field.errors.map(message => ({ message }))"
+              />
+            </Field>
+          </FormischField>
+        </FieldGroup>
+      </Form>
+    </CardContent>
+    <CardFooter>
+      <Field orientation="horizontal">
+        <Button type="button" variant="outline" @click="reset(form)">
+          Reset
+        </Button>
+        <Button type="submit" form="form-formisch-textarea">
+          Save
+        </Button>
+      </Field>
+    </CardFooter>
+  </Card>
+</template>

--- a/apps/v4/components/demo/index.ts
+++ b/apps/v4/components/demo/index.ts
@@ -50,6 +50,17 @@ export { default as ComboboxWithListboxDemo } from './ComboboxWithListboxDemo.vu
 export { default as DialogDemo } from './DialogDemo.vue'
 export { default as DialogResponsive } from './DialogResponsive.vue'
 
+// Formisch demos
+export { default as FormischArray } from './FormischArray.vue'
+export { default as FormischCheckbox } from './FormischCheckbox.vue'
+export { default as FormischComplex } from './FormischComplex.vue'
+export { default as FormischDemo } from './FormischDemo.vue'
+export { default as FormischInput } from './FormischInput.vue'
+export { default as FormischRadioGroup } from './FormischRadioGroup.vue'
+export { default as FormischSelect } from './FormischSelect.vue'
+export { default as FormischSwitch } from './FormischSwitch.vue'
+export { default as FormischTextarea } from './FormischTextarea.vue'
+
 // Hover Card demos
 export { default as HoverCardDemo } from './HoverCardDemo.vue'
 

--- a/apps/v4/content/docs/forms.md
+++ b/apps/v4/content/docs/forms.md
@@ -25,6 +25,24 @@ Start by selecting your framework. Then follow the instructions to learn how to 
     </svg>
     <p class="mt-2 font-medium">TanStack Form</p>
   </linked-card>
+  <linked-card href="/docs/forms/formisch">
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 512 512"
+      class="size-10"
+      fill="currentColor"
+    >
+      <path
+        fill="none"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="20"
+        d="M90.9 291.7 49 299.4v125.5l193.3 63.8 221-63.8V304.7l-62-13.7m-352.2 8.6 193.2 53.6V488m221-183.2-221.1 48.4m-171-67.7 147.5 47 212.7-48.3L437 76 271.9 25 72.1 66.3Zm1-219.3L220.5 118l-1.8 214m1.8-214.3 216.2-41.6m-84.4 159.6-.9 1.9c-5.2 11.3-16.2 34.8-33.5 35.5h-1a22 22 0 0 1-9.7-2.2 26 26 0 0 1-7.4-5.5c-4.3-4.4-7.4-10-10-14.5q-1.2-2.4-2.7-4.7a54 54 0 0 0 21.7 4.1 74 74 0 0 0 23.6-4 70 70 0 0 0 11.4-5 64 64 0 0 0 8.5-5.6M247.6 168c19.5-20.8 34.8-12.3 36-18.4 1.5-7-12.2-7.7-22.2-2.6s-18 17.7-13.8 21m101.2-33.2c1.6 2.6 8.7-1.6 19.5-1.2s15.8 5.7 18 4.1-4.6-14.7-17.1-15.2-22 9.7-20.4 12.3m21.2 16.3c9.4.6 17.1 12.8 16.1 27.6s-10.4 25.9-19.8 25.2-17.1-12.9-16.1-27.7 10.4-25.8 19.8-25.1m-97.4 19c11 1.2 19 15.1 17.4 30.5s-12.3 27.4-23.4 26.2-19-15-17.4-30.5 12.3-27.3 23.4-26.2"
+      />
+    </svg>
+    <p class="mt-2 font-medium">Formisch</p>
+  </linked-card>
   <linked-card href="#" class="border border-dashed bg-transparent">
   <svg xmlns="http://www.w3.org/2000/svg" class="size-10" viewBox="0 0 24 24"><!-- Icon from Akar Icons by Arturo Wibawa - https://github.com/artcoholic/akar-icons/blob/master/LICENSE --><path fill="currentColor" d="M19.114 2H15l-3 4.9L9.429 2H0l12 21L24 2zM3 3.75h2.914L12 14.6l6.086-10.85H21L12 19.5z"/></svg>
     <p class="mt-2 font-medium">Composable</p>

--- a/apps/v4/content/docs/forms/03.formisch.md
+++ b/apps/v4/content/docs/forms/03.formisch.md
@@ -1,0 +1,677 @@
+---
+title: Formisch
+description: Build forms in Vue using Formisch and Valibot.
+links:
+  doc: https://formisch.dev
+---
+
+This guide covers building forms with [Formisch](https://formisch.dev), the lightweight, schema-first, and fully type-safe form library for Vue. We'll create forms with the `Field` component, validate them with Valibot schemas, handle errors, and ensure accessibility.
+
+## Demo
+
+We'll build the following form. It has a simple text input and a textarea. On submit, we'll validate the form data and display any errors.
+
+::callout
+---
+icon: true
+---
+**Note:** For the purpose of this demo, we have intentionally disabled browser validation to show how schema validation and form errors work in Formisch. It is recommended to add basic browser validation in your production code.
+::
+
+::component-preview
+---
+name: FormischDemo
+class: sm:[&_.preview]:h-[700px] sm:[&_pre]:!h-[700px]
+chromeLessOnMobile: true
+---
+::
+
+## Approach
+
+This form leverages Formisch for headless, schema-first form handling. We'll build our form using the `Field` component, which gives you **complete flexibility over the markup and styling**.
+
+- Uses Formisch's `useForm` composable for form state management.
+- `Form` component to wrap the native `form` element with submit handling.
+- `Field` component with a slot prop for controlled inputs.
+- Schema validation using [Valibot](https://valibot.dev).
+- Type-safe field paths inferred from the schema.
+
+## Form Methods
+
+Formisch exposes form operations as **top-level functions** rather than methods on a form object. Import only what you need:
+
+```ts
+import { getInput, insert, reset, submit } from '@formisch/vue'
+```
+
+Every method follows the same signature: the **first parameter is always the form store**, and the **second parameter (if necessary) is always a config object**.
+
+```ts
+// Read a field value
+const email = getInput(form, { path: ['email'] })
+
+// Reset the form with new initial values
+reset(form, { initialInput: { email: '', password: '' } })
+
+// Move an item in a field array
+move(form, { path: ['items'], from: 0, to: 3 })
+```
+
+This design keeps the API flexible and consistent across all methods. You'll see the same `(form, config)` shape used throughout this guide for reading state (`getInput`, `getErrors`), writing state (`setInput`, `setErrors`), form control (`submit`, `validate`, `focus`), and array operations (`insert`, `remove`, `move`, `swap`, `replace`). See the [full methods reference](https://formisch.dev/vue/guides/form-methods) for details.
+
+## Anatomy
+
+Here's a basic example of a form using the `Field` component from Formisch and the shadcn-vue `Field` component.
+
+```vue showLineNumbers {3-21}
+<template>
+  <Form :of="form" @submit="handleSubmit">
+    <FieldGroup>
+      <FormischField :of="form" :path="['title']" v-slot="field">
+        <Field :data-invalid="field.errors !== null">
+          <FieldLabel for="form-title">Bug Title</FieldLabel>
+          <Input
+            v-model="field.input"
+            v-bind="field.props"
+            id="form-title"
+            :aria-invalid="field.errors !== null"
+            placeholder="Login button not working on mobile"
+            autocomplete="off"
+          />
+          <FieldDescription>
+            Provide a concise title for your bug report.
+          </FieldDescription>
+          <FieldError
+            v-if="field.errors"
+            :errors="field.errors.map((message) => ({ message }))"
+          />
+        </Field>
+      </FormischField>
+    </FieldGroup>
+  </Form>
+</template>
+```
+
+::callout
+---
+icon: true
+---
+**Note:** Formisch ships its own `Field` component. To avoid a name clash with the shadcn-vue `Field`, the examples below import the Formisch one as `FormischField` and keep the shadcn-vue `Field` under its original name. In your own code you can alias either side — just be consistent.
+::
+
+## Form
+
+### Create a form schema
+
+We'll start by defining the shape of our form using a Valibot schema. Formisch infers all input and output types directly from this schema.
+
+```vue showLineNumbers
+<script setup lang="ts">
+import * as v from 'valibot'
+
+const FormSchema = v.object({
+  title: v.pipe(
+    v.string(),
+    v.minLength(5, 'Bug title must be at least 5 characters.'),
+    v.maxLength(32, 'Bug title must be at most 32 characters.'),
+  ),
+  description: v.pipe(
+    v.string(),
+    v.minLength(20, 'Description must be at least 20 characters.'),
+    v.maxLength(100, 'Description must be at most 100 characters.'),
+  ),
+})
+</script>
+```
+
+### Setup the form
+
+Next, we'll use the `useForm` composable from Formisch to create our form instance. The schema is passed directly to `useForm` — there is no resolver step.
+
+```vue showLineNumbers
+<script setup lang="ts">
+import { Field as FormischField, Form, useForm } from '@formisch/vue'
+import type { SubmitHandler } from '@formisch/vue'
+import * as v from 'valibot'
+
+const FormSchema = v.object({
+  // ...
+})
+
+const form = useForm({
+  schema: FormSchema,
+  initialInput: {
+    title: '',
+    description: '',
+  },
+})
+
+const handleSubmit: SubmitHandler<typeof FormSchema> = (output) => {
+  // Do something with the validated form values.
+  console.log(output)
+}
+</script>
+
+<template>
+  <Form :of="form" @submit="handleSubmit">
+    <!-- ... -->
+  </Form>
+</template>
+```
+
+The `Form` component wraps a native `form` element. It calls `event.preventDefault()`, runs validation, and only invokes the submit handler when the data is valid. The `output` you receive is fully typed from the schema.
+
+### Build the form
+
+We can now build the form using the `FormischField` component from Formisch and the `Field` components.
+
+::component-source
+---
+name: FormischDemo
+title: Form.vue
+---
+::
+
+### Done
+
+That's it. You now have a fully accessible form with client-side validation.
+
+When you submit the form, the `handleSubmit` function will be called with the validated form data. If the form data is invalid, Formisch will populate `field.errors` for each invalid field and the UI will display them.
+
+## Validation
+
+### Client-side Validation
+
+Formisch validates your form data using the Valibot schema you pass to `useForm`. There is no resolver — the schema is the single source of truth for both runtime validation and static types.
+
+```vue showLineNumbers
+<script setup lang="ts">
+import { useForm } from '@formisch/vue'
+import * as v from 'valibot'
+
+const FormSchema = v.object({
+  title: v.string(),
+  description: v.optional(v.string()),
+})
+
+const form = useForm({
+  schema: FormSchema,
+  initialInput: {
+    title: '',
+    description: '',
+  },
+})
+</script>
+```
+
+### Validation Modes
+
+Formisch separates the **first** validation from **subsequent** validations. You configure them with the `validate` and `revalidate` options on `useForm`.
+
+```vue showLineNumbers {5-6}
+<script setup lang="ts">
+const form = useForm({
+  schema: FormSchema,
+  validate: 'blur',
+  revalidate: 'input',
+})
+</script>
+```
+
+| Option       | Value       | Description                                                     |
+| ------------ | ----------- | --------------------------------------------------------------- |
+| `validate`   | `'submit'`  | Validate on form submission (default).                          |
+| `validate`   | `'blur'`    | Validate when a field loses focus.                              |
+| `validate`   | `'input'`   | Validate on every input change.                                 |
+| `validate`   | `'initial'` | Validate immediately on form creation.                          |
+| `revalidate` | `'input'`   | Revalidate on every input change after the first run (default). |
+| `revalidate` | `'blur'`    | Revalidate on blur after the first run.                         |
+| `revalidate` | `'submit'`  | Revalidate only on form submission.                             |
+
+## Displaying Errors
+
+Display errors next to the field using `FieldError`. Formisch returns errors as an array of strings, so map them to the shape `FieldError` expects. For styling and accessibility:
+
+- Add the `:data-invalid` prop to the `Field` component.
+- Add the `:aria-invalid` prop to the form control such as `Input`, `SelectTrigger`, `Checkbox`, etc.
+
+```vue showLineNumbers {3,7,13-16}
+<template>
+  <FormischField :of="form" :path="['email']" v-slot="field">
+    <Field :data-invalid="field.errors !== null">
+      <FieldLabel for="form-email">Email</FieldLabel>
+      <Input
+        v-model="field.input"
+        v-bind="field.props"
+        id="form-email"
+        type="email"
+        :aria-invalid="field.errors !== null"
+      />
+      <FieldError
+        v-if="field.errors"
+        :errors="field.errors.map((message) => ({ message }))"
+      />
+    </Field>
+  </FormischField>
+</template>
+```
+
+## Working with Different Field Types
+
+Formisch exposes two ways to bind a field to an element:
+
+- **Native HTML elements** (like `Input` and `Textarea`) — use `v-model="field.input"` and spread `field.props` with `v-bind`. Formisch wires up `name`, `ref`, and the focus and blur events for you.
+- **Component-library inputs** (like reka-ui based `Select`, `Checkbox`, `RadioGroup`, `Switch`) — bind `field.input` directly with `v-model` or `:model-value` and `@update:model-value`.
+
+### Input
+
+- For input fields, use `v-model="field.input"` and `v-bind="field.props"`.
+- To show errors, add the `:aria-invalid` prop to the `Input` component and the `:data-invalid` prop to the `Field` component.
+
+::component-preview
+---
+name: FormischInput
+class: sm:[&_.preview]:h-[700px] sm:[&_pre]:!h-[700px]
+chromeLessOnMobile: true
+---
+::
+
+```vue showLineNumbers {5-10}
+<template>
+  <FormischField :of="form" :path="['username']" v-slot="field">
+    <Field :data-invalid="field.errors !== null">
+      <FieldLabel for="form-username">Username</FieldLabel>
+      <Input
+        v-model="field.input"
+        v-bind="field.props"
+        id="form-username"
+        :aria-invalid="field.errors !== null"
+      />
+      <FieldError
+        v-if="field.errors"
+        :errors="field.errors.map((message) => ({ message }))"
+      />
+    </Field>
+  </FormischField>
+</template>
+```
+
+### Textarea
+
+- For textarea fields, use `v-model="field.input"` and `v-bind="field.props"`.
+- To show errors, add the `:aria-invalid` prop to the `Textarea` component and the `:data-invalid` prop to the `Field` component.
+
+::component-preview
+---
+name: FormischTextarea
+class: sm:[&_.preview]:h-[700px] sm:[&_pre]:!h-[700px]
+chromeLessOnMobile: true
+---
+::
+
+```vue showLineNumbers {5-12}
+<template>
+  <FormischField :of="form" :path="['about']" v-slot="field">
+    <Field :data-invalid="field.errors !== null">
+      <FieldLabel for="form-about">More about you</FieldLabel>
+      <Textarea
+        v-model="field.input"
+        v-bind="field.props"
+        id="form-about"
+        :aria-invalid="field.errors !== null"
+        placeholder="I'm a software engineer..."
+        class="min-h-[120px]"
+      />
+      <FieldDescription>
+        Tell us more about yourself. This will be used to help us personalize
+        your experience.
+      </FieldDescription>
+      <FieldError
+        v-if="field.errors"
+        :errors="field.errors.map((message) => ({ message }))"
+      />
+    </Field>
+  </FormischField>
+</template>
+```
+
+### Select
+
+- For select components, bind `field.input` with `v-model` on the `Select` component.
+- To show errors, add the `:aria-invalid` prop to the `SelectTrigger` component and the `:data-invalid` prop to the `Field` component.
+
+::component-preview
+---
+name: FormischSelect
+class: sm:[&_.preview]:h-[500px] sm:[&_pre]:!h-[500px]
+chromeLessOnMobile: true
+---
+::
+
+```vue showLineNumbers {14}
+<template>
+  <FormischField :of="form" :path="['language']" v-slot="field">
+    <Field orientation="responsive" :data-invalid="field.errors !== null">
+      <FieldContent>
+        <FieldLabel for="form-language">Spoken Language</FieldLabel>
+        <FieldDescription>
+          For best results, select the language you speak.
+        </FieldDescription>
+        <FieldError
+          v-if="field.errors"
+          :errors="field.errors.map((message) => ({ message }))"
+        />
+      </FieldContent>
+      <Select v-model="field.input">
+        <SelectTrigger
+          id="form-language"
+          :aria-invalid="field.errors !== null"
+          class="min-w-[120px]"
+        >
+          <SelectValue placeholder="Select" />
+        </SelectTrigger>
+        <SelectContent position="item-aligned">
+          <SelectItem value="auto">Auto</SelectItem>
+          <SelectItem value="en">English</SelectItem>
+        </SelectContent>
+      </Select>
+    </Field>
+  </FormischField>
+</template>
+```
+
+### Checkbox
+
+- For checkbox arrays, read `field.input` and write the updated array back to it from `@update:model-value`.
+- To show errors, add the `:aria-invalid` prop to the `Checkbox` component and the `:data-invalid` prop to the `Field` component.
+- Remember to add `data-slot="checkbox-group"` to the `FieldGroup` component for proper styling and spacing.
+
+::component-preview
+---
+name: FormischCheckbox
+class: sm:[&_.preview]:h-[700px] sm:[&_pre]:!h-[700px]
+chromeLessOnMobile: true
+---
+::
+
+```vue showLineNumbers {15-22}
+<template>
+  <FormischField :of="form" :path="['tasks']" v-slot="field">
+    <FieldSet>
+      <FieldLegend variant="label">Tasks</FieldLegend>
+      <FieldDescription>
+        Get notified when tasks you've created have updates.
+      </FieldDescription>
+      <FieldGroup data-slot="checkbox-group">
+        <Field
+          v-for="task in tasks"
+          :key="task.id"
+          orientation="horizontal"
+          :data-invalid="field.errors !== null"
+        >
+          <Checkbox
+            :id="`form-checkbox-${task.id}`"
+            :aria-invalid="field.errors !== null"
+            :model-value="field.input?.includes(task.id) ?? false"
+            @update:model-value="
+              (checked) =>
+                (field.input = checked
+                  ? [...(field.input ?? []), task.id]
+                  : (field.input ?? []).filter((value) => value !== task.id))
+            "
+          />
+          <FieldLabel :for="`form-checkbox-${task.id}`" class="font-normal">
+            {{ task.label }}
+          </FieldLabel>
+        </Field>
+      </FieldGroup>
+      <FieldError
+        v-if="field.errors"
+        :errors="field.errors.map((message) => ({ message }))"
+      />
+    </FieldSet>
+  </FormischField>
+</template>
+```
+
+### Radio Group
+
+- For radio groups, bind `field.input` with `v-model` on the `RadioGroup` component.
+- To show errors, add the `:aria-invalid` prop to the `RadioGroupItem` component and the `:data-invalid` prop to the `Field` component.
+
+::component-preview
+---
+name: FormischRadioGroup
+class: sm:[&_.preview]:h-[700px] sm:[&_pre]:!h-[700px]
+chromeLessOnMobile: true
+---
+::
+
+```vue showLineNumbers {8}
+<template>
+  <FormischField :of="form" :path="['plan']" v-slot="field">
+    <FieldSet>
+      <FieldLegend>Plan</FieldLegend>
+      <FieldDescription>
+        You can upgrade or downgrade your plan at any time.
+      </FieldDescription>
+      <RadioGroup v-model="field.input">
+        <FieldLabel
+          v-for="plan in plans"
+          :key="plan.id"
+          :for="`form-radiogroup-${plan.id}`"
+        >
+          <Field orientation="horizontal" :data-invalid="field.errors !== null">
+            <FieldContent>
+              <FieldTitle>{{ plan.title }}</FieldTitle>
+              <FieldDescription>{{ plan.description }}</FieldDescription>
+            </FieldContent>
+            <RadioGroupItem
+              :value="plan.id"
+              :id="`form-radiogroup-${plan.id}`"
+              :aria-invalid="field.errors !== null"
+            />
+          </Field>
+        </FieldLabel>
+      </RadioGroup>
+      <FieldError
+        v-if="field.errors"
+        :errors="field.errors.map((message) => ({ message }))"
+      />
+    </FieldSet>
+  </FormischField>
+</template>
+```
+
+### Switch
+
+- For switches, bind `field.input` with `v-model` on the `Switch` component.
+- To show errors, add the `:aria-invalid` prop to the `Switch` component and the `:data-invalid` prop to the `Field` component.
+
+::component-preview
+---
+name: FormischSwitch
+class: sm:[&_.preview]:h-[500px] sm:[&_pre]:!h-[500px]
+chromeLessOnMobile: true
+---
+::
+
+```vue showLineNumbers {15-19}
+<template>
+  <FormischField :of="form" :path="['twoFactor']" v-slot="field">
+    <Field orientation="horizontal" :data-invalid="field.errors !== null">
+      <FieldContent>
+        <FieldLabel for="form-twoFactor">
+          Multi-factor authentication
+        </FieldLabel>
+        <FieldDescription>
+          Enable multi-factor authentication to secure your account.
+        </FieldDescription>
+        <FieldError
+          v-if="field.errors"
+          :errors="field.errors.map((message) => ({ message }))"
+        />
+      </FieldContent>
+      <Switch
+        id="form-twoFactor"
+        v-model="field.input"
+        :aria-invalid="field.errors !== null"
+      />
+    </Field>
+  </FormischField>
+</template>
+```
+
+### Complex Forms
+
+Here is an example of a more complex form with multiple fields and validation.
+
+::component-preview
+---
+name: FormischComplex
+class: sm:[&_.preview]:h-[1300px] sm:[&_pre]:!h-[1300px]
+chromeLessOnMobile: true
+---
+::
+
+## Resetting the Form
+
+Formisch exposes a top-level `reset` function. Pass the form store to reset it to its initial input.
+
+```vue showLineNumbers
+<template>
+  <Button type="button" variant="outline" @click="reset(form)">
+    Reset
+  </Button>
+</template>
+```
+
+You can also reset to new initial values, or reset while keeping the user's current input:
+
+```ts showLineNumbers
+// Reset to a fresh set of initial values
+reset(form, { initialInput: { title: '', description: '' } })
+
+// Sync the baseline to new server data, but keep the user's edits
+reset(form, { initialInput: serverData, keepInput: true })
+```
+
+## Array Fields
+
+Formisch provides a `FieldArray` component and a set of helper functions for managing dynamic array fields. Use it whenever you need to add, remove, or reorder items.
+
+::component-preview
+---
+name: FormischArray
+class: sm:[&_.preview]:h-[700px] sm:[&_pre]:!h-[700px]
+chromeLessOnMobile: true
+---
+::
+
+### Using FieldArray
+
+`FieldArray` follows the same slot pattern as `Field`. Its `items` array contains a stable key per item that you should use as the `v-for` key.
+
+```vue showLineNumbers {2,8-14}
+<script setup lang="ts">
+import { Field as FormischField, FieldArray, insert, remove } from '@formisch/vue'
+</script>
+
+<template>
+  <FieldArray :of="form" :path="['emails']" v-slot="fieldArray">
+    <FieldGroup class="gap-4">
+      <FormischField
+        v-for="(item, index) in fieldArray.items"
+        :key="item"
+        :of="form"
+        :path="['emails', index, 'address']"
+        v-slot="field"
+      >
+        <!-- ... -->
+      </FormischField>
+    </FieldGroup>
+  </FieldArray>
+</template>
+```
+
+### Array Field Structure
+
+Wrap your array fields in a `FieldSet` with a `FieldLegend` and `FieldDescription`.
+
+```vue showLineNumbers
+<template>
+  <FieldSet class="gap-4">
+    <FieldLegend variant="label">Email Addresses</FieldLegend>
+    <FieldDescription>
+      Add up to 5 email addresses where we can contact you.
+    </FieldDescription>
+    <FieldGroup class="gap-4">
+      <!-- Array items go here -->
+    </FieldGroup>
+  </FieldSet>
+</template>
+```
+
+### Adding Items
+
+Use the `insert` function to add new items to the array. By default new items are appended to the end. You can also pass an `at` index to insert at a specific position.
+
+```vue showLineNumbers
+<template>
+  <Button
+    type="button"
+    variant="outline"
+    size="sm"
+    @click="insert(form, { path: ['emails'], initialInput: { address: '' } })"
+    :disabled="fieldArray.items.length >= 5"
+  >
+    Add Email Address
+  </Button>
+</template>
+```
+
+### Removing Items
+
+Use the `remove` function with an `at` index to remove items from the array.
+
+```vue showLineNumbers
+<template>
+  <InputGroupAddon v-if="fieldArray.items.length > 1" align="inline-end">
+    <InputGroupButton
+      type="button"
+      variant="ghost"
+      size="icon-xs"
+      @click="remove(form, { path: ['emails'], at: index })"
+      :aria-label="`Remove email ${index + 1}`"
+    >
+      <XIcon />
+    </InputGroupButton>
+  </InputGroupAddon>
+</template>
+```
+
+Formisch also exposes `move`, `swap`, and `replace` for reordering and replacing items. They follow the same `(form, config)` signature.
+
+### Array Validation
+
+Use Valibot's `array` and pipeline validators to constrain array fields.
+
+```vue showLineNumbers
+<script setup lang="ts">
+const FormSchema = v.object({
+  emails: v.pipe(
+    v.array(
+      v.object({
+        address: v.pipe(
+          v.string(),
+          v.nonEmpty('Enter an email address.'),
+          v.email('Enter a valid email address.'),
+        ),
+      }),
+    ),
+    v.minLength(1, 'Add at least one email address.'),
+    v.maxLength(5, 'You can add up to 5 email addresses.'),
+  ),
+})
+</script>
+```

--- a/apps/v4/package.json
+++ b/apps/v4/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@dnd-kit/abstract": "^0.5.0",
+    "@formisch/vue": "^1.0.0-rc.0",
     "@hugeicons/core-free-icons": "^4.2.3",
     "@hugeicons/vue": "^1.0.7",
     "@internationalized/date": "catalog:",
@@ -57,6 +58,7 @@
     "tw-animate-css": "catalog:",
     "unifont": "catalog:",
     "unstorage": "^1.17.5",
+    "valibot": "^1.4.1",
     "vaul-vue": "catalog:",
     "vee-validate": "catalog:",
     "vue": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -175,6 +175,9 @@ importers:
       '@dnd-kit/abstract':
         specifier: ^0.5.0
         version: 0.5.0
+      '@formisch/vue':
+        specifier: ^1.0.0-rc.0
+        version: 1.0.0-rc.0(typescript@5.9.3)(valibot@1.4.2(typescript@5.9.3))(vue@3.5.40(typescript@5.9.3))
       '@hugeicons/core-free-icons':
         specifier: ^4.2.3
         version: 4.2.3
@@ -289,6 +292,9 @@ importers:
       unstorage:
         specifier: ^1.17.5
         version: 1.17.5(db0@0.3.4)(ioredis@5.10.1)
+      valibot:
+        specifier: ^1.4.1
+        version: 1.4.2(typescript@5.9.3)
       vaul-vue:
         specifier: 'catalog:'
         version: 0.4.1(reka-ui@2.10.1(vue@3.5.40(typescript@5.9.3)))(vue@3.5.40(typescript@5.9.3))
@@ -1772,6 +1778,16 @@ packages:
 
   '@floating-ui/vue@1.1.9':
     resolution: {integrity: sha512-BfNqNW6KA83Nexspgb9DZuz578R7HT8MZw1CfK9I6Ah4QReNWEJsXWHN+SdmOVLNGmTPDi+fDT535Df5PzMLbQ==}
+
+  '@formisch/vue@1.0.0-rc.0':
+    resolution: {integrity: sha512-tRObIdotqHTCCXxqn/sG7s7pWfjyx1wWbY6L5VgcomGzfhZEFNHWXfvjXaZLMq6x+Yv1qJHCkmK9sj+sZGs0cQ==}
+    peerDependencies:
+      typescript: '>=5'
+      valibot: ^1.4.1
+      vue: ^3.3.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   '@hono/node-server@1.19.14':
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
@@ -13435,6 +13451,13 @@ snapshots:
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
+
+  '@formisch/vue@1.0.0-rc.0(typescript@5.9.3)(valibot@1.4.2(typescript@5.9.3))(vue@3.5.40(typescript@5.9.3))':
+    dependencies:
+      valibot: 1.4.2(typescript@5.9.3)
+      vue: 3.5.40(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
 
   '@hono/node-server@1.19.14(hono@4.12.30)':
     dependencies:


### PR DESCRIPTION
Adds a [Formisch](https://formisch.dev/) guide to the Forms docs, alongside the existing VeeValidate and TanStack Form pages, so users can see how to wire up Formisch with shadcn-vue components. Mirrors the Formisch guide on [ui.shadcn.com](https://ui.shadcn.com/docs/forms/formisch) and includes nine demo components. I'm the author of the library.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interactive Vue form demos covering inputs, checkboxes, radio groups, selects, switches, textareas, dynamic arrays, and complex forms.
  * Added validation, inline error messages, reset actions, and submission feedback across the demos.
  * Added Formisch to the forms documentation with setup guidance, validation patterns, accessible errors, and dynamic field examples.
  * Added a Formisch card linking to the new documentation.

* **Documentation**
  * Added comprehensive Formisch usage examples and guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->