### PR TITLE
feat(v4): port Typeset from shadcn-ui

### DIFF
--- a/apps/v4/assets/css/main.css
+++ b/apps/v4/assets/css/main.css
@@ -5,6 +5,22 @@
 @import "./themes.css";
 @import "./fonts.css";
 
+/*
+ * shadcn/typeset. Imported here, after Tailwind, for the same reason the docs
+ * tell users to do it: CSS orders @layer by first appearance, so typeset's
+ * `components` rules must be registered after Tailwind's layer list or
+ * preflight wins and every typeset rule is dead. Loading it as a standalone
+ * <link> or a route-level chunk gets this wrong — the order then depends on
+ * which stylesheet the browser parses first, which differs between dev and
+ * the production build.
+ *
+ * Same file that is served verbatim at /typeset.css for users to download,
+ * so the preview always shows exactly what they get. Its rules only match
+ * inside a `.typeset` container, so importing it globally styles nothing on
+ * its own.
+ */
+@import "../../public/typeset.css";
+
 @import "../../registry/styles/style-vega.css" layer(base);
 @import "../../registry/styles/style-nova.css" layer(base);
 @import "../../registry/styles/style-lyra.css" layer(base);

--- a/apps/v4/components/DocsSidebar.vue
+++ b/apps/v4/components/DocsSidebar.vue
@@ -55,6 +55,10 @@ const TOP_LEVEL_SECTIONS = [
     href: '/docs/forms',
   },
   {
+    name: 'Typeset',
+    href: '/docs/typeset',
+  },
+  {
     name: 'Changelog',
     href: '/docs/changelog',
   },

--- a/apps/v4/components/typeset/Customizer.vue
+++ b/apps/v4/components/typeset/Customizer.vue
@@ -1,0 +1,101 @@
+<script setup lang="ts">
+import {
+  ArrowHorizontalIcon,
+  ParagraphSpacingIcon,
+  TextSmallcapsIcon,
+} from '@hugeicons/core-free-icons'
+import { LineHeightIcon } from '@/lib/typeset/icons'
+import {
+  TYPESET_FLOWS,
+  TYPESET_LEADINGS,
+  TYPESET_MEASURES,
+  TYPESET_SIZES,
+} from '@/lib/typeset/params'
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+} from '@/styles/reka-nova/ui/card'
+import { FieldGroup, FieldSeparator } from '@/styles/reka-nova/ui/field'
+
+const params = useTypesetSearchParams()
+const isMobile = useIsMobile()
+
+// The resolved px rhythm is a design-time aid, not something to ship.
+const isDev = import.meta.dev
+
+// Resolve the rhythm to px off the current size: leading is a multiple, flow is
+// an em value.
+const sizePx = computed(() => Number(params.scale.value))
+const leadingPx = computed(() => Math.round(sizePx.value * Number(params.leading.value)))
+const flowPx = computed(() => Math.round(sizePx.value * Number.parseFloat(params.flow.value)))
+</script>
+
+<template>
+  <Card
+    size="sm"
+    class="dark isolate z-10 max-h-full min-h-0 w-full self-start rounded-2xl bg-card/90 backdrop-blur-xl md:w-(--customizer-width)"
+  >
+    <CardHeader class="hidden items-center justify-between gap-2 border-b md:flex">
+      <TypesetMainMenu />
+    </CardHeader>
+    <CardContent class="no-scrollbar min-h-0 flex-1 overflow-x-auto overflow-y-hidden max-md:px-0 md:overflow-y-auto">
+      <FieldGroup class="flex-row gap-2.5 py-px **:data-[slot=field-separator]:-mx-4 **:data-[slot=field-separator]:w-auto max-md:px-3 md:flex-col md:gap-3.25">
+        <!-- Below ~60ch the viewport already constrains width, so measure does
+             nothing: hide it. -->
+        <TypesetOptionPicker
+          v-model="params.measure.value"
+          label="Measure"
+          param="measure"
+          class="max-[28rem]:hidden"
+          :icon="ArrowHorizontalIcon"
+          :options="TYPESET_MEASURES"
+          :is-mobile="isMobile"
+        />
+        <FieldSeparator class="hidden md:block" />
+        <TypesetFontPicker label="Heading" param="heading" :is-mobile="isMobile" />
+        <TypesetFontPicker label="Body" param="body" :is-mobile="isMobile" />
+        <TypesetFontPicker label="Mono" param="mono" :is-mobile="isMobile" />
+        <FieldSeparator class="hidden md:block" />
+        <TypesetOptionPicker
+          v-model="params.scale.value"
+          label="Size"
+          param="scale"
+          :icon="TextSmallcapsIcon"
+          :options="TYPESET_SIZES"
+          :is-mobile="isMobile"
+        />
+        <TypesetOptionPicker
+          v-model="params.leading.value"
+          label="Leading"
+          param="leading"
+          :icon="LineHeightIcon"
+          :options="TYPESET_LEADINGS"
+          :is-mobile="isMobile"
+        />
+        <TypesetOptionPicker
+          v-model="params.flow.value"
+          label="Flow"
+          param="flow"
+          :icon="ParagraphSpacingIcon"
+          :options="TYPESET_FLOWS"
+          :is-mobile="isMobile"
+        />
+        <div
+          v-if="isDev"
+          class="hidden px-1 pt-0.5 text-center font-mono text-xs text-muted-foreground tabular-nums md:block"
+        >
+          {{ sizePx }}px / {{ leadingPx }}px / {{ flowPx }}px
+        </div>
+        <!-- Scroll-end spacer: the group is a CQ container (inline-size
+             containment), so trailing padding cannot grow it. -->
+        <div aria-hidden class="w-0.5 shrink-0 md:hidden" />
+      </FieldGroup>
+    </CardContent>
+    <CardFooter class="flex min-w-0 flex-row-reverse gap-2 border-t md:flex-col md:**:[button]:w-full">
+      <TypesetRandomButton class="min-w-0 flex-1 md:flex-none" />
+      <TypesetGetCodeDrawer class="min-w-0 flex-1 touch-manipulation bg-transparent! px-2! py-0! text-sm! transition-none select-none hover:bg-muted! md:flex-none xl:hidden pointer-coarse:h-10!" />
+    </CardFooter>
+  </Card>
+</template>

--- a/apps/v4/components/typeset/DocsCode.vue
+++ b/apps/v4/components/typeset/DocsCode.vue
@@ -1,0 +1,15 @@
+<script setup lang="ts">
+import type { HTMLAttributes } from 'vue'
+import { cn } from '@/lib/utils'
+
+const props = defineProps<{
+  code: string
+  class?: HTMLAttributes['class']
+}>()
+</script>
+
+<template>
+  <div class="relative rounded-lg bg-muted/60">
+    <pre :class="cn('scrollbar-none overflow-x-auto p-3 font-mono text-sm leading-relaxed', props.class)">{{ code }}</pre>
+  </div>
+</template>

--- a/apps/v4/components/typeset/DocsContent.vue
+++ b/apps/v4/components/typeset/DocsContent.vue
@@ -1,0 +1,253 @@
+<script setup lang="ts">
+import type { TemplateValue } from '@/lib/templates'
+import { CheckIcon, CopyIcon } from '@lucide/vue'
+import { useClipboard } from '@vueuse/core'
+import { siteConfig } from '@/lib/config'
+import { PACKAGE_MANAGERS, TEMPLATES } from '@/lib/templates'
+import {
+  getCommandForPackageManager,
+  getFontsourceCommand,
+  getFontsourceCss,
+  getFontVariablesCss,
+  getNuxtFontCode,
+} from '@/lib/typeset/code'
+import { findTypesetFont } from '@/lib/typeset/fonts'
+import { TYPESET_MEASURES } from '@/lib/typeset/params'
+import { Button } from '@/styles/reka-nova/ui/button'
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/styles/reka-nova/ui/select'
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from '@/styles/reka-nova/ui/tabs'
+
+const params = useTypesetSearchParams()
+const { config } = useConfig()
+
+const framework = ref<TemplateValue>('nuxt')
+const isNuxt = computed(() => framework.value === 'nuxt')
+
+const importSnippet = '@import "tailwindcss";\n@import "./typeset.css";'
+
+// Served straight from public/ so the copy is always the current stylesheet,
+// byte for byte what the docs tell people to save.
+const { data: rawCss } = await useFetch<string>('/typeset.css', {
+  responseType: 'text',
+  server: false,
+})
+
+const pickedFonts = computed(() => {
+  const ids = [params.body.value, params.heading.value, params.mono.value]
+  return [...new Set(ids)]
+    .map(id => findTypesetFont(id))
+    .filter(font => font !== undefined)
+})
+
+const measureWidth = computed(
+  () => TYPESET_MEASURES.find(option => option.value === params.measure.value)?.width,
+)
+
+const presetName = computed(() => `typeset-${params.item.value}`)
+
+const presetCss = computed(() => {
+  const headingId = params.heading.value === 'inherit' ? params.body.value : params.heading.value
+  const bodyVar = findTypesetFont(params.body.value)?.cssVar
+  const headingVar = findTypesetFont(headingId)?.cssVar
+  const monoVar = findTypesetFont(params.mono.value)?.cssVar
+
+  return `.${presetName.value} {
+  --typeset-font-body: var(${bodyVar});
+  --typeset-font-heading: var(${headingVar});
+  --typeset-font-mono: var(${monoVar});
+  --typeset-size: ${params.scale.value}px;
+  --typeset-leading: ${params.leading.value};
+  --typeset-flow: ${params.flow.value};
+}`
+})
+
+const preset = computed(() => `/* main.css */
+@import "tailwindcss";
+@import "./typeset.css";
+
+${presetCss.value}`)
+
+const usage = computed(() => `<div class="typeset ${presetName.value} max-w-[${measureWidth.value}]">
+  <!-- rendered markdown -->
+</div>`)
+
+const fontsourceCommand = computed(() => getFontsourceCommand(pickedFonts.value))
+const resolvedFontsourceCommand = computed(() =>
+  getCommandForPackageManager(config.value.packageManager, fontsourceCommand.value),
+)
+const fontsourceCss = computed(() => getFontsourceCss(pickedFonts.value))
+const nuxtFontCode = computed(() => getNuxtFontCode(pickedFonts.value))
+const fontVariablesCss = computed(() => getFontVariablesCss(pickedFonts.value))
+
+const prompt = computed(() => {
+  const fontStep = isNuxt.value
+    ? `Register the fonts with @nuxt/fonts:
+
+${nuxtFontCode.value}
+
+Then declare the CSS variables in the main CSS file:
+
+${fontVariablesCss.value}`
+    : `Install the fonts:
+
+${resolvedFontsourceCommand.value}
+
+Then import them in the main CSS file:
+
+${fontsourceCss.value}`
+
+  return `Install shadcn/typeset in this project.
+
+Typeset is a single stylesheet that styles rendered markdown: wrap the output in a \`typeset\` container and everything inside (headings, lists, tables, code, blockquotes, math) is styled. Everything outside is untouched.
+
+1. Download ${siteConfig.url}/typeset.css and save it as typeset.css next to the project's main CSS file (where Tailwind is imported). If the file already exists, replace it with the downloaded copy.
+
+2. Import it in the main CSS file, after the Tailwind import:
+
+@import "./typeset.css";
+
+3. ${fontStep}
+
+4. Add this preset to the main CSS file, after the typeset import. If a class named .${presetName.value} already exists, update its values in place. Leave any other typeset-* presets untouched: they are separate surfaces:
+
+${presetCss.value}
+
+5. Do not apply the class anywhere yet. Search the project for surfaces that render markdown or rich content: Nuxt Content's ContentRenderer, markdown-it or marked output bound with v-html, MDC components, prose classes, CMS content renderers. Present the candidates you find as a short list and ask the user which surface should use typeset. Then wrap only the surface they pick:
+
+${usage.value}
+
+If the picked surface already has its own typography (a prose class, styled markdown components), list those styles and let the user decide what to remove before wrapping.
+
+Notes:
+
+- To exclude an embedded component from typeset styles, add the not-typeset class or the data-not-typeset attribute to it.
+- Verify on the surface the user picked: headings, lists, tables, and code inside the container should be styled with no classes on the content itself.
+- Docs: ${siteConfig.url}/docs/typeset`
+})
+
+const { copy: copyCss, copied: copiedCss } = useClipboard({ copiedDuring: 2000 })
+const { copy: copyPrompt, copied: copiedPrompt } = useClipboard({ copiedDuring: 2000 })
+</script>
+
+<template>
+  <Tabs default-value="docs" class="flex min-h-0 flex-1 flex-col gap-0">
+    <div class="flex items-center justify-between gap-2 border-b px-4 py-3">
+      <TabsList>
+        <TabsTrigger value="docs">
+          Docs
+        </TabsTrigger>
+        <TabsTrigger value="prompt">
+          Prompt
+        </TabsTrigger>
+      </TabsList>
+      <Select v-model="framework">
+        <SelectTrigger size="sm">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent align="end">
+          <SelectGroup>
+            <SelectItem v-for="template in TEMPLATES" :key="template.value" :value="template.value">
+              {{ template.title }}
+            </SelectItem>
+          </SelectGroup>
+        </SelectContent>
+      </Select>
+    </div>
+    <div class="min-h-0 flex-1 scroll-fade scrollbar-none overflow-y-auto p-4 md:p-6">
+      <TabsContent value="docs" class="flex flex-col gap-6">
+        <section class="flex flex-col gap-2.5">
+          <h3 class="text-sm font-medium">
+            1. Create typeset.css
+          </h3>
+          <p class="text-sm leading-relaxed text-muted-foreground">
+            Copy the stylesheet into a <code class="font-mono">typeset.css</code> file next to your
+            main CSS file, then import it:
+          </p>
+          <Button
+            variant="outline"
+            size="sm"
+            class="w-fit"
+            :disabled="!rawCss"
+            @click="rawCss && copyCss(rawCss)"
+          >
+            <CheckIcon v-if="copiedCss" data-icon="inline-start" />
+            <CopyIcon v-else data-icon="inline-start" />
+            Copy typeset.css
+          </Button>
+          <TypesetDocsCode :code="importSnippet" />
+        </section>
+        <section class="flex flex-col gap-2.5">
+          <h3 class="text-sm font-medium">
+            2. Add the fonts
+          </h3>
+          <template v-if="isNuxt">
+            <p class="text-sm leading-relaxed text-muted-foreground">
+              Register the families with <code class="font-mono">@nuxt/fonts</code>:
+            </p>
+            <TypesetDocsCode :code="nuxtFontCode" />
+            <p class="text-sm leading-relaxed text-muted-foreground">
+              Then declare the variables in your CSS file:
+            </p>
+            <TypesetDocsCode :code="fontVariablesCss" />
+          </template>
+          <template v-else>
+            <div class="rounded-lg bg-muted/60">
+              <div class="flex items-center gap-3 px-3 pt-2">
+                <button
+                  v-for="pm in PACKAGE_MANAGERS"
+                  :key="pm.value"
+                  type="button"
+                  :data-active="pm.value === config.packageManager"
+                  class="font-mono text-xs text-muted-foreground transition-colors hover:text-foreground data-[active=true]:text-foreground"
+                  @click="config.packageManager = pm.value"
+                >
+                  {{ pm.label }}
+                </button>
+              </div>
+              <pre class="scrollbar-none overflow-x-auto p-3 font-mono text-xs leading-relaxed">{{ resolvedFontsourceCommand }}</pre>
+            </div>
+            <p class="text-sm leading-relaxed text-muted-foreground">
+              Then import them in your CSS file:
+            </p>
+            <TypesetDocsCode :code="fontsourceCss" />
+          </template>
+        </section>
+        <section class="flex flex-col gap-2.5">
+          <h3 class="text-sm font-medium">
+            3. Create your custom typeset
+          </h3>
+          <TypesetDocsCode :code="preset" />
+        </section>
+        <section class="flex flex-col gap-2.5">
+          <h3 class="text-sm font-medium">
+            4. Wrap your content
+          </h3>
+          <TypesetDocsCode :code="usage" />
+        </section>
+      </TabsContent>
+      <TabsContent value="prompt" class="flex flex-col gap-2.5">
+        <p class="text-sm leading-relaxed text-muted-foreground">
+          One prompt with your picks baked in. Copy it and paste it into your coding agent.
+        </p>
+        <TypesetDocsCode :code="prompt" class="max-h-102 scroll-fade overflow-y-auto whitespace-pre-wrap" />
+        <Button variant="outline" size="sm" class="w-fit" @click="copyPrompt(prompt)">
+          <CheckIcon v-if="copiedPrompt" data-icon="inline-start" />
+          <CopyIcon v-else data-icon="inline-start" />
+          Copy Prompt
+        </Button>
+      </TabsContent>
+    </div>
+  </Tabs>
+</template>

--- a/apps/v4/components/typeset/DocsPanel.vue
+++ b/apps/v4/components/typeset/DocsPanel.vue
@@ -1,0 +1,16 @@
+<script setup lang="ts">
+import { Button } from '@/styles/reka-nova/ui/button'
+</script>
+
+<template>
+  <div class="hidden w-88 flex-col items-start gap-3 xl:flex 2xl:w-104">
+    <div class="isolate flex max-h-[calc(100vh-16rem)] w-full flex-col overflow-hidden rounded-2xl bg-background ring-1 ring-foreground/10">
+      <TypesetDocsContent />
+    </div>
+    <Button variant="link" size="sm" as-child class="text-muted-foreground">
+      <NuxtLink to="/docs/typeset">
+        Read the docs
+      </NuxtLink>
+    </Button>
+  </div>
+</template>

--- a/apps/v4/components/typeset/FontPicker.vue
+++ b/apps/v4/components/typeset/FontPicker.vue
@@ -1,0 +1,116 @@
+<script setup lang="ts">
+import { findTypesetFont, TYPESET_FONTS } from '@/lib/typeset/fonts'
+import { coerceTypesetValue } from '@/lib/typeset/params'
+
+const props = defineProps<{
+  label: string
+  param: 'body' | 'heading' | 'mono'
+  isMobile: boolean
+}>()
+
+const params = useTypesetSearchParams()
+const { setOverride, clearOverride } = useTypesetPreviewOverride()
+
+const currentValue = computed(() => params[props.param].value)
+
+const bodyFont = computed(() => findTypesetFont(params.body.value) ?? TYPESET_FONTS[0]!)
+
+// The heading picker's first entry is "inherit": it follows whatever the body
+// font is, so it renders under the body font's name rather than "Inherit".
+const inheritsBodyFont = computed(
+  () => props.param === 'heading' && currentValue.value === 'inherit',
+)
+
+const currentFont = computed(() =>
+  inheritsBodyFont.value
+    ? bodyFont.value
+    : findTypesetFont(currentValue.value) ?? bodyFont.value,
+)
+
+// Every picker offers every font (no type filter); grouping is just labels.
+const groupedFonts = computed(() => [
+  { label: 'Sans', fonts: TYPESET_FONTS.filter(font => font.type === 'sans') },
+  { label: 'Serif', fonts: TYPESET_FONTS.filter(font => font.type === 'serif') },
+  { label: 'Mono', fonts: TYPESET_FONTS.filter(font => font.type === 'mono') },
+])
+
+function selectFont(value: string) {
+  const coerced = coerceTypesetValue(props.param, value)
+  if (coerced !== null) {
+    params[props.param].value = coerced as never
+  }
+}
+
+function previewFont(value: string) {
+  if (props.isMobile) {
+    return
+  }
+  const coerced = coerceTypesetValue(props.param, value)
+  if (coerced !== null) {
+    setOverride({ [props.param]: coerced })
+  }
+}
+</script>
+
+<template>
+  <div class="group/picker relative">
+    <Picker @update:open="(open: boolean) => !open && clearOverride()">
+      <PickerTrigger>
+        <div class="flex flex-col justify-start text-left">
+          <div class="text-xs text-muted-foreground">
+            {{ label }}
+          </div>
+          <div class="line-clamp-1 max-w-[80%] truncate text-sm font-medium text-foreground">
+            {{ currentFont.label }}
+          </div>
+        </div>
+        <div
+          class="pointer-events-none absolute top-1/2 right-4 flex size-4 -translate-y-1/2 items-center justify-center text-base text-foreground select-none md:right-2.5"
+          :style="{ fontFamily: currentFont.value }"
+        >
+          Aa
+        </div>
+      </PickerTrigger>
+      <PickerContent
+        :side="isMobile ? 'top' : 'right'"
+        :align="isMobile ? 'center' : 'start'"
+        class="max-h-96"
+        @mouseleave="clearOverride"
+      >
+        <PickerRadioGroup
+          :model-value="currentValue"
+          @update:model-value="(value) => selectFont(value as string)"
+        >
+          <template v-if="param === 'heading'">
+            <PickerGroup>
+              <PickerRadioItem
+                value="inherit"
+                @mousemove="previewFont('inherit')"
+                @focus="previewFont('inherit')"
+              >
+                {{ bodyFont.label }}
+              </PickerRadioItem>
+            </PickerGroup>
+            <PickerSeparator />
+          </template>
+          <PickerGroup v-for="group in groupedFonts" :key="group.label">
+            <PickerLabel>{{ group.label }}</PickerLabel>
+            <PickerRadioItem
+              v-for="font in group.fonts"
+              :key="font.id"
+              :value="font.id"
+              @mousemove="previewFont(font.id)"
+              @focus="previewFont(font.id)"
+            >
+              {{ font.label }}
+            </PickerRadioItem>
+          </PickerGroup>
+        </PickerRadioGroup>
+      </PickerContent>
+    </Picker>
+    <TypesetLockButton
+      :param="param"
+      class="absolute top-1/2 right-8 -translate-y-1/2"
+    />
+  </div>
+</template>

--- a/apps/v4/components/typeset/GetCodeDrawer.vue
+++ b/apps/v4/components/typeset/GetCodeDrawer.vue
@@ -1,0 +1,46 @@
+<script setup lang="ts">
+import type { HTMLAttributes } from 'vue'
+import { Button } from '@/styles/reka-nova/ui/button'
+import {
+  Drawer,
+  DrawerClose,
+  DrawerContent,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerTrigger,
+} from '@/styles/reka-nova/ui/drawer'
+
+const props = defineProps<{
+  class?: HTMLAttributes['class']
+}>()
+
+const isMobile = useIsMobile()
+</script>
+
+<template>
+  <Drawer :direction="isMobile ? 'bottom' : 'right'">
+    <DrawerTrigger as-child>
+      <Button variant="outline" :class="props.class">
+        Get Code
+      </Button>
+    </DrawerTrigger>
+    <DrawerContent :data-mobile="isMobile" class="data-[mobile=true]:max-h-[85svh]">
+      <DrawerHeader>
+        <DrawerTitle>Get Code</DrawerTitle>
+        <DrawerDescription>
+          Install typeset with the values you picked.
+        </DrawerDescription>
+      </DrawerHeader>
+      <TypesetDocsContent />
+      <DrawerFooter>
+        <DrawerClose as-child>
+          <Button variant="outline">
+            Done
+          </Button>
+        </DrawerClose>
+      </DrawerFooter>
+    </DrawerContent>
+  </Drawer>
+</template>

--- a/apps/v4/components/typeset/LockButton.vue
+++ b/apps/v4/components/typeset/LockButton.vue
@@ -1,0 +1,35 @@
+<script setup lang="ts">
+import type { HTMLAttributes } from 'vue'
+import type { TypesetLockableParam } from '@/lib/typeset/params'
+import { SquareLock01Icon, SquareUnlock01Icon } from '@hugeicons/core-free-icons'
+import { HugeiconsIcon } from '@hugeicons/vue'
+import { cn } from '@/lib/utils'
+
+const props = defineProps<{
+  param: TypesetLockableParam
+  class?: HTMLAttributes['class']
+}>()
+
+const { isLocked, toggleLock } = useTypesetLocks()
+const locked = computed(() => isLocked(props.param))
+</script>
+
+<template>
+  <button
+    type="button"
+    :title="locked ? 'Unlock' : 'Lock'"
+    :aria-label="locked ? 'Unlock' : 'Lock'"
+    :data-locked="locked"
+    :class="cn(
+      'flex size-4 cursor-pointer items-center justify-center rounded opacity-0 ring-foreground/60 transition-opacity outline-none group-focus-within/picker:opacity-100 group-hover/picker:opacity-100 focus:opacity-100 focus-visible:ring-1 data-[locked=true]:opacity-100 max-md:hidden pointer-coarse:hidden',
+      props.class,
+    )"
+    @click="toggleLock(param)"
+  >
+    <HugeiconsIcon
+      :icon="locked ? SquareLock01Icon : SquareUnlock01Icon"
+      :stroke-width="2"
+      class="size-5 text-foreground"
+    />
+  </button>
+</template>

--- a/apps/v4/components/typeset/MainMenu.vue
+++ b/apps/v4/components/typeset/MainMenu.vue
@@ -17,7 +17,7 @@ const { shuffle, reset } = useTypesetShuffle()
 
 // R shuffles, ⇧R resets. Undo/Redo (⌘Z) and Light/Dark (D) are bound in their
 // own composables.
-useEventListener(document, 'keydown', (event: KeyboardEvent) => {
+useEventListener(globalThis.document, 'keydown', (event: KeyboardEvent) => {
   if (event.metaKey || event.ctrlKey || event.altKey) {
     return
   }

--- a/apps/v4/components/typeset/MainMenu.vue
+++ b/apps/v4/components/typeset/MainMenu.vue
@@ -1,0 +1,75 @@
+<script setup lang="ts">
+import type { HTMLAttributes } from 'vue'
+import { Menu09Icon } from '@hugeicons/core-free-icons'
+import { HugeiconsIcon } from '@hugeicons/vue'
+import { useEventListener } from '@vueuse/core'
+import { isEditableTarget } from '@/lib/typeset/keyboard'
+import { cn } from '@/lib/utils'
+
+const props = defineProps<{
+  class?: HTMLAttributes['class']
+}>()
+
+const isMac = useIsMac()
+const { canGoBack, canGoForward, goBack, goForward } = useTypesetHistory()
+const { toggleTheme } = useTypesetThemeToggle()
+const { shuffle, reset } = useTypesetShuffle()
+
+// R shuffles, ⇧R resets. Undo/Redo (⌘Z) and Light/Dark (D) are bound in their
+// own composables.
+useEventListener(document, 'keydown', (event: KeyboardEvent) => {
+  if (event.metaKey || event.ctrlKey || event.altKey) {
+    return
+  }
+  if (isEditableTarget(event.target)) {
+    return
+  }
+  if (event.key !== 'r' && event.key !== 'R') {
+    return
+  }
+  event.preventDefault()
+  if (event.shiftKey) {
+    reset()
+  }
+  else {
+    shuffle()
+  }
+})
+</script>
+
+<template>
+  <Picker>
+    <PickerTrigger
+      :class="cn(
+        'flex items-center justify-between gap-2 rounded-lg px-1.75 ring-1 ring-foreground/10 focus-visible:ring-1',
+        props.class,
+      )"
+    >
+      <span class="font-medium">Menu</span>
+      <HugeiconsIcon :icon="Menu09Icon" :stroke-width="2" class="size-5" />
+    </PickerTrigger>
+    <PickerContent side="right" align="start" :align-offset="-8">
+      <PickerGroup>
+        <PickerItem @click="shuffle">
+          Shuffle <PickerShortcut>R</PickerShortcut>
+        </PickerItem>
+        <PickerItem @click="toggleTheme">
+          Light/Dark <PickerShortcut>D</PickerShortcut>
+        </PickerItem>
+      </PickerGroup>
+      <PickerSeparator />
+      <PickerGroup>
+        <PickerItem :disabled="!canGoBack" @click="goBack">
+          Undo <PickerShortcut>{{ isMac ? '⌘Z' : 'Ctrl+Z' }}</PickerShortcut>
+        </PickerItem>
+        <PickerItem :disabled="!canGoForward" @click="goForward">
+          Redo <PickerShortcut>{{ isMac ? '⇧⌘Z' : 'Ctrl+Shift+Z' }}</PickerShortcut>
+        </PickerItem>
+        <PickerSeparator />
+        <PickerItem @click="reset">
+          Reset <PickerShortcut>⇧R</PickerShortcut>
+        </PickerItem>
+      </PickerGroup>
+    </PickerContent>
+  </Picker>
+</template>

--- a/apps/v4/components/typeset/OptionPicker.vue
+++ b/apps/v4/components/typeset/OptionPicker.vue
@@ -1,0 +1,85 @@
+<script setup lang="ts">
+import type { HTMLAttributes } from 'vue'
+import type { TypesetIcon } from '@/lib/typeset/icons'
+import type { TypesetLockableParam, TypesetParamKey } from '@/lib/typeset/params'
+import { HugeiconsIcon } from '@hugeicons/vue'
+import { coerceTypesetValue } from '@/lib/typeset/params'
+import { cn } from '@/lib/utils'
+
+const props = defineProps<{
+  label: string
+  /** Omit to render a picker that neither locks nor previews on hover. */
+  param?: TypesetLockableParam
+  icon?: TypesetIcon
+  options: readonly { label: string, value: string }[]
+  isMobile: boolean
+  class?: HTMLAttributes['class']
+}>()
+
+const model = defineModel<string>({ required: true })
+
+const { setOverride, clearOverride } = useTypesetPreviewOverride()
+
+const current = computed(() =>
+  props.options.find(option => option.value === model.value),
+)
+
+// Previews apply when the pointer settles: every mousemove re-arms the trailing
+// timer in useTypesetPreviewOverride, so nothing applies while the cursor is in
+// motion. Reka moves DOM focus to the highlighted item, so `focus` covers
+// keyboard (arrow key) browsing. Touch gets no preview — there is no hover.
+function previewItem(value: string) {
+  if (props.isMobile || !props.param) {
+    return
+  }
+  const coerced = coerceTypesetValue(props.param as TypesetParamKey, value)
+  if (coerced !== null) {
+    setOverride({ [props.param]: coerced })
+  }
+}
+</script>
+
+<template>
+  <div :class="cn('group/picker relative', props.class)">
+    <Picker @update:open="(open: boolean) => !open && clearOverride()">
+      <PickerTrigger>
+        <div class="flex min-w-0 flex-col justify-start pr-8 text-left">
+          <div class="text-xs text-muted-foreground">
+            {{ label }}
+          </div>
+          <div class="line-clamp-1 text-sm font-medium text-foreground">
+            {{ current?.label }}
+          </div>
+        </div>
+        <div
+          v-if="icon"
+          class="pointer-events-none absolute top-1/2 right-4 flex size-4 -translate-y-1/2 items-center justify-center text-foreground select-none md:right-2.5"
+        >
+          <HugeiconsIcon :icon="icon" :stroke-width="2" class="size-4.5" />
+        </div>
+      </PickerTrigger>
+      <PickerContent
+        :side="isMobile ? 'top' : 'right'"
+        :align="isMobile ? 'center' : 'start'"
+        @mouseleave="clearOverride"
+      >
+        <PickerRadioGroup v-model="model">
+          <PickerRadioItem
+            v-for="option in options"
+            :key="option.value"
+            :value="option.value"
+            @mousemove="previewItem(option.value)"
+            @focus="previewItem(option.value)"
+          >
+            {{ option.label }}
+          </PickerRadioItem>
+        </PickerRadioGroup>
+      </PickerContent>
+    </Picker>
+    <TypesetLockButton
+      v-if="param"
+      :param="param"
+      class="absolute top-1/2 right-8 -translate-y-1/2"
+    />
+  </div>
+</template>

--- a/apps/v4/components/typeset/Preview.vue
+++ b/apps/v4/components/typeset/Preview.vue
@@ -1,0 +1,112 @@
+<script setup lang="ts">
+import type { TypesetCommand, TypesetSearchParams } from '@/lib/typeset/params'
+import { useEventListener } from '@vueuse/core'
+import {
+  serializeTypesetSearchParams,
+  TYPESET_COMMAND_MESSAGE,
+  TYPESET_PARAMS_MESSAGE,
+  TYPESET_READY_MESSAGE,
+} from '@/lib/typeset/params'
+
+const params = useTypesetSearchParams()
+const { override } = useTypesetPreviewOverride()
+const { shuffle, reset } = useTypesetShuffle()
+const { goBack, goForward } = useTypesetHistory()
+const { toggleTheme } = useTypesetThemeToggle({ shortcut: false })
+
+const iframeRef = ref<HTMLIFrameElement | null>(null)
+
+// Hover previews overlay the committed params without touching the URL —
+// clearing the override re-sends the committed params, reverting the preview.
+// Overrides never contain `item`, so the reload branch below is only ever
+// driven by committed changes.
+const mergedParams = computed<TypesetSearchParams>(() => ({
+  ...params.toValues(),
+  ...(override.value ?? {}),
+}))
+
+// Deliberately NOT a computed over mergedParams. The URL only seeds the
+// iframe's first paint; every later change rides the postMessage channel
+// below. Recomputing it per param would rewrite `src` and navigate the iframe
+// on every pick — and on every hover preview.
+//
+// `item` is the exception: it picks a different specimen route, so it needs a
+// real navigation. The watch re-seeds the URL and the matching `key` remounts
+// the iframe onto it.
+function buildPreviewUrl() {
+  return serializeTypesetSearchParams(
+    `/preview/typeset/${params.item.value}`,
+    mergedParams.value,
+  )
+}
+
+const previewUrl = ref(buildPreviewUrl())
+
+watch(() => params.item.value, () => {
+  previewUrl.value = buildPreviewUrl()
+})
+
+function sendParams() {
+  iframeRef.value?.contentWindow?.postMessage(
+    { type: TYPESET_PARAMS_MESSAGE, data: mergedParams.value },
+    window.location.origin,
+  )
+}
+
+// Every param change after the initial load goes over postMessage, so the
+// iframe restyles in place instead of reloading and flashing.
+watch(mergedParams, () => sendParams(), { flush: 'post' })
+
+const commands: Record<TypesetCommand, () => void> = {
+  shuffle,
+  reset,
+  'undo': goBack,
+  'redo': goForward,
+  'toggle-theme': toggleTheme,
+}
+
+// The iframe forwards its keyboard shortcuts as typed commands; handle them
+// here by calling the real actions.
+useEventListener(globalThis.window, 'message', (event: MessageEvent) => {
+  const iframeWindow = iframeRef.value?.contentWindow
+  if (
+    !iframeWindow
+    || event.origin !== window.location.origin
+    || event.source !== iframeWindow
+    || event.data?.type !== TYPESET_COMMAND_MESSAGE
+  ) {
+    return
+  }
+
+  const command = event.data.command as TypesetCommand
+  if (command in commands) {
+    commands[command]()
+  }
+})
+
+// The preview announces when its listener is live; answer with the current
+// design. `load` alone is not enough — it fires before the iframe hydrates.
+useEventListener(globalThis.window, 'message', (event: MessageEvent) => {
+  if (
+    event.origin === window.location.origin
+    && event.source === iframeRef.value?.contentWindow
+    && event.data?.type === TYPESET_READY_MESSAGE
+  ) {
+    sendParams()
+  }
+})
+</script>
+
+<template>
+  <div class="relative isolate flex size-full min-h-0 flex-1 overflow-hidden rounded-2xl bg-background ring-1 ring-foreground/10">
+    <iframe
+      ref="iframeRef"
+      :key="params.item.value"
+      :src="previewUrl"
+      title="typeset preview"
+      class="size-full"
+      @load="sendParams"
+    />
+    <TypesetToolbar />
+  </div>
+</template>

--- a/apps/v4/components/typeset/Preview.vue
+++ b/apps/v4/components/typeset/Preview.vue
@@ -33,10 +33,12 @@ const mergedParams = computed<TypesetSearchParams>(() => ({
 // `item` is the exception: it picks a different specimen route, so it needs a
 // real navigation. The watch re-seeds the URL and the matching `key` remounts
 // the iframe onto it.
+// Seeded from the committed params, never the merged ones: a hover preview is
+// uncommitted by definition and must not be baked into a real navigation.
 function buildPreviewUrl() {
   return serializeTypesetSearchParams(
     `/preview/typeset/${params.item.value}`,
-    mergedParams.value,
+    params.toValues(),
   )
 }
 

--- a/apps/v4/components/typeset/RandomButton.vue
+++ b/apps/v4/components/typeset/RandomButton.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+import type { HTMLAttributes } from 'vue'
+import { cn } from '@/lib/utils'
+import { Button } from '@/styles/reka-nova/ui/button'
+
+const props = defineProps<{
+  class?: HTMLAttributes['class']
+}>()
+
+const { shuffle } = useTypesetShuffle()
+</script>
+
+<template>
+  <Button
+    variant="outline"
+    :class="cn(
+      'touch-manipulation bg-transparent! px-2! py-0! text-sm! transition-none select-none hover:bg-muted! pointer-coarse:h-10!',
+      props.class,
+    )"
+    @click="shuffle"
+  >
+    <span class="w-full truncate text-center font-medium">Shuffle</span>
+  </Button>
+</template>

--- a/apps/v4/components/typeset/Skeleton.vue
+++ b/apps/v4/components/typeset/Skeleton.vue
@@ -1,0 +1,14 @@
+<script setup lang="ts">
+import { Skeleton } from '@/styles/reka-nova/ui/skeleton'
+</script>
+
+<template>
+  <div
+    data-slot="designer"
+    class="flex min-h-0 flex-1 flex-col items-start gap-(--gap) p-(--gap) pt-[calc(var(--gap)*0.25)] md:flex-row-reverse"
+  >
+    <Skeleton class="isolate hidden w-88 shrink-0 self-stretch rounded-2xl xl:block 2xl:w-104" />
+    <Skeleton class="min-h-0 w-full flex-1 self-stretch rounded-2xl" />
+    <Skeleton class="min-h-[151px] w-full self-start rounded-2xl md:h-full md:max-h-full md:min-h-0 md:w-(--customizer-width)" />
+  </div>
+</template>

--- a/apps/v4/components/typeset/Toolbar.vue
+++ b/apps/v4/components/typeset/Toolbar.vue
@@ -1,0 +1,79 @@
+<script setup lang="ts">
+import { LinkSquare02Icon } from '@hugeicons/core-free-icons'
+import { HugeiconsIcon } from '@hugeicons/vue'
+import { CONTENT_OPTIONS, DEV_CONTENT_OPTIONS } from '@/lib/typeset/fixtures'
+import { serializeTypesetSearchParams } from '@/lib/typeset/params'
+import { Button } from '@/registry/new-york-v4/ui/button'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/styles/reka-nova/ui/tooltip'
+
+const params = useTypesetSearchParams()
+
+const isDev = import.meta.dev
+
+const openInNewTabHref = computed(() =>
+  serializeTypesetSearchParams(`/preview/typeset/${params.item.value}`, params.toValues()),
+)
+</script>
+
+<template>
+  <div class="absolute bottom-3 left-1/2 z-20 flex -translate-x-1/2 items-center justify-center gap-1.5">
+    <div class="dark flex items-center gap-1 rounded-xl bg-card/90 p-1 shadow-xl backdrop-blur-xl">
+      <Tooltip v-for="(option, index) in CONTENT_OPTIONS" :key="option.value">
+        <TooltipTrigger as-child>
+          <Button
+            variant="ghost"
+            size="sm"
+            :data-active="params.item.value === option.value"
+            class="h-7 min-w-7 cursor-pointer rounded-lg px-2 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground data-[active=true]:bg-accent data-[active=true]:text-accent-foreground"
+            @click="params.item.value = option.value"
+          >
+            {{ String(index + 1).padStart(2, '0') }}
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="top" :side-offset="10">
+          {{ option.label }}
+        </TooltipContent>
+      </Tooltip>
+      <div v-if="isDev && DEV_CONTENT_OPTIONS.length" class="hidden items-center gap-1 md:flex">
+        <div class="mx-0.5 h-4 w-px bg-border" />
+        <Tooltip v-for="(option, index) in DEV_CONTENT_OPTIONS" :key="option.value">
+          <TooltipTrigger as-child>
+            <Button
+              variant="ghost"
+              size="sm"
+              :data-active="params.item.value === option.value"
+              class="h-7 min-w-7 cursor-pointer rounded-lg px-2 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground data-[active=true]:bg-accent data-[active=true]:text-accent-foreground"
+              @click="params.item.value = option.value"
+            >
+              {{ String(CONTENT_OPTIONS.length + index + 1).padStart(2, '0') }}
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="top" :side-offset="10">
+            {{ option.label }}
+          </TooltipContent>
+        </Tooltip>
+      </div>
+    </div>
+    <div class="dark flex items-center gap-1 rounded-xl bg-card/90 p-1 shadow-xl backdrop-blur-xl">
+      <Button
+        as-child
+        variant="ghost"
+        size="sm"
+        class="h-7 cursor-pointer rounded-lg px-2.5 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
+      >
+        <a :href="openInNewTabHref" target="_blank" rel="noreferrer">
+          <HugeiconsIcon
+            :icon="LinkSquare02Icon"
+            :stroke-width="2"
+            class="size-3.5 md:hidden"
+          />
+          <span class="max-md:sr-only">Open in New Tab</span>
+        </a>
+      </Button>
+    </div>
+  </div>
+</template>

--- a/apps/v4/composables/useTypesetHistory.ts
+++ b/apps/v4/composables/useTypesetHistory.ts
@@ -1,0 +1,115 @@
+import { useEventListener } from '@vueuse/core'
+import { isEditableTarget } from '@/lib/typeset/keyboard'
+import {
+  parseTypesetSnapshot,
+  TYPESET_PARAM_KEYS,
+} from '@/lib/typeset/params'
+
+/**
+ * Undo/redo for the designer.
+ *
+ * The browser's own history is not usable here: every picker interaction writes
+ * with `replace` (see useTypesetSearchParams), so there is nothing to pop. This
+ * keeps its own stack of URL snapshots instead.
+ *
+ * Pass `record: true` from the owning page — exactly one caller must set up the
+ * recording watcher and the keyboard shortcuts. Every other caller gets the
+ * shared state and the actions.
+ */
+export function useTypesetHistory({ record = false } = {}) {
+  const route = useRoute()
+  const { setParams } = useTypesetSearchParams()
+
+  const entries = useState<string[]>('typeset-history-entries', () => [])
+  const index = useState('typeset-history-index', () => 0)
+  const maxIndex = useState('typeset-history-max-index', () => 0)
+
+  // Set while restoring, so the snapshot watcher does not record the change it
+  // just made as a new entry.
+  const isRestoring = useState('typeset-history-restoring', () => false)
+
+  const canGoBack = computed(() => index.value > 0)
+  const canGoForward = computed(() => index.value < maxIndex.value)
+
+  // A history entry is a snapshot of every typeset param read from the settled
+  // URL. Absent keys snapshot as null so restoring clears them back to their
+  // default.
+  const snapshot = computed(() => JSON.stringify(
+    Object.fromEntries(
+      TYPESET_PARAM_KEYS.map((key) => {
+        const value = route.query[key]
+        return [key, typeof value === 'string' ? value : null]
+      }),
+    ),
+  ))
+
+  function restore(entry: string | undefined) {
+    if (entry === undefined) {
+      return
+    }
+    isRestoring.value = true
+    setParams(parseTypesetSnapshot(entry))
+  }
+
+  function goBack() {
+    if (index.value <= 0) {
+      return
+    }
+    index.value -= 1
+    restore(entries.value[index.value])
+  }
+
+  function goForward() {
+    if (index.value >= maxIndex.value) {
+      return
+    }
+    index.value += 1
+    restore(entries.value[index.value])
+  }
+
+  if (record) {
+    watch(snapshot, (next) => {
+      // Seed the stack with the first snapshot (no undo available yet).
+      if (entries.value.length === 0) {
+        entries.value = [next]
+        return
+      }
+
+      if (isRestoring.value) {
+        isRestoring.value = false
+        return
+      }
+
+      if (next === entries.value[index.value]) {
+        return
+      }
+
+      // A new change after undoing discards the redo tail.
+      entries.value = [...entries.value.slice(0, index.value + 1), next]
+      index.value = entries.value.length - 1
+      maxIndex.value = index.value
+    }, { immediate: true })
+
+    useEventListener(document, 'keydown', (event: KeyboardEvent) => {
+      if (!event.metaKey && !event.ctrlKey) {
+        return
+      }
+      if (isEditableTarget(event.target)) {
+        return
+      }
+
+      const key = event.key.toLowerCase()
+      if ((key === 'z' && event.shiftKey) || (key === 'y' && event.ctrlKey)) {
+        event.preventDefault()
+        goForward()
+        return
+      }
+      if (key === 'z') {
+        event.preventDefault()
+        goBack()
+      }
+    })
+  }
+
+  return { canGoBack, canGoForward, goBack, goForward }
+}

--- a/apps/v4/composables/useTypesetHistory.ts
+++ b/apps/v4/composables/useTypesetHistory.ts
@@ -90,7 +90,7 @@ export function useTypesetHistory({ record = false } = {}) {
       maxIndex.value = index.value
     }, { immediate: true })
 
-    useEventListener(document, 'keydown', (event: KeyboardEvent) => {
+    useEventListener(globalThis.document, 'keydown', (event: KeyboardEvent) => {
       if (!event.metaKey && !event.ctrlKey) {
         return
       }

--- a/apps/v4/composables/useTypesetLocks.ts
+++ b/apps/v4/composables/useTypesetLocks.ts
@@ -1,0 +1,25 @@
+import type { TypesetLockableParam } from '@/lib/typeset/params'
+
+/**
+ * Which params Shuffle must leave alone.
+ *
+ * Backed by `useState` so every LockButton and the shuffle action share one
+ * store without leaking between SSR requests (a module-level ref would).
+ * Stored as an array rather than a Set because useState serialises into the
+ * Nuxt payload.
+ */
+export function useTypesetLocks() {
+  const locks = useState<TypesetLockableParam[]>('typeset-locks', () => [])
+
+  function isLocked(param: TypesetLockableParam) {
+    return locks.value.includes(param)
+  }
+
+  function toggleLock(param: TypesetLockableParam) {
+    locks.value = isLocked(param)
+      ? locks.value.filter(lock => lock !== param)
+      : [...locks.value, param]
+  }
+
+  return { locks, isLocked, toggleLock }
+}

--- a/apps/v4/composables/useTypesetPreviewOverride.ts
+++ b/apps/v4/composables/useTypesetPreviewOverride.ts
@@ -1,0 +1,66 @@
+import type { TypesetSearchParams } from '@/lib/typeset/params'
+
+export type TypesetPreviewOverride = Partial<TypesetSearchParams> | null
+
+/**
+ * How long the pointer must settle before a preview applies. Every mousemove
+ * over a picker item re-arms this trailing timer, so nothing applies while the
+ * cursor is in motion. Clears are never debounced: reverting on leave/Escape
+ * must feel instant.
+ */
+const PREVIEW_OVERRIDE_DEBOUNCE_MS = 50
+
+// One shared timer so a pending preview from one picker is cancelled the moment
+// another picker asks for one. Only ever touched from pointer/focus handlers,
+// so it never runs during SSR.
+let timeout: ReturnType<typeof setTimeout> | null = null
+
+function isSameOverride(a: TypesetPreviewOverride, b: TypesetPreviewOverride) {
+  if (a === b) {
+    return true
+  }
+  if (!a || !b) {
+    return false
+  }
+  const aKeys = Object.keys(a) as (keyof TypesetSearchParams)[]
+  const bKeys = Object.keys(b)
+  return aKeys.length === bKeys.length && aKeys.every(key => a[key] === b[key])
+}
+
+/**
+ * Uncommitted params applied to the preview while hovering a picker item.
+ *
+ * Kept out of the URL on purpose: the URL is what the undo stack snapshots, so
+ * committing hovers would record a phantom entry for every hovered item. The
+ * preview iframe receives these through the same postMessage channel as
+ * committed params and reverts when cleared.
+ */
+export function useTypesetPreviewOverride() {
+  const override = useState<TypesetPreviewOverride>('typeset-preview-override', () => null)
+
+  function cancelPending() {
+    if (timeout !== null) {
+      clearTimeout(timeout)
+      timeout = null
+    }
+  }
+
+  function setOverride(next: Partial<TypesetSearchParams>) {
+    cancelPending()
+    timeout = setTimeout(() => {
+      timeout = null
+      // Skip identical updates: mouseenter and focus both fire for the hovered
+      // item, and hovering the committed value is a no-op.
+      if (!isSameOverride(override.value, next)) {
+        override.value = next
+      }
+    }, PREVIEW_OVERRIDE_DEBOUNCE_MS)
+  }
+
+  function clearOverride() {
+    cancelPending()
+    override.value = null
+  }
+
+  return { override, setOverride, clearOverride }
+}

--- a/apps/v4/composables/useTypesetPreviewParams.ts
+++ b/apps/v4/composables/useTypesetPreviewParams.ts
@@ -1,0 +1,65 @@
+import type { TypesetSearchParams } from '@/lib/typeset/params'
+import { useEventListener } from '@vueuse/core'
+import {
+  coerceTypesetValue,
+  TYPESET_DEFAULTS,
+  TYPESET_PARAM_KEYS,
+  TYPESET_PARAMS_MESSAGE,
+  TYPESET_READY_MESSAGE,
+} from '@/lib/typeset/params'
+
+/**
+ * Param state for the preview iframe.
+ *
+ * The URL only *seeds* this: deep links and "Open in New Tab" carry the design
+ * in their query string, but once the designer is driving over postMessage the
+ * updates land in local reactive state and never touch the router.
+ *
+ * Writing them back through the router instead is what the designer does, and
+ * it does not work here: the iframe's first `router.replace` lands while Vue
+ * Router is still settling its initial navigation and is silently dropped, so
+ * the first pick after load never applies.
+ */
+export function useTypesetPreviewParams() {
+  const route = useRoute()
+
+  const seed = {} as TypesetSearchParams
+  for (const key of TYPESET_PARAM_KEYS) {
+    const raw = route.query[key]
+    const value = coerceTypesetValue(key, typeof raw === 'string' ? raw : null)
+    seed[key] = (value ?? TYPESET_DEFAULTS[key]) as never
+  }
+
+  const params = reactive<TypesetSearchParams>(seed)
+
+  // Announce as soon as the listener below is attached, so the designer can
+  // send the current design instead of racing the iframe's `load` event.
+  onMounted(() => {
+    if (window.parent && window.parent !== window) {
+      window.parent.postMessage(
+        { type: TYPESET_READY_MESSAGE },
+        window.location.origin,
+      )
+    }
+  })
+
+  useEventListener(globalThis.window, 'message', (event: MessageEvent) => {
+    if (event.origin !== window.location.origin) {
+      return
+    }
+    if (event.data?.type !== TYPESET_PARAMS_MESSAGE || !event.data.data) {
+      return
+    }
+
+    // Validate on the way in: the payload crosses a window boundary, so it is
+    // untrusted input even though it is same-origin.
+    for (const key of TYPESET_PARAM_KEYS) {
+      const value = coerceTypesetValue(key, event.data.data[key])
+      if (value !== null) {
+        params[key] = value as never
+      }
+    }
+  })
+
+  return params
+}

--- a/apps/v4/composables/useTypesetSearchParams.ts
+++ b/apps/v4/composables/useTypesetSearchParams.ts
@@ -1,0 +1,84 @@
+import type { WritableComputedRef } from 'vue'
+import type {
+  TypesetParamKey,
+  TypesetSearchParams,
+} from '@/lib/typeset/params'
+import { useRouteQuery } from '@vueuse/router'
+import { computed } from 'vue'
+import {
+  coerceTypesetValue,
+  TYPESET_DEFAULTS,
+  TYPESET_PARAM_KEYS,
+} from '@/lib/typeset/params'
+
+type TypesetParamRefs = {
+  [K in TypesetParamKey]: WritableComputedRef<TypesetSearchParams[K]>
+}
+
+/**
+ * URL-backed state for the typeset designer. One query key per param (so the
+ * URL stays shareable and human-readable, unlike /create's encoded preset).
+ *
+ * Reads are validated against the param model, so a hand-edited URL falls back
+ * to the default instead of rendering something broken. Writes drop values
+ * equal to the default, keeping the URL free of noise.
+ *
+ * Always writes with `replace`: every picker interaction would otherwise push a
+ * browser history entry, and the designer keeps its own undo stack
+ * (see useTypesetHistory).
+ */
+export function useTypesetSearchParams() {
+  const options = { mode: 'replace' as const, route: useRoute(), router: useRouter() }
+
+  // Built through a loose record: writing to a mapped type under a union key
+  // narrows the assignable type to `never`.
+  const built: Record<string, WritableComputedRef<string>> = {}
+
+  for (const key of TYPESET_PARAM_KEYS) {
+    const query = useRouteQuery<string | undefined>(key, undefined, options)
+
+    built[key] = computed({
+      get: () => coerceTypesetValue(key, query.value) ?? TYPESET_DEFAULTS[key],
+      set: (value) => {
+        query.value = value === TYPESET_DEFAULTS[key] ? undefined : value
+      },
+    })
+  }
+
+  const params = built as TypesetParamRefs
+
+  /** Current values as a plain object — the shape posted to the preview iframe. */
+  function toValues(): TypesetSearchParams {
+    const values = {} as TypesetSearchParams
+    for (const key of TYPESET_PARAM_KEYS) {
+      values[key] = params[key].value as never
+    }
+    return values
+  }
+
+  /**
+   * Applies a partial update. A `null` value clears the param back to its
+   * default, which is how history snapshots restore params that were absent
+   * from the URL.
+   */
+  function setParams(
+    next: Partial<{ [K in TypesetParamKey]: TypesetSearchParams[K] | null }>,
+  ) {
+    for (const key of TYPESET_PARAM_KEYS) {
+      if (!(key in next)) {
+        continue
+      }
+      const value = next[key]
+      params[key].value = (value ?? TYPESET_DEFAULTS[key]) as never
+    }
+  }
+
+  /** Clears every managed key back to its default. */
+  function resetParams() {
+    for (const key of TYPESET_PARAM_KEYS) {
+      params[key].value = TYPESET_DEFAULTS[key] as never
+    }
+  }
+
+  return { ...params, toValues, setParams, resetParams }
+}

--- a/apps/v4/composables/useTypesetShuffle.ts
+++ b/apps/v4/composables/useTypesetShuffle.ts
@@ -1,0 +1,48 @@
+import type { TypesetSearchParams } from '@/lib/typeset/params'
+import { TYPESET_FONTS } from '@/lib/typeset/fonts'
+import {
+  TYPESET_FLOWS,
+  TYPESET_LEADINGS,
+  TYPESET_MEASURES,
+  TYPESET_SIZES,
+} from '@/lib/typeset/params'
+
+function randomItem<T>(items: readonly T[]): T {
+  return items[Math.floor(Math.random() * items.length)]!
+}
+
+export function useTypesetShuffle() {
+  const { locks } = useTypesetLocks()
+  const { setParams, resetParams } = useTypesetSearchParams()
+
+  /**
+   * Randomize the type design (fonts + size/measure/rhythm). Leaves `item` (the
+   * specimen) alone; locked params keep their current value.
+   */
+  function shuffle() {
+    const bodyFonts = TYPESET_FONTS
+      .filter(font => font.type !== 'mono')
+      .map(font => font.id)
+    const monoFonts = TYPESET_FONTS
+      .filter(font => font.type === 'mono')
+      .map(font => font.id)
+
+    const next: Partial<TypesetSearchParams> = {
+      body: randomItem(bodyFonts),
+      heading: randomItem(['inherit', ...bodyFonts]),
+      mono: randomItem(monoFonts),
+      scale: randomItem(TYPESET_SIZES).value,
+      measure: randomItem(TYPESET_MEASURES).value,
+      leading: randomItem(TYPESET_LEADINGS).value,
+      flow: randomItem(TYPESET_FLOWS).value,
+    }
+
+    for (const param of locks.value) {
+      delete next[param]
+    }
+
+    setParams(next)
+  }
+
+  return { shuffle, reset: resetParams }
+}

--- a/apps/v4/composables/useTypesetThemeToggle.ts
+++ b/apps/v4/composables/useTypesetThemeToggle.ts
@@ -15,7 +15,7 @@ export function useTypesetThemeToggle({ shortcut = true } = {}) {
   }
 
   if (shortcut) {
-    useEventListener(document, 'keydown', (event: KeyboardEvent) => {
+    useEventListener(globalThis.document, 'keydown', (event: KeyboardEvent) => {
       if (event.key !== 'd' && event.key !== 'D') {
         return
       }

--- a/apps/v4/composables/useTypesetThemeToggle.ts
+++ b/apps/v4/composables/useTypesetThemeToggle.ts
@@ -1,0 +1,34 @@
+import { useEventListener } from '@vueuse/core'
+import { isEditableTarget } from '@/lib/typeset/keyboard'
+
+/**
+ * Light/dark toggle for the designer.
+ *
+ * `shortcut: false` gives callers that only need the action (the preview's
+ * command handler) the toggle without a second D listener.
+ */
+export function useTypesetThemeToggle({ shortcut = true } = {}) {
+  const colorMode = useColorMode()
+
+  function toggleTheme() {
+    colorMode.preference = colorMode.value === 'dark' ? 'light' : 'dark'
+  }
+
+  if (shortcut) {
+    useEventListener(document, 'keydown', (event: KeyboardEvent) => {
+      if (event.key !== 'd' && event.key !== 'D') {
+        return
+      }
+      if (event.metaKey || event.ctrlKey || event.altKey) {
+        return
+      }
+      if (isEditableTarget(event.target)) {
+        return
+      }
+      event.preventDefault()
+      toggleTheme()
+    })
+  }
+
+  return { toggleTheme }
+}

--- a/apps/v4/content/docs/typeset.md
+++ b/apps/v4/content/docs/typeset.md
@@ -1,0 +1,254 @@
+---
+title: Typeset
+description: A styling system for HTML and rendered markdown, from blog posts to streaming chat. One CSS file you own.
+---
+
+You render markdown and get back plain unstyled HTML: headings, paragraphs, lists, and tables. So you style the elements one by one: font sizes, line heights, spacing.
+
+You do it for your blog. Then you do it again for the docs. Then again for the chat app. Every time you're fighting the same thing: sizing and spacing.
+
+To fix this, we ported **shadcn/typeset**. It's one CSS file that styles everything inside a `typeset` container. The file lives in your project, so you can change it directly when you need to.
+
+A typeset is just a small preset class. You can have multiple typesets in your app, for different contexts.
+
+```css
+.typeset-docs {
+  --typeset-font-body: var(--font-geist-sans);
+  --typeset-font-heading: var(--font-geist-sans);
+  --typeset-font-mono: var(--font-geist-mono);
+  --typeset-size: 15px;
+  --typeset-leading: 1.75;
+  --typeset-flow: 1.25em;
+}
+```
+
+[Build your typeset](/typeset)
+
+---
+
+## Principles
+
+We read a lot about type: scale ratios, tracking, kerning, optical sizing, measure, leading, the space above and below every element. We tried exposing all of it, and it was too much. Nobody wants to set a dozen variables to make markdown look right.
+
+So we sat down and condensed everything into three controls: size, leading, and flow. Everything else, heading sizes, list indents, the gap under a heading, the space around a rule, derives from them. Three controls. We called it rhythm.
+
+---
+
+## Features
+
+- **It fits its container.** Put it in a chat bubble and it follows the smaller type around it. Put it in an article and it scales up with the page. On smaller screens, it gets a small bump for readability.
+- **It uses your theme.** Colors, fonts, and radius come from your app. Dark mode follows the same tokens.
+- **It's easy to tune.** Three values control the base size, line height, and space between blocks. Change them in a preset and the whole document follows.
+- **It works well with streaming.** When a new block arrives, Typeset doesn't make earlier blocks switch margins, borders, or styles.
+
+---
+
+## Building Your Typeset
+
+Create your typeset in the [typeset builder](/typeset). Pick your fonts and rhythm, then preview them on docs, chat, articles, and other real content.
+
+The panel gives you the `typeset.css` file, the font setup for your framework, a preset class with your choices, and the wrapper to add around your content.
+
+Copy `typeset.css` next to your main CSS file and import it after Tailwind:
+
+```css
+@import "tailwindcss";
+@import "./typeset.css";
+```
+
+Then wrap your rendered markdown with `typeset` and your preset class:
+
+```vue
+<template>
+  <div class="typeset typeset-docs">
+    <ContentRenderer :value="page" />
+  </div>
+</template>
+```
+
+`typeset` turns the styles on. `typeset-docs` is the preset you created in the builder.
+
+---
+
+## Custom Typesets
+
+The file includes defaults, so you can use `typeset` by itself. Most of the reading rhythm comes from three values:
+
+```css
+.typeset {
+  --typeset-font-body: inherit;
+  --typeset-font-heading: var(--font-heading);
+  --typeset-font-mono: var(--font-mono);
+
+  --typeset-size: 1em; /* body font-size */
+  --typeset-leading: 1.75; /* line-height */
+  --typeset-flow: 1.25em; /* space between blocks */
+}
+```
+
+- **`--typeset-size`** sets the base text size. `1em` follows the surrounding layout. On smaller screens, Typeset bumps it up a little.
+- **`--typeset-leading`** sets the space between lines.
+- **`--typeset-flow`** sets the space between blocks. Headings and other elements derive their spacing from it.
+
+The font variables tell Typeset which families to use. Leave them alone and it follows your app. Colors and radius come from your theme too.
+
+Typeset doesn't set a maximum width. Your layout owns that. The Measure control in the builder adds a `max-width` to the wrapper instead of hiding it in the stylesheet.
+
+You can keep more than one preset in the same app. Here is a tighter one for chat and a roomier one for docs:
+
+```css
+.typeset-chat {
+  --typeset-flow: 1em;
+  --typeset-leading: 1.6;
+}
+
+.typeset-docs {
+  --typeset-size: 15px;
+  --typeset-flow: 1.5em;
+}
+```
+
+```vue
+<template>
+  <div class="typeset typeset-chat" v-html="message" />
+  <article class="typeset typeset-docs" v-html="page" />
+</template>
+```
+
+For a one-off change, skip the preset and set a value on the container:
+
+```vue
+<template>
+  <article class="typeset [--typeset-flow:1.75em]">...</article>
+</template>
+```
+
+---
+
+## Custom Themes
+
+A preset can change the whole feel of the content, not just the spacing. You can give readers a serif reading mode, a compact UI mode, or any other style that fits your product.
+
+```css
+/* Reading: serif, larger type, roomy rhythm. */
+.typeset-reading {
+  --typeset-font-body: var(--font-lora);
+  --typeset-font-heading: var(--font-lora);
+  --typeset-size: 18px;
+  --typeset-leading: 1.9;
+  --typeset-flow: 2em;
+}
+
+/* Compact: sans, smaller type, tighter rhythm. */
+.typeset-compact {
+  --typeset-font-body: var(--font-geist-sans);
+  --typeset-font-heading: var(--font-geist-sans);
+  --typeset-size: 14px;
+  --typeset-leading: 1.6;
+  --typeset-flow: 1em;
+}
+```
+
+---
+
+## Accessibility and Dark Mode
+
+For readers who prefer larger type and more space, create a roomier typeset and expose it as a setting:
+
+```css
+.typeset-large {
+  --typeset-size: 16px;
+  --typeset-leading: 2;
+  --typeset-flow: 2em;
+}
+```
+
+Dark mode already follows your theme colors. If the text feels a little tight on a dark surface, you can loosen the leading there:
+
+```css
+.dark .typeset {
+  --typeset-leading: 1.9;
+}
+```
+
+---
+
+## Responsive Table
+
+Tables stay real tables and wrap to fit. To scroll a wide one horizontally instead, wrap it in `typeset-scroll`:
+
+```vue
+<template>
+  <div class="typeset-scroll">
+    <table>...</table>
+  </div>
+</template>
+```
+
+Do this in your renderer's table component or a small rehype plugin. It works for any wide block, not just tables.
+
+---
+
+## Overrides
+
+Typeset lives in the `components` layer and uses `:where()` for its element selectors. Tailwind utilities on an element win without `!important`:
+
+```vue
+<template>
+  <div class="typeset typeset-docs">
+    <p class="text-lg">...</p>
+  </div>
+</template>
+```
+
+Plain CSS can override Typeset with a normal selector too.
+
+---
+
+## Opting Out
+
+To keep a component out of Typeset, add `not-typeset` or `data-not-typeset`:
+
+```vue
+<template>
+  <div class="typeset">
+    <p>Styled prose.</p>
+    <Card class="not-typeset">
+      Untouched component.
+    </Card>
+  </div>
+</template>
+```
+
+Both options cover the component and everything inside it. Another `typeset` container inside that subtree stays opted out too.
+
+---
+
+## Streaming
+
+Typeset is written so that adding a new block does not change the styles of the blocks already on screen.
+
+- No forward-looking selectors. `:last-child`, `:has()`, and `:empty` are left out of layout rules because their matches can change as content is added.
+- Spacing flows in one direction, using `margin-block-start` only. A new block adds its own space.
+- Table separators live on the cells being added, so a new row does not restyle the row above it.
+
+Text that is still streaming can grow and wrap normally. Typeset just avoids restyling the blocks that came before it.
+
+---
+
+## Prior Art
+
+The `prose` class from `@tailwindcss/typography` is excellent at what it was built for: adding beautiful typographic defaults to plain HTML, including content rendered from Markdown or a CMS.
+
+Typeset takes a different approach with container-aware sizing, app theme tokens, presets for different contexts, and streaming stability. Here's where they differ:
+
+|              | @tailwindcss/typography                      | Typeset                                          |
+| ------------ | -------------------------------------------- | ------------------------------------------------ |
+| Sizing       | Fixed `rem` scale, `prose-sm` to `prose-2xl` | Relative to the container, any size              |
+| Dark mode    | `prose-invert`, a second palette             | Your tokens flip, nothing to add                 |
+| Theming      | Prose color variables; scale baked in        | Your theme tokens, plus font and rhythm controls |
+| Overrides    | `prose-a:`, `prose-headings:` modifier API   | Plain utilities and CSS win                      |
+| Streaming    | No append-stability contract                 | Designed for stable appends                      |
+| Distribution | npm plugin, generated CSS                    | One CSS file you own                             |
+
+Typeset borrows the two best ideas from the plugin: the zero-specificity `:where()` guard pattern, and the escape-hatch class (`not-typeset`, in the spirit of `not-prose`).

--- a/apps/v4/content/docs/typeset.md
+++ b/apps/v4/content/docs/typeset.md
@@ -175,17 +175,19 @@ Dark mode already follows your theme colors. If the text feels a little tight on
 
 ## Responsive Table
 
-Tables stay real tables and wrap to fit. To scroll a wide one horizontally instead, wrap it in `typeset-scroll`:
+Tables stay real tables and wrap to fit. To scroll a wide one horizontally instead, wrap it in `typeset-scroll`. The wrapper is styled as part of the content, so it only works *inside* a `typeset` container:
 
 ```vue
 <template>
-  <div class="typeset-scroll">
-    <table>...</table>
-  </div>
+  <article class="typeset typeset-docs">
+    <div class="typeset-scroll">
+      <table>...</table>
+    </div>
+  </article>
 </template>
 ```
 
-Do this in your renderer's table component or a small rehype plugin. It works for any wide block, not just tables.
+Do this in your renderer's table component or a small rehype plugin, where the output already sits inside the container. It works for any wide block, not just tables.
 
 ---
 

--- a/apps/v4/lib/config.ts
+++ b/apps/v4/lib/config.ts
@@ -41,6 +41,10 @@ export const siteConfig = {
       href: '/create',
       label: 'Create',
     },
+    {
+      href: '/typeset',
+      label: 'Typeset',
+    },
   ],
 }
 

--- a/apps/v4/lib/typeset/code.ts
+++ b/apps/v4/lib/typeset/code.ts
@@ -1,0 +1,74 @@
+import type { TemplateValue } from '@/lib/templates'
+import type { TypesetFont } from '@/lib/typeset/fonts'
+
+/**
+ * Fontsource ships one package per family, named after the family in kebab
+ * case — "IBM Plex Sans" -> @fontsource/ibm-plex-sans.
+ */
+export function getFontsourcePackage(font: TypesetFont) {
+  return `@fontsource/${font.family.toLowerCase().replace(/\s+/g, '-')}`
+}
+
+/**
+ * Nuxt loads fonts through @nuxt/fonts. Families are declared explicitly rather
+ * than left to the module's CSS scan, because typeset only ever names them
+ * through custom properties.
+ */
+export function getNuxtFontCode(fonts: TypesetFont[]) {
+  return [
+    '// nuxt.config.ts',
+    'export default defineNuxtConfig({',
+    '  modules: [\'@nuxt/fonts\'],',
+    '  fonts: {',
+    '    families: [',
+    ...fonts.map(font => `      { name: '${font.family}', provider: 'google' },`),
+    '    ],',
+    '  },',
+    '})',
+  ].join('\n')
+}
+
+export function getFontsourceCommand(fonts: TypesetFont[]) {
+  return `npm install ${fonts.map(getFontsourcePackage).join(' ')}`
+}
+
+export function getFontsourceCss(fonts: TypesetFont[]) {
+  return [
+    '/* main.css */',
+    ...fonts.map(font => `@import "${getFontsourcePackage(font)}";`),
+    '',
+    ':root {',
+    ...fonts.map(font => `  ${font.cssVar}: ${font.value};`),
+    '}',
+  ].join('\n')
+}
+
+/** The CSS vars every framework needs, whatever loaded the font files. */
+export function getFontVariablesCss(fonts: TypesetFont[]) {
+  return [
+    '/* main.css */',
+    ':root {',
+    ...fonts.map(font => `  ${font.cssVar}: ${font.value};`),
+    '}',
+  ].join('\n')
+}
+
+export function getCommandForPackageManager(
+  packageManager: 'pnpm' | 'npm' | 'yarn' | 'bun',
+  command: string,
+) {
+  if (packageManager === 'pnpm') {
+    return command.replace('npm install', 'pnpm add').replace('npx', 'pnpm dlx')
+  }
+  if (packageManager === 'yarn') {
+    return command.replace('npm install', 'yarn add').replace('npx', 'yarn dlx')
+  }
+  if (packageManager === 'bun') {
+    return command.replace('npm install', 'bun add').replace('npx', 'bunx --bun')
+  }
+  return command
+}
+
+export function isNuxt(framework: TemplateValue) {
+  return framework === 'nuxt'
+}

--- a/apps/v4/lib/typeset/fixtures/article.ts
+++ b/apps/v4/lib/typeset/fixtures/article.ts
@@ -1,0 +1,40 @@
+// Editorial long-form: image-forward blog post (Unsplash photos at two aspect
+// ratios), a pull quote, lists, and links. No code; the docs fixture owns that.
+export const ARTICLE_HTML = `
+<h1>A Morning at the Letterpress Museum</h1>
+<p>The first thing you notice is the smell: machine oil, paper dust, and a century of ink that never fully dries. The second thing is the sound. A working letterpress shop is not quiet, and the museum on Greer Street keeps three presses working, because, as the docent told me within a minute of my arrival, <em>a silent press is just furniture</em>.</p>
+<p>I went because I write software that arranges text on screens, and I had started to suspect that everything hard about my job had been solved a hundred years ago by people with steel tools and no undo. I left four hours later with ink on my sleeve and a notebook full of confirmations.</p>
+<figure>
+  <img class="grayscale dark:brightness-50" src="https://images.unsplash.com/photo-1629968417841-d87296c4205b?q=80&amp;w=1200&amp;h=675&amp;fit=crop" alt="Textured surface, worn by use." width="1200" height="675">
+  <figcaption>Ink before it becomes language.</figcaption>
+</figure>
+<h2>The composing room</h2>
+<p>Type lives in shallow wooden drawers called cases, and the layout of a case is itself a piece of interface design: the letters you reach for most sit nearest your hand, in the biggest compartments. Nobody alphabetized them. The arrangement was settled by frequency, argued over for a generation, and then never changed again, which is roughly the story of every good default I have ever shipped.</p>
+<p>A compositor working at full speed sets about two thousand characters an hour, reading the manuscript with one eye while the other confirms each pick. The docent, a retired compositor named <strong>Ruth Okafor</strong>, demonstrated without looking down once. When I asked how long that took to learn she said, "The hands take a year. Knowing when a line is wrong takes ten."</p>
+<blockquote>
+  <p>Every em of space in this room is a physical object. You want more air between two lines, you go get the lead and you carry it back. It keeps your opinions about spacing very honest.</p>
+</blockquote>
+<p>That line rearranged something in my head. The strips of lead that printers wedged between lines of type are why we still say <a href="#">leading</a>. On my screen, spacing is a number I can change in a keystroke, and so I change it constantly, carelessly. Ruth's shop had exactly four widths of lead, and the whole trade agreed on them, and a hundred years of books came out beautiful anyway. Constraint was not the obstacle to the craft. It was the craft.</p>
+<h2>What the metal knows</h2>
+<figure>
+  <img class="grayscale dark:brightness-50" src="https://images.unsplash.com/photo-1637325258040-d2f09636ecf6?q=80&amp;w=900&amp;h=1200&amp;fit=crop" alt="Recycled paper, up close." width="900" height="1200">
+  <figcaption>Space is material.</figcaption>
+</figure>
+<p>Three things the metal insists on, which screens let us forget:</p>
+<ul>
+  <li><strong>Space is material.</strong> Word spaces, line leads, and margins are objects with widths. Nothing is "auto." Someone chose everything.</li>
+  <li><strong>Hierarchy is expensive.</strong> Changing size means walking to a different case. Printers built emphasis from weight and space first because size was the costly move, and their pages read better for it.</li>
+  <li><strong>The page is finished before it is printed.</strong> A locked-up chase either holds together or it doesn't. There is a satisfying finality to it that no deploy has ever given me.</li>
+</ul>
+<p>None of this is nostalgia, or not only. The constraints were real costs, and digital type was right to remove them. But removal has a second-order effect: when nothing is expensive, nothing forces a decision, and unforced decisions drift. The printers' defaults survived because changing them was work. Ours have to survive on discipline, which is a weaker material.</p>
+<hr>
+<h2>Field notes</h2>
+<p>Practical things I wrote down, in the order I wrote them:</p>
+<ol>
+  <li>Ruth sets solid (no leading) only for lines shorter than the alphabet. Anything longer gets air. Our line-length rules agree, which pleased me more than it should have.</li>
+  <li>The shop's "house style" fits on an index card taped inside a cabinet door. Four leads, two faces, three sizes. An entire design system, physically enumerable.</li>
+  <li>Apprentices learn distribution (putting type away) before composition. You learn a system by returning things to it.</li>
+</ol>
+<p>The museum runs open studio on the first Saturday of every month, and they will let you set your own name if you ask. Mine came out crooked. Ruth looked at it for a moment and said it was a common beginner's error: I had been so careful choosing the letters that I forgot to check the spaces. I have been thinking about that all week.</p>
+<p><em>The Greer Street Press Museum is open Thursday through Sunday. If you go, bring a jacket; the composing room is kept cold for the metal.</em></p>
+`

--- a/apps/v4/lib/typeset/fixtures/changelog.ts
+++ b/apps/v4/lib/typeset/fixtures/changelog.ts
@@ -1,0 +1,29 @@
+export const CHANGELOG_HTML = `
+<h1>Changelog</h1>
+<h2>v2.4.0</h2>
+<p><em>June 18, 2026</em></p>
+<ul>
+  <li><strong>Added:</strong> <code>store.batch(fn)</code> groups multiple writes into a single notification. Listeners observe only the final state.</li>
+  <li><strong>Added:</strong> a <code>name</code> option for devtools traces; anonymous stores now display as <code>store#3</code> instead of <code>undefined</code>.</li>
+  <li><strong>Changed:</strong> selectors are memoized per subscriber, cutting re-render counts roughly in half on wide stores.</li>
+  <li><strong>Fixed:</strong> subscribing during a notification no longer skips the next update.</li>
+  <li><strong>Fixed:</strong> <code>equals</code> is respected for the initial <code>useStore</code> read, matching the documented behavior.</li>
+</ul>
+<h3>Breaking changes</h3>
+<p>The deprecated <code>store.update()</code> alias is removed. Replace it with <code>store.set()</code>; the signature is identical:</p>
+<pre><code>- store.update((s) =&gt; ({ count: s.count + 1 }))
++ store.set((s) =&gt; ({ count: s.count + 1 }))</code></pre>
+<h2>v2.3.1</h2>
+<p><em>May 30, 2026</em></p>
+<ul>
+  <li><strong>Fixed:</strong> a race where two synchronous writes in the same tick could notify in reverse order under React’s concurrent rendering.</li>
+  <li><strong>Docs:</strong> clarified that stores must be hoisted out of components, with a lint rule to catch it.</li>
+</ul>
+<h2>v2.3.0</h2>
+<p><em>May 12, 2026</em></p>
+<ul>
+  <li><strong>Added:</strong> React Native support; <code>useStore</code> no longer touches <code>window</code>.</li>
+  <li><strong>Deprecated:</strong> <code>store.update()</code>, removed in v2.4.0. A console warning links to the migration note.</li>
+  <li><strong>Performance:</strong> subscription bookkeeping moved from an array to a Set; unsubscribe is now O(1).</li>
+</ul>
+`

--- a/apps/v4/lib/typeset/fixtures/chat.ts
+++ b/apps/v4/lib/typeset/fixtures/chat.ts
@@ -1,0 +1,41 @@
+// Assistant chat answer: the core genre. Short paragraphs, scannable lists,
+// a small table, code, and a closing question. The user bubble that precedes
+// it is page chrome, rendered outside the typeset container.
+export const CHAT_QUESTION
+  = 'My Next.js dev server takes forever to start. How do I figure out what\'s actually slow?'
+
+export const CHAT_HTML = `
+<p>Slow dev startup in Next.js almost always comes down to one of three things: module count, heavy config work at boot, or something outside the compiler entirely. Here's how to narrow it down fast.</p>
+<h3>1. Get a baseline</h3>
+<p>Start the server with profiling on and note the two numbers it prints:</p>
+<pre><code>NEXT_TURBOPACK_TRACING=1 next dev</code></pre>
+<ul>
+<li><strong>Startup time</strong>: everything before "Ready". Config loading, env files, plugins.</li>
+<li><strong>First compile</strong>: the time after you hit a route. Module graph size lives here.</li>
+</ul>
+<h3>2. Check the usual suspects</h3>
+<table>
+<thead>
+<tr><th>Symptom</th><th>Likely cause</th></tr>
+</thead>
+<tbody>
+<tr><td>Slow before "Ready"</td><td>Heavy <code>next.config</code>, sync I/O in config, large <code>.env</code> cascade</td></tr>
+<tr><td>Slow first page</td><td>Barrel files pulling in whole icon or UI libraries</td></tr>
+<tr><td>Slow every save</td><td>Type checking or lint running in the dev loop</td></tr>
+</tbody>
+</table>
+<p>The barrel-file one is the classic. A single <code>import { Check } from "lucide-react"</code> through a barrel can pull thousands of modules into the graph. Fix it with:</p>
+<pre><code>// next.config.ts
+const nextConfig = {
+  experimental: {
+    optimizePackageImports: ["lucide-react", "@acme/ui"],
+  },
+}</code></pre>
+<h3>3. Measure, don't guess</h3>
+<p>If neither jumps out, generate a trace and look at the actual spans:</p>
+<pre><code>next dev
+# reproduce the slow start, then:
+next internal trace .next/trace</code></pre>
+<blockquote><p>Compare against a bare <code>create-next-app</code> on the same machine first. If that's also slow, the problem is your machine or antivirus scanning <code>node_modules</code>, not your app.</p></blockquote>
+<p>Want to paste the first few lines of your trace output? I can point at the exact span that's eating the time.</p>
+`

--- a/apps/v4/lib/typeset/fixtures/docs.ts
+++ b/apps/v4/lib/typeset/fixtures/docs.ts
@@ -1,0 +1,156 @@
+// Long technical doc: prose + lists + many code blocks + Note blockquotes +
+// a reference table, hr-separated sections, and native MathML.
+export const DOCS_HTML = `
+<h1>Building a Streaming Chatbot</h1>
+<p>The <code>useChat</code> hook makes it effortless to create a conversational user interface for your chatbot application. It enables the streaming of chat messages from your AI provider, manages the chat state, and updates the UI automatically as new messages arrive.</p>
+<p>To summarize, the <code>useChat</code> hook provides the following features:</p>
+<ul>
+<li><strong>Message Streaming</strong>: All the messages from the AI provider are streamed to the chat UI in real-time.</li>
+<li><strong>Managed States</strong>: The hook manages the states for input, messages, status, error and more for you.</li>
+<li><strong>Seamless Integration</strong>: Easily integrate your chat AI into any design or layout with minimal effort.</li>
+</ul>
+<p>In this guide, you will learn how to use the <code>useChat</code> hook to create a chatbot application with real-time message streaming. Check out our <a href="/docs/ai-sdk-ui/chatbot-tool-usage">chatbot with tools guide</a> to learn how to use tools in your chatbot.</p>
+<h2>Example</h2>
+<p>The request flow works like this:</p>
+<ol>
+<li>The user submits a message and <code>sendMessage</code> posts it to your API route.</li>
+<li>Your route calls the provider and returns a UI message stream.</li>
+<li>The hook appends chunks to the last message as they arrive, re-rendering as it goes.</li>
+</ol>
+<pre><code>'use client';
+
+import { useChat } from '@ai-sdk/react';
+
+export default function Chat() {
+  const { messages, sendMessage, status } = useChat();
+
+  return (
+    &lt;&gt;
+      {messages.map(message =&gt; (
+        &lt;Message key={message.id} message={message} /&gt;
+      ))}
+      &lt;ChatInput
+        onSubmit={text =&gt; sendMessage({ text })}
+        disabled={status !== 'ready'}
+      /&gt;
+    &lt;/&gt;
+  );
+}</code></pre>
+<pre><code>import { openai } from '@ai-sdk/openai';
+import { convertToModelMessages, streamText } from 'ai';
+
+export async function POST(req: Request) {
+  const { messages } = await req.json();
+
+  const result = streamText({
+    model: openai('gpt-4o'),
+    messages: await convertToModelMessages(messages),
+  });
+
+  return result.toUIMessageStreamResponse();
+}</code></pre>
+<blockquote><p>The UI messages have a new <code>parts</code> property that contains the message parts. We recommend rendering the messages using the <code>parts</code> property instead of the <code>content</code> property. The parts property supports different message types, including text, tool invocation, and tool result, and allows for more flexible and complex chat UIs.</p></blockquote>
+<p>In the <code>Page</code> component, the <code>useChat</code> hook will request to your AI provider endpoint whenever the user sends a message using <code>sendMessage</code>. The messages are then streamed back in real-time and displayed in the chat UI.</p>
+<h2>Customized UI</h2>
+<p><code>useChat</code> also provides ways to manage the chat message states via code, show status, and update messages without being triggered by user interactions.</p>
+<h3>Status</h3>
+<p>The <code>useChat</code> hook returns a <code>status</code>. It has the following possible values:</p>
+<ul>
+<li><code>submitted</code>: The message has been sent to the API and we're awaiting the start of the response stream.</li>
+<li><code>streaming</code>: The response is actively streaming in from the API, receiving chunks of data.</li>
+<li><code>ready</code>: The full response has been received and processed; a new user message can be submitted.</li>
+<li><code>error</code>: An error occurred during the API request, preventing successful completion.</li>
+</ul>
+<pre><code>const { messages, sendMessage, status, stop } = useChat({
+  transport: new DefaultChatTransport({ api: '/api/chat' }),
+});
+
+// ...
+
+{(status === 'submitted' || status === 'streaming') &amp;&amp; (
+  &lt;div&gt;
+    {status === 'submitted' &amp;&amp; &lt;Spinner /&gt;}
+    &lt;button type="button" onClick={() =&gt; stop()}&gt;
+      Stop
+    &lt;/button&gt;
+  &lt;/div&gt;
+)}</code></pre>
+<h3>Error State</h3>
+<p>Similarly, the <code>error</code> state reflects the error object thrown during the fetch request. It can be used to display an error message, disable the submit button, or show a retry button:</p>
+<blockquote><p>We recommend showing a generic error message to the user, such as "Something went wrong." This is a good practice to avoid leaking information from the server.</p></blockquote>
+<pre><code>const { messages, sendMessage, error, regenerate } = useChat({
+  transport: new DefaultChatTransport({ api: '/api/chat' }),
+});
+
+// ...
+
+{error &amp;&amp; (
+  &lt;&gt;
+    &lt;div&gt;An error occurred.&lt;/div&gt;
+    &lt;button type="button" onClick={() =&gt; regenerate()}&gt;
+      Retry
+    &lt;/button&gt;
+  &lt;/&gt;
+)}</code></pre>
+<h3>Cancellation and regeneration</h3>
+<p>It's also a common use case to abort the response message while it's still streaming back from the AI provider. You can do this by calling the <code>stop</code> function returned by the <code>useChat</code> hook.</p>
+<pre><code>const { stop, status } = useChat();
+
+&lt;button
+  onClick={stop}
+  disabled={!(status === 'streaming' || status === 'submitted')}
+&gt;
+  Stop
+&lt;/button&gt;</code></pre>
+<hr>
+<h2>API reference</h2>
+<h3>useChat(options)</h3>
+<p>Creates a chat helper. All options are optional; the defaults talk to <code>/api/chat</code> and render at native stream speed.</p>
+<table>
+  <thead>
+    <tr><th>Prop</th><th>Type</th><th>Description</th></tr>
+  </thead>
+  <tbody>
+    <tr><td><code>transport</code></td><td><code>ChatTransport&lt;UIMessage&gt;</code></td><td>How messages reach your API route</td></tr>
+    <tr><td><code>messages</code></td><td><code>UIMessage[]</code></td><td>Initial messages to seed the conversation</td></tr>
+    <tr><td><code>onFinish</code></td><td><code>(event: FinishEvent) =&gt; void</code></td><td>Runs when the assistant response completes</td></tr>
+    <tr><td><code>onError</code></td><td><code>(error: Error) =&gt; void</code></td><td>Runs when the fetch request fails</td></tr>
+    <tr><td><code>throttle</code></td><td><code>number</code></td><td>Milliseconds between UI updates while streaming</td></tr>
+  </tbody>
+</table>
+<h2>Event Callbacks</h2>
+<p><code>useChat</code> provides optional event callbacks that you can use to handle different stages of the chatbot lifecycle:</p>
+<ul>
+<li><code>onFinish</code>: Called when the assistant response is completed. The event includes the response message, all messages, and flags for abort, disconnect, and errors.</li>
+<li><code>onError</code>: Called when an error occurs during the fetch request.</li>
+<li><code>onData</code>: Called whenever a data part is received.</li>
+</ul>
+<p>These callbacks can be used to trigger additional actions, such as logging, analytics, or custom UI updates.</p>
+<pre><code>const { messages } = useChat({
+  onFinish: ({ message }) =&gt; saveToHistory(message),
+  onError: error =&gt; console.error(error),
+});</code></pre>
+<hr>
+<h2>Math</h2>
+<p>Display math sits in the flow rhythm and scrolls when it runs long. Inline math like <math><msup><mi>e</mi><mrow><mi>i</mi><mi>π</mi></mrow></msup><mo>+</mo><mn>1</mn><mo>=</mo><mn>0</mn></math> rides the line without stretching it.</p>
+<h3>Display</h3>
+<p>The quadratic formula, as a block:</p>
+<math display="block">
+  <mi>x</mi><mo>=</mo>
+  <mfrac>
+    <mrow><mo>−</mo><mi>b</mi><mo>±</mo><msqrt><mrow><msup><mi>b</mi><mn>2</mn></msup><mo>−</mo><mn>4</mn><mi>a</mi><mi>c</mi></mrow></msqrt></mrow>
+    <mrow><mn>2</mn><mi>a</mi></mrow>
+  </mfrac>
+</math>
+<p>Prose continues after the block at the normal distance, so equations read as part of the argument, not decoration.</p>
+<h3>Overflow</h3>
+<p>A long expansion scrolls inside its own box instead of breaking the column:</p>
+<math display="block">
+  <msup><mrow><mo>(</mo><mi>a</mi><mo>+</mo><mi>b</mi><mo>)</mo></mrow><mn>4</mn></msup><mo>=</mo>
+  <msup><mi>a</mi><mn>4</mn></msup><mo>+</mo>
+  <mn>4</mn><msup><mi>a</mi><mn>3</mn></msup><mi>b</mi><mo>+</mo>
+  <mn>6</mn><msup><mi>a</mi><mn>2</mn></msup><msup><mi>b</mi><mn>2</mn></msup><mo>+</mo>
+  <mn>4</mn><mi>a</mi><msup><mi>b</mi><mn>3</mn></msup><mo>+</mo>
+  <msup><mi>b</mi><mn>4</mn></msup>
+</math>
+`

--- a/apps/v4/lib/typeset/fixtures/elements.ts
+++ b/apps/v4/lib/typeset/fixtures/elements.ts
@@ -1,0 +1,119 @@
+export const KITCHEN_SINK_HTML = `
+<h1>Streaming markdown to a million sessions</h1>
+<p>Six months ago we rewrote how assistant messages render, and this is the retrospective we wish we could have read first. The short version: the parser was never the problem, the <em>typography</em> was, and the fixes that mattered were <strong>boring, measurable, and CSS-shaped</strong>. We <del>estimated two weeks</del> spent six, and the difference was all edge cases.</p>
+<p>Everything below comes from production traffic against our completions endpoint (<a href="#">https://api.example.com/v1/organizations/org_2f8a91c/deployments/dep_09xkq/streaming-completions?include_usage=true&amp;format=sse</a>), rendered by the same stylesheet you’re reading now.<sup><a href="#fn1" id="ref1">1</a></sup></p>
+<h2>The setup</h2>
+<p>Messages arrive as <abbr title="Server-Sent Events">SSE</abbr> and render token by token. The renderer repairs unterminated markdown; the stylesheet’s only job is to keep already-painted content perfectly still while new content arrives below it. The whole contract fits in one handler:</p>
+<pre><code>export async function POST(req: Request) {
+  const { messages } = await req.json()
+  const result = streamText({ model, messages })
+  return result.toDataStreamResponse()
+}</code></pre>
+<p>Every block above the insertion point must keep its computed styles byte-for-byte identical across appends. We test exactly that, and press <kbd>⌘</kbd> <kbd>K</kbd> in the playground to replay any captured stream against the assertion.</p>
+<h2>What the data said</h2>
+<p>We captured 40,000 assistant replies and counted what models actually emit. The distribution surprised us; <mark>deep headings and tables are not rare events</mark>, they’re Tuesday.</p>
+<table>
+  <thead>
+    <tr>
+      <th>Element</th>
+      <th align="right">Percentage</th>
+      <th>Notes</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th scope="row">Lists</th>
+      <td align="right">78.4</td>
+      <td>Nesting to three levels is common</td>
+    </tr>
+    <tr>
+      <th scope="row">Code blocks</th>
+      <td align="right">41.2</td>
+      <td>Half specify no language tag at all</td>
+    </tr>
+    <tr>
+      <th scope="row">Tables</th>
+      <td align="right">17.9</td>
+      <td>Comparison questions produce 40-column monsters</td>
+    </tr>
+    <tr>
+      <th scope="row">Headings</th>
+      <td align="right">12.6</td>
+      <td>Models outline far deeper than humans do</td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr>
+      <th scope="row">Any block element</th>
+      <td align="right">94.1</td>
+      <td>Plain-paragraph-only replies are the rare case</td>
+    </tr>
+  </tfoot>
+</table>
+<p>That last row is why the bottom of the heading scale exists at all.<sup><a href="#fn2" id="ref2">2</a></sup> Nobody designs h6 for people; you design it for machines that never learned restraint.</p>
+<figure>
+  <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='1200' height='630'%3E%3Crect width='1200' height='630' fill='%23EAEAEA' rx='6'/%3E%3Cpath d='M80 470 L280 380 L480 420 L680 260 L880 300 L1120 160' stroke='%23BDBDBD' stroke-width='8' fill='none' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E" alt="Latency dashboard the morning after rollout" width="1200" height="630">
+  <figcaption>Figure 1. The morning after rollout: style recalculation cost per token, before and after the append-stable rules landed.</figcaption>
+</figure>
+<h2>Three mistakes we made</h2>
+<h3>We trusted margin collapsing</h3>
+<p>Our first spacing model used symmetric margins and let the browser deduplicate them. Then a designer wrapped messages in a flex column and every paragraph gap silently doubled. Single-direction margins fixed it everywhere at once:</p>
+<ol>
+  <li>Space belongs above blocks, and only above.</li>
+  <li>Headings own the gap beneath them, so following content never negotiates.</li>
+  <li>Nothing, anywhere, sets a bottom margin.</li>
+</ol>
+<h3>We styled the last row</h3>
+<p>Tables drew their border under the final row, which meant every streamed row restyled the previous one on arrival. Users reported it as “the table flickers while it types.” The fix was embarrassingly small:</p>
+<ul>
+  <li>Borders go <em>between</em> rows (<code>tr + tr</code>), never after the last one
+    <ul>
+      <li>The same rule saved us again on blockquote citations and list dividers</li>
+    </ul>
+  </li>
+  <li>Selectors may look backward at earlier siblings, never forward</li>
+</ul>
+<h3>We ignored the quiet feedback</h3>
+<blockquote>
+  <p>The new answers feel calmer, and I can’t tell you why. I just stopped noticing the formatting.</p>
+  <p>That was the entire review. It’s still the best QA signal we’ve ever received, because typography you notice is typography that failed.</p>
+</blockquote>
+<h2>The checklist we run now</h2>
+<p>Before any typography change ships, a release candidate has to clear the same four gates, in order:</p>
+<ul class="contains-task-list">
+  <li class="task-list-item"><input type="checkbox" checked disabled> Append-stability suite passes on all captured streams</li>
+  <li class="task-list-item"><input type="checkbox" checked disabled> Reads correctly at <code>text-sm</code> inside a bubble and at 16px full width</li>
+  <li class="task-list-item"><input type="checkbox" checked disabled> Squint test shows even gray, no hotspots</li>
+  <li class="task-list-item"><input type="checkbox" disabled> Sixty seconds of sustained reading by someone who didn’t write it</li>
+</ul>
+<details>
+  <summary>How we capture the streams for the suite</summary>
+  <p>Every failed render in production writes its raw token sequence to a bucket. The suite replays each capture twice, once all at once and once token by token, and diffs the computed styles of everything that was on screen before the last token arrived.</p>
+  <pre><code>replay: captures
+	bun run suite --replay captures/ --diff computed
+
+captures:
+	bun run capture --since yesterday --failures-only</code></pre>
+</details>
+<hr>
+<h2>Appendix</h2>
+<h4>Glossary</h4>
+<dl>
+  <dt>flow</dt>
+  <dd>The rhythm unit: one em-based value that spaces every block from the one before it.</dd>
+  <dt>measure</dt>
+  <dd>Line length in average characters. Not the CSS <code>ch</code> unit, which overcounts by roughly a third.</dd>
+</dl>
+<h4>Reference notes</h4>
+<h5>On the numbers in this post</h5>
+<p>Percentages are per-reply presence, not token share. A reply containing one table and one list counts once in each row.</p>
+<h6>Revision history</h6>
+<p>Corrected the p95 code-block count<sup><a href="#fn3" id="ref3">3</a></sup> and added the flex-column incident after two readers asked whether “boring, measurable, and CSS-shaped” was a typo. It wasn’t.</p>
+<section data-footnotes class="footnotes">
+  <ol>
+    <li id="fn1"><p>Endpoint anonymized. The path structure is real; the org is not. <a href="#ref1">↩</a></p></li>
+    <li id="fn2"><p>Specifically the reply that contained fourteen h6 elements and zero h1–h3. <a href="#ref2">↩</a></p></li>
+    <li id="fn3"><p>The original draft said nine; the correct p95 is seven. <a href="#ref3">↩</a></p></li>
+  </ol>
+</section>
+`

--- a/apps/v4/lib/typeset/fixtures/index.ts
+++ b/apps/v4/lib/typeset/fixtures/index.ts
@@ -1,0 +1,39 @@
+import { ARTICLE_HTML } from './article'
+import { CHANGELOG_HTML } from './changelog'
+import { CHAT_HTML } from './chat'
+import { DOCS_HTML } from './docs'
+import { KITCHEN_SINK_HTML } from './elements'
+import { NOTES_HTML } from './notes'
+import { RECIPE_HTML } from './recipe'
+import { TAILWIND_HTML } from './tailwind'
+
+export const FIXTURES = {
+  docs: DOCS_HTML,
+  chat: CHAT_HTML,
+  article: ARTICLE_HTML,
+  changelog: CHANGELOG_HTML,
+  notes: NOTES_HTML,
+  recipe: RECIPE_HTML,
+  elements: KITCHEN_SINK_HTML,
+  tailwind: TAILWIND_HTML,
+} as const
+
+export type FixtureName = keyof typeof FIXTURES
+
+export const CONTENT_OPTIONS = [
+  { value: 'docs', label: 'Docs' },
+  { value: 'chat', label: 'Chat' },
+  { value: 'article', label: 'Article' },
+  { value: 'changelog', label: 'Changelog' },
+  { value: 'notes', label: 'Notes' },
+  // { value: 'recipe', label: 'Recipe' },
+  // { value: 'elements', label: 'Elements' },
+] as const satisfies readonly { value: FixtureName, label: string }[]
+
+// Testing baselines, dev-only: never built or offered in production.
+export const DEV_CONTENT_OPTIONS: readonly { value: FixtureName, label: string }[] = [
+  // { value: 'tailwind', label: 'Tailwind' },
+]
+
+export const AVAILABLE_CONTENT_OPTIONS: readonly { value: FixtureName, label: string }[]
+  = import.meta.dev ? [...CONTENT_OPTIONS, ...DEV_CONTENT_OPTIONS] : CONTENT_OPTIONS

--- a/apps/v4/lib/typeset/fixtures/notes.ts
+++ b/apps/v4/lib/typeset/fixtures/notes.ts
@@ -1,0 +1,39 @@
+export const NOTES_HTML = `
+<h1>Platform sync: week 27</h1>
+<p><em>July 3, 2026 · 25 min · recording available</em></p>
+<h2>Decisions</h2>
+<ul>
+  <li>Ship the streaming endpoint behind a flag on Tuesday; full rollout gated on the p95 latency holding under 800ms for 48 hours.</li>
+  <li>Adopt cursor pagination for the activity feed. Offset stays on the admin tables only, capped at page 500.</li>
+  <li>Postpone the queue migration to Q3. Nobody could name a current failure it fixes.</li>
+</ul>
+<h2>Action items</h2>
+<ul class="contains-task-list">
+  <li class="task-list-item"><input type="checkbox" checked disabled> <strong>Mia:</strong> flag config + kill switch for the streaming endpoint</li>
+  <li class="task-list-item"><input type="checkbox" disabled> <strong>Devon:</strong> latency dashboard with the 800ms line drawn on it</li>
+  <li class="task-list-item"><input type="checkbox" disabled> <strong>Sam:</strong> write the cursor encoding RFC, one page max</li>
+  <li class="task-list-item"><input type="checkbox" disabled> <strong>Priya:</strong> close out the three stale runbook pages before Friday</li>
+</ul>
+<h2>Discussion</h2>
+<ul>
+  <li>Streaming rollout
+    <ul>
+      <li>Retry behavior on disconnect is still client-defined; server sends <code>retry-after</code> but nobody reads it.</li>
+      <li>Agreement: the SDK should honor it, apps that hand-roll fetch are on their own.
+        <ul>
+          <li>Devon volunteered to add it to the SDK changelog as a “behavior change” callout.</li>
+        </ul>
+      </li>
+    </ul>
+  </li>
+  <li>On-call load
+    <ul>
+      <li>Pages are down 40% since the alert dedup work. Two of the remaining alerts are known-noisy and owned by nobody.</li>
+      <li>Priya takes both; if they can’t be fixed in an hour each, they get deleted.</li>
+    </ul>
+  </li>
+</ul>
+<blockquote>
+  <p>“If an alert has fired twelve times and been actioned zero times, it isn’t an alert, it’s a screensaver.”</p>
+</blockquote>
+`

--- a/apps/v4/lib/typeset/fixtures/recipe.ts
+++ b/apps/v4/lib/typeset/fixtures/recipe.ts
@@ -1,0 +1,43 @@
+export const RECIPE_HTML = `
+<h1>Overnight focaccia</h1>
+<p>This is the low-effort, high-reward version: no mixer, no kneading, one bowl, and most of the work happens while you sleep. The dough is wet by bread standards, around 80% hydration, which is exactly what produces the open crumb and the crackly, olive-oil-fried bottom.</p>
+<h2>Ingredients</h2>
+<ul>
+  <li>500g bread flour</li>
+  <li>400g lukewarm water</li>
+  <li>10g fine sea salt</li>
+  <li>4g instant yeast (about 1¼ teaspoons)</li>
+  <li>40g olive oil, plus more for the pan, your hands, and your conscience</li>
+  <li>Flaky salt and two sprigs of rosemary, to finish</li>
+</ul>
+<h2>Method</h2>
+<ol>
+  <li>
+    <p>Whisk the yeast into the water. Add the flour and fine salt and stir with a spatula until no dry flour remains, about two minutes. It will look shaggy and wrong. It is neither.</p>
+  </li>
+  <li>
+    <p>Cover the bowl and leave it on the counter for 30 minutes, then perform one set of folds: wet your hand, grab the far edge of the dough, stretch it up, and press it into the middle. Rotate the bowl a quarter turn and repeat four times.</p>
+  </li>
+  <li>
+    <p>Cover and refrigerate overnight, 12 to 18 hours. The cold ferment is where the flavor comes from; do not rush this step with a warm rise unless you enjoy bland bread.</p>
+  </li>
+  <li>
+    <p>Pour 2 tablespoons of olive oil into a 9×13 metal pan. Fold the dough onto itself twice in the bowl, then transfer it seam-side down into the pan. Turn it once to coat, cover, and let it relax for 3 to 4 hours at room temperature, until it fills the pan and jiggles.</p>
+  </li>
+  <li>
+    <p>Heat the oven to 230°C (450°F). Oil your fingers and dimple the dough firmly, all the way to the bottom of the pan. Scatter the rosemary and flaky salt. Bake 22 to 26 minutes until deeply golden.</p>
+  </li>
+  <li>
+    <p>Lift it out of the pan onto a rack within five minutes, or the fried bottom you worked for will steam itself soft.</p>
+  </li>
+</ol>
+<blockquote>
+  <p>The dimpling is not decorative. It redistributes the gas so the crumb bakes even; skip it and the middle domes like a loaf that has something to prove.</p>
+</blockquote>
+<h3>Variations</h3>
+<ul>
+  <li>Halved cherry tomatoes, pressed in cut-side up before baking</li>
+  <li>Thinly sliced potato and thyme, shingled like roof tiles</li>
+  <li>A whole head of roasted garlic, smashed and dotted across the top</li>
+</ul>
+`

--- a/apps/v4/lib/typeset/fixtures/tailwind.ts
+++ b/apps/v4/lib/typeset/fixtures/tailwind.ts
@@ -1,0 +1,205 @@
+export const TAILWIND_HTML = `
+<h1>Tailwind Typography</h1>
+<p>By default, Tailwind removes all of the default browser styling from paragraphs, headings, lists and more. This ends up being really useful for building application UIs because you spend less time undoing user-agent styles, but when you <em>really are</em> just trying to style some content that came from a rich-text editor in a CMS or a markdown file, it can be surprising and unintuitive.</p>
+<p>We get lots of complaints about it actually, with people regularly asking us things like:</p>
+<blockquote>
+  <p>Why is Tailwind removing the default styles on my <code>h1</code> elements? How do I disable this? What do you mean I lose all the other base styles too?</p>
+</blockquote>
+<p>We hear you, but we're not convinced that simply disabling our base styles is what you really want. You don't want to have to remove annoying margins every time you use a <code>p</code> element in a piece of your dashboard UI. And I doubt you really want your blog posts to use the user-agent styles either — you want them to look <em>awesome</em>, not awful.</p>
+<p>The <code>@tailwindcss/typography</code> plugin is our attempt to give you what you <em>actually</em> want, without any of the downsides of doing something stupid like disabling our base styles.</p>
+<p>It adds a new <code>prose</code> class that you can slap on any block of vanilla HTML content and turn it into a beautiful, well-formatted document:</p>
+<pre><code class="language-html">&lt;article class="prose"&gt;
+  &lt;h1&gt;Garlic bread with cheese: What the science tells us&lt;/h1&gt;
+  &lt;p&gt;
+    For years parents have espoused the health benefits of eating garlic bread with cheese to their
+    children, with the food earning such an iconic status in our culture that kids will often dress
+    up as warm, cheesy loaf for Halloween.
+  &lt;/p&gt;
+  &lt;p&gt;
+    But a recent study shows that the celebrated appetizer may be linked to a series of rabies cases
+    springing up around the country.
+  &lt;/p&gt;
+  &lt;!-- ... --&gt;
+&lt;/article&gt;
+</code></pre>
+<p>For more information about how to use the plugin and the features it includes, <a href="https://github.com/tailwindcss/typography/blob/main/README.md">read the documentation</a>.</p>
+<hr>
+<h2 id="what-to-expect-from-here-on-out">What to expect from here on out</h2>
+<p>What follows from here is just a bunch of absolute nonsense I've written to dogfood the plugin itself. It includes every sensible typographic element I could think of, like <strong>bold text</strong>, unordered lists, ordered lists, code blocks, block quotes, <em>and even italics</em>.</p>
+<p>It's important to cover all of these use cases for a few reasons:</p>
+<ol>
+  <li>We want everything to look good out of the box.</li>
+  <li>Really just the first reason, that's the whole point of the plugin.</li>
+  <li>Here's a third pretend reason though a list with three items looks more realistic than a list with two items.</li>
+</ol>
+<p>Now we're going to try out another header style.</p>
+<h3 id="typography-should-be-easy">Typography should be easy</h3>
+<p>So that's a header for you — with any luck if we've done our job correctly that will look pretty reasonable.</p>
+<p>Something a wise person once told me about typography is:</p>
+<blockquote>
+  <p>Typography is pretty important if you don't want your stuff to look like trash. Make it good then it won't be bad.</p>
+</blockquote>
+<p>It's probably important that images look okay here by default as well:</p>
+<figure>
+  <img src="https://images.unsplash.com/photo-1556740758-90de374c12ad?ixlib=rb-1.2.1&amp;ixid=eyJhcHBfaWQiOjEyMDd9&amp;auto=format&amp;fit=crop&amp;w=1000&amp;q=80" alt="">
+  <figcaption>Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old.</figcaption>
+</figure>
+<p>Now I'm going to show you an example of an unordered list to make sure that looks good, too:</p>
+<ul>
+  <li>So here is the first item in this list.</li>
+  <li>In this example we're keeping the items short.</li>
+  <li>Later, we'll use longer, more complex list items.</li>
+</ul>
+<p>And that's the end of this section.</p>
+<h2 id="what-if-we-stack-headings">What if we stack headings?</h2>
+<h3 id="we-should-make-sure-that-looks-good-too">We should make sure that looks good, too.</h3>
+<p>Sometimes you have headings directly underneath each other. In those cases you often have to undo the top margin on the second heading because it usually looks better for the headings to be closer together than a paragraph followed by a heading should be.</p>
+<h3 id="when-a-heading-comes-after-a-paragraph">When a heading comes after a paragraph …</h3>
+<p>When a heading comes after a paragraph, we need a bit more space, like I already mentioned above. Now let's see what a more complex list would look like.</p>
+<ul>
+  <li>
+    <p><strong>I often do this thing where list items have headings.</strong></p>
+    <p>For some reason I think this looks cool which is unfortunate because it's pretty annoying to get the styles right.</p>
+    <p>I often have two or three paragraphs in these list items, too, so the hard part is getting the spacing between the paragraphs, list item heading, and separate list items to all make sense. Pretty tough honestly, you could make a strong argument that you just shouldn't write this way.</p>
+  </li>
+  <li>
+    <p><strong>Since this is a list, I need at least two items.</strong></p>
+    <p>I explained what I'm doing already in the previous list item, but a list wouldn't be a list if it only had one item, and we really want this to look realistic. That's why I've added this second list item so I actually have something to look at when writing the styles.</p>
+  </li>
+  <li>
+    <p><strong>It's not a bad idea to add a third item either.</strong></p>
+    <p>I think it probably would've been fine to just use two items but three is definitely not worse, and since I seem to be having no trouble making up arbitrary things to type, I might as well include it. I'm going to press <kbd>Enter</kbd> now.</p>
+  </li>
+</ul>
+<p>After this sort of list I usually have a closing statement or paragraph, because it kinda looks weird jumping right to a heading.</p>
+<h2 id="code-should-look-okay-by-default">Code should look okay by default.</h2>
+<p>I think most people are going to use <a href="https://highlightjs.org/">highlight.js</a> or <a href="https://prismjs.com/">Prism</a> or something if they want to style their code blocks but it wouldn't hurt to make them look <em>okay</em> out of the box, even with no syntax highlighting.</p>
+<p>Here's what a default <code>tailwind.config.js</code> file looks like at the time of writing:</p>
+<pre><code class="language-js">module.exports = {
+  purge: [],
+  theme: {
+    extend: {},
+  },
+  variants: {},
+  plugins: [],
+}
+</code></pre>
+<p>Hopefully that looks good enough to you.</p>
+<h3 id="what-about-nested-lists">What about nested lists?</h3>
+<p>Nested lists basically always look bad which is why editors like Medium don't even let you do it, but I guess since some of you goofballs are going to do it we have to carry the burden of at least making it work.</p>
+<ol>
+  <li>
+    <strong>Nested lists are rarely a good idea.</strong>
+    <ul>
+      <li>You might feel like you are being really "organized" or something but you are just creating a gross shape on the screen that is hard to read.</li>
+      <li>Nested navigation in UIs is a bad idea too, keep things as flat as possible.</li>
+      <li>Nesting tons of folders in your source code is also not helpful.</li>
+    </ul>
+  </li>
+  <li>
+    <strong>Since we need to have more items, here's another one.</strong>
+    <ul>
+      <li>I'm not sure if we'll bother styling more than two levels deep.</li>
+      <li>Two is already too much, three is guaranteed to be a bad idea.</li>
+      <li>If you nest four levels deep you belong in prison.</li>
+    </ul>
+  </li>
+  <li>
+    <strong>Two items isn't really a list, three is good though.</strong>
+    <ul>
+      <li>Again please don't nest lists if you want people to actually read your content.</li>
+      <li>Nobody wants to look at this.</li>
+      <li>I'm upset that we even have to bother styling this.</li>
+    </ul>
+  </li>
+</ol>
+<p>The most annoying thing about lists in Markdown is that <code>&lt;li&gt;</code> elements aren't given a child <code>&lt;p&gt;</code> tag unless there are multiple paragraphs in the list item. That means I have to worry about styling that annoying situation too.</p>
+<ul>
+  <li>
+    <p><strong>For example, here's another nested list.</strong></p>
+    <p>But this time with a second paragraph.</p>
+    <ul>
+      <li>These list items won't have <code>&lt;p&gt;</code> tags</li>
+      <li>Because they are only one line each</li>
+    </ul>
+  </li>
+  <li>
+    <p><strong>But in this second top-level list item, they will.</strong></p>
+    <p>This is especially annoying because of the spacing on this paragraph.</p>
+    <ul>
+      <li>
+        <p>As you can see here, because I've added a second line, this list item now has a <code>&lt;p&gt;</code> tag.</p>
+        <p>This is the second line I'm talking about by the way.</p>
+      </li>
+      <li>
+        <p>Finally here's another list item so it's more like a list.</p>
+      </li>
+    </ul>
+  </li>
+  <li>
+    <p>A closing list item, but with no nested list, because why not?</p>
+  </li>
+</ul>
+<p>And finally a sentence to close off this section.</p>
+<h2 id="we-didnt-forget-about-description-lists">We didn't forget about description lists</h2>
+<p>Well, that's not exactly true, we first released this plugin back in 2020 and it took three years before we added description lists. But they're here now, so let's just be happy about that…okay? They can be great for things like FAQs.</p>
+<dl>
+  <dt>Why do you never see elephants hiding in trees?</dt>
+  <dd>Because they're so good at it. Lorem ipsum dolor sit amet consectetur adipisicing elit. Quas cupiditate laboriosam fugiat.</dd>
+  <dt>What do you call someone with no body and no nose?</dt>
+  <dd>Nobody knows. Lorem ipsum dolor sit amet consectetur adipisicing elit. Culpa, voluptas ipsa quia excepturi, quibusdam natus exercitationem sapiente tempore labore voluptatem.</dd>
+  <dt>Why can't you hear a pterodactyl go to the bathroom?</dt>
+  <dd>Because the pee is silent. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Ipsam, quas voluptatibus ex culpa ipsum, aspernatur blanditiis fugiat ullam magnam suscipit deserunt illum natus facilis atque vero consequatur! Quisquam, debitis error.</dd>
+</dl>
+<h2 id="there-are-other-elements-we-need-to-style">There are other elements we need to style</h2>
+<p>I almost forgot to mention links, like <a href="https://tailwindcss.com">this link to the Tailwind CSS website</a>. We almost made them blue but that's so yesterday, so we went with dark gray, feels edgier.</p>
+<p>We even included table styles, check it out:</p>
+<table>
+  <thead>
+    <tr>
+      <th>Wrestler</th>
+      <th>Origin</th>
+      <th>Finisher</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Bret "The Hitman" Hart</td>
+      <td>Calgary, AB</td>
+      <td>Sharpshooter</td>
+    </tr>
+    <tr>
+      <td>Stone Cold Steve Austin</td>
+      <td>Austin, TX</td>
+      <td>Stone Cold Stunner</td>
+    </tr>
+    <tr>
+      <td>Randy Savage</td>
+      <td>Sarasota, FL</td>
+      <td>Elbow Drop</td>
+    </tr>
+    <tr>
+      <td>Vader</td>
+      <td>Boulder, CO</td>
+      <td>Vader Bomb</td>
+    </tr>
+    <tr>
+      <td>Razor Ramon</td>
+      <td>Chuluota, FL</td>
+      <td>Razor's Edge</td>
+    </tr>
+  </tbody>
+</table>
+<p>We also need to make sure inline code looks good, like if I wanted to talk about <code>&lt;span&gt;</code> elements or tell you the good news about <code>@tailwindcss/typography</code>.</p>
+<h3 id="sometimes-i-even-use-code-in-headings">Sometimes I even use <code>code</code> in headings</h3>
+<p>Even though it's probably a bad idea, and historically I've had a hard time making it look good. This <em>"wrap the code blocks in backticks"</em> trick works pretty well though really.</p>
+<p>Another thing I've done in the past is put a <code>code</code> tag inside of a link, like if I wanted to tell you about the <a href="https://github.com/tailwindcss/docs"><code>tailwindcss/docs</code></a> repository. I don't love that there is an underline below the backticks but it is absolutely not worth the madness it would require to avoid it.</p>
+<h4 id="we-havent-used-an-h4-yet">We haven't used an <code>h4</code> yet</h4>
+<p>But now we have. Please don't use <code>h5</code> or <code>h6</code> in your content, Medium only supports two heading levels for a reason, you animals. I honestly considered using a <code>before</code> pseudo-element to scream at you if you use an <code>h5</code> or <code>h6</code>.</p>
+<p>We don't style them at all out of the box because <code>h4</code> elements are already so small that they are the same size as the body copy. What are we supposed to do with an <code>h5</code>, make it <em>smaller</em> than the body copy? No thanks.</p>
+<h3 id="we-still-need-to-think-about-stacked-headings-though">We still need to think about stacked headings though.</h3>
+<h4 id="lets-make-sure-we-dont-screw-that-up-with-h4-elements-either">Let's make sure we don't screw that up with <code>h4</code> elements, either.</h4>
+<p>Phew, with any luck we have styled the headings above this text and they look pretty good.</p>
+<p>Let's add a closing paragraph here so things end with a decently sized block of text. I can't explain why I want things to end that way but I have to assume it's because I think things will look weird or unbalanced if there is a heading too close to the end of the document.</p>
+<p>What I've written here is probably long enough, but adding this final sentence can't hurt.</p>
+`

--- a/apps/v4/lib/typeset/fonts.ts
+++ b/apps/v4/lib/typeset/fonts.ts
@@ -1,0 +1,24 @@
+import { FONTS as SITE_FONTS } from '@/lib/fonts'
+
+// Display-only faces that read poorly as body text stay out of typeset.
+const EXCLUDED_FONTS: string[] = ['playfair-display']
+
+// The pickers/preview want a small {id,label,type} plus a render value (the
+// CSS font stack). `family` is the canonical Google/Bunny name that
+// useFontLoader resolves @font-face rules for.
+export const TYPESET_FONTS = SITE_FONTS
+  .filter(font => !EXCLUDED_FONTS.includes(font.value))
+  .map(font => ({
+    id: font.value,
+    label: font.name,
+    type: font.type,
+    family: font.name,
+    value: font.fontFamily,
+    cssVar: font.cssVar,
+  }))
+
+export type TypesetFont = (typeof TYPESET_FONTS)[number]
+
+export function findTypesetFont(id: string | null | undefined) {
+  return TYPESET_FONTS.find(font => font.id === id)
+}

--- a/apps/v4/lib/typeset/icons.ts
+++ b/apps/v4/lib/typeset/icons.ts
@@ -1,0 +1,24 @@
+/**
+ * Structural match for @hugeicons' `IconSvgObject`, which the package declares
+ * but does not export.
+ */
+export type TypesetIcon
+  = | [string, Record<string, string | number>][]
+    | readonly (readonly [string, { readonly [key: string]: string | number }])[]
+
+// Hugeicons has no leading/line-height glyph, so this one is hand-drawn in the
+// same 24x24 grid and stroke weight as the rest of the customizer's icons.
+export const LineHeightIcon: TypesetIcon = [
+  ['path', { 'd': 'M4.5 3.5H19.5', 'stroke': 'currentColor', 'stroke-linecap': 'round', 'stroke-width': '1.5' }],
+  ['path', { 'd': 'M4.5 20.5H19.5', 'stroke': 'currentColor', 'stroke-linecap': 'round', 'stroke-width': '1.5' }],
+  [
+    'path',
+    {
+      'd': 'M17 17L14.8905 11.4741C13.9109 8.90801 13.4211 7.625 12.625 7.625C11.8289 7.625 11.3391 8.90801 10.3595 11.4741L8.25 17',
+      'stroke': 'currentColor',
+      'stroke-linecap': 'round',
+      'stroke-width': '1.5',
+    },
+  ],
+  ['path', { 'd': 'M9.5 13H15.75', 'stroke': 'currentColor', 'stroke-linecap': 'round', 'stroke-width': '1.5' }],
+]

--- a/apps/v4/lib/typeset/keyboard.ts
+++ b/apps/v4/lib/typeset/keyboard.ts
@@ -1,0 +1,12 @@
+/**
+ * Single-key shortcuts must not fire while the user is typing. Shared by every
+ * typeset keydown handler (and by the scripts injected into the preview iframe).
+ */
+export function isEditableTarget(target: EventTarget | null) {
+  return (
+    (target instanceof HTMLElement && target.isContentEditable)
+    || target instanceof HTMLInputElement
+    || target instanceof HTMLTextAreaElement
+    || target instanceof HTMLSelectElement
+  )
+}

--- a/apps/v4/lib/typeset/params.ts
+++ b/apps/v4/lib/typeset/params.ts
@@ -1,0 +1,134 @@
+import { AVAILABLE_CONTENT_OPTIONS } from '@/lib/typeset/fixtures'
+import { TYPESET_FONTS } from '@/lib/typeset/fonts'
+
+export const TYPESET_PARAMS_MESSAGE = 'typeset-params'
+export const TYPESET_COMMAND_MESSAGE = 'typeset-command'
+/**
+ * Sent by the preview once its listener is live. The iframe's `load` event
+ * fires before Vue hydrates it, so a params message posted on `load` alone can
+ * arrive before anything is listening and be dropped — which leaves the first
+ * paint showing defaults. The preview asks instead of the designer guessing.
+ */
+export const TYPESET_READY_MESSAGE = 'typeset-ready'
+
+export type TypesetCommand = 'shuffle' | 'reset' | 'undo' | 'redo' | 'toggle-theme'
+
+export const TYPESET_SIZES = [
+  { value: '14', label: '14px' },
+  { value: '15', label: '15px' },
+  { value: '16', label: '16px' },
+  { value: '18', label: '18px' },
+] as const
+
+export const TYPESET_LEADINGS = [
+  { value: '1.6', label: 'Tight (1.6)' },
+  { value: '1.75', label: 'Regular (1.75)' },
+  { value: '1.9', label: 'Loose (1.9)' },
+] as const
+
+export const TYPESET_FLOWS = [
+  { value: '1em', label: 'Compact (1em)' },
+  { value: '1.25em', label: 'Regular (1.25em)' },
+  { value: '2em', label: 'Airy (2em)' },
+] as const
+
+export const TYPESET_MEASURES = [
+  { value: '60', label: '60ch', width: '28em' },
+  { value: '70', label: '70ch', width: '33em' },
+  { value: '80', label: '80ch', width: '37em' },
+  { value: '90', label: '90ch', width: '42em' },
+] as const
+
+// The one source of truth for what each param accepts. The validators, the
+// history restorer, and the picker coercion all read from here.
+export const TYPESET_PARAM_VALUES = {
+  body: TYPESET_FONTS.map(font => font.id),
+  heading: ['inherit', ...TYPESET_FONTS.map(font => font.id)],
+  mono: TYPESET_FONTS.map(font => font.id),
+  scale: TYPESET_SIZES.map(option => option.value),
+  measure: TYPESET_MEASURES.map(option => option.value),
+  flow: TYPESET_FLOWS.map(option => option.value),
+  leading: TYPESET_LEADINGS.map(option => option.value),
+  item: AVAILABLE_CONTENT_OPTIONS.map(option => option.value),
+} as const satisfies Record<string, readonly string[]>
+
+export const TYPESET_DEFAULTS = {
+  body: 'geist-sans',
+  heading: 'inherit',
+  mono: 'geist-mono',
+  scale: '15',
+  measure: '80',
+  flow: '1.25em',
+  leading: '1.75',
+  item: 'docs',
+} as const
+
+export type TypesetParamKey = keyof typeof TYPESET_DEFAULTS
+
+export type TypesetSearchParams = {
+  [K in TypesetParamKey]: (typeof TYPESET_PARAM_VALUES)[K][number]
+}
+
+export const TYPESET_PARAM_KEYS = Object.keys(TYPESET_DEFAULTS) as TypesetParamKey[]
+
+// Everything but the specimen switcher; derived so locks cannot drift from
+// the param model.
+export type TypesetLockableParam = Exclude<TypesetParamKey, 'item'>
+
+/** Narrows a raw string to the param's allowed values, or null if invalid. */
+export function coerceTypesetValue<K extends TypesetParamKey>(
+  key: K,
+  value: string | null | undefined,
+): TypesetSearchParams[K] | null {
+  if (typeof value !== 'string') {
+    return null
+  }
+  return (TYPESET_PARAM_VALUES[key] as readonly string[]).includes(value)
+    ? (value as TypesetSearchParams[K])
+    : null
+}
+
+/**
+ * History snapshots restore through here: values are validated against the
+ * param model, unknown keys are dropped, and absent keys become null so
+ * defaults clear.
+ */
+export function parseTypesetSnapshot(raw: string) {
+  let parsed: Record<string, unknown> = {}
+  try {
+    const json: unknown = JSON.parse(raw)
+    if (json && typeof json === 'object' && !Array.isArray(json)) {
+      parsed = json as Record<string, unknown>
+    }
+  }
+  catch {
+    // Malformed entries restore as all-null, clearing back to defaults.
+  }
+
+  const snapshot: Record<string, string | null> = {}
+  for (const key of TYPESET_PARAM_KEYS) {
+    const value = parsed[key]
+    snapshot[key] = typeof value === 'string' ? coerceTypesetValue(key, value) : null
+  }
+  return snapshot as { [K in TypesetParamKey]: TypesetSearchParams[K] | null }
+}
+
+/** Builds a preview URL carrying only the params that differ from defaults. */
+export function serializeTypesetSearchParams(
+  base: string,
+  params: TypesetSearchParams,
+) {
+  const search = new URLSearchParams()
+  for (const key of TYPESET_PARAM_KEYS) {
+    // `item` is part of the path, not the query.
+    if (key === 'item') {
+      continue
+    }
+    const value = params[key]
+    if (value && value !== TYPESET_DEFAULTS[key]) {
+      search.set(key, value)
+    }
+  }
+  const query = search.toString()
+  return query ? `${base}?${query}` : base
+}

--- a/apps/v4/pages/preview/typeset/[name].vue
+++ b/apps/v4/pages/preview/typeset/[name].vue
@@ -1,0 +1,138 @@
+<script setup lang="ts">
+import type { FixtureName } from '@/lib/typeset/fixtures'
+import { useEventListener } from '@vueuse/core'
+import { AVAILABLE_CONTENT_OPTIONS, FIXTURES } from '@/lib/typeset/fixtures'
+import { CHAT_QUESTION } from '@/lib/typeset/fixtures/chat'
+import { findTypesetFont } from '@/lib/typeset/fonts'
+import { isEditableTarget } from '@/lib/typeset/keyboard'
+import {
+  TYPESET_COMMAND_MESSAGE,
+  TYPESET_MEASURES,
+} from '@/lib/typeset/params'
+
+definePageMeta({ layout: 'blank' })
+
+const route = useRoute()
+// Seeded from the URL, then driven by the designer over postMessage — see the
+// composable for why this deliberately never writes back to the router.
+const params = useTypesetPreviewParams()
+const { loadFont } = useFontLoader()
+
+const name = computed(() => route.params.name as FixtureName)
+
+if (!AVAILABLE_CONTENT_OPTIONS.some(option => option.value === name.value)) {
+  throw createError({ statusCode: 404, statusMessage: 'Specimen not found', fatal: true })
+}
+
+const bodyFont = computed(() => findTypesetFont(params.body))
+const headingFont = computed(() =>
+  params.heading === 'inherit'
+    ? bodyFont.value
+    : findTypesetFont(params.heading),
+)
+const monoFont = computed(() => findTypesetFont(params.mono))
+
+const measureWidth = computed(
+  () => TYPESET_MEASURES.find(option => option.value === params.measure)?.width,
+)
+
+// Fire-and-forget: resolve + inject the @font-face rules on demand (deduped).
+watchEffect(() => {
+  for (const font of [bodyFont.value, headingFont.value, monoFont.value]) {
+    if (font) {
+      loadFont(font.family)
+    }
+  }
+})
+
+// Set through typeset's own custom properties — the exact API the docs hand to
+// users — rather than a private preview indirection. Inline styles win over the
+// defaults typeset.css declares in @layer components.
+const typesetStyle = computed(() => ({
+  '--typeset-font-body': bodyFont.value?.value,
+  '--typeset-font-heading': headingFont.value?.value,
+  '--typeset-font-mono': monoFont.value?.value,
+  '--typeset-size': `${params.scale}px`,
+  '--typeset-leading': params.leading,
+  '--typeset-flow': params.flow,
+}))
+
+const html = computed(() => FIXTURES[name.value])
+
+// Shortcuts pressed inside the iframe belong to the designer around it: forward
+// them as typed commands and let the parent run the real action.
+function forwardCommand(command: string) {
+  if (window.parent && window.parent !== window) {
+    window.parent.postMessage(
+      { type: TYPESET_COMMAND_MESSAGE, command },
+      window.location.origin,
+    )
+  }
+}
+
+useEventListener(globalThis.document, 'keydown', (event: KeyboardEvent) => {
+  if (isEditableTarget(event.target)) {
+    return
+  }
+
+  if (event.metaKey || event.ctrlKey) {
+    const key = event.key.toLowerCase()
+    if ((key === 'z' && event.shiftKey) || (key === 'y' && event.ctrlKey)) {
+      event.preventDefault()
+      forwardCommand('redo')
+    }
+    else if (key === 'z') {
+      event.preventDefault()
+      forwardCommand('undo')
+    }
+    return
+  }
+
+  if (event.altKey) {
+    return
+  }
+
+  if (event.key === 'r' || event.key === 'R') {
+    event.preventDefault()
+    forwardCommand(event.shiftKey ? 'reset' : 'shuffle')
+  }
+  else if (event.key === 'd' || event.key === 'D') {
+    event.preventDefault()
+    forwardCommand('toggle-theme')
+  }
+})
+</script>
+
+<template>
+  <div
+    class="flex min-h-svh justify-center px-6 pt-8 pb-24 md:pt-24 md:pb-32"
+    :style="{ fontFamily: bodyFont?.value }"
+  >
+    <div class="w-full" :style="{ maxWidth: measureWidth }">
+      <!-- The user bubble is page chrome: it sits outside the typeset
+           container on purpose, so only the answer is styled. -->
+      <div v-if="name === 'chat'" class="flex w-full flex-col gap-10">
+        <div class="ml-auto w-fit max-w-[65%] rounded-3xl bg-muted px-4 py-2.5">
+          {{ CHAT_QUESTION }}
+        </div>
+        <!-- eslint-disable-next-line vue/no-v-html -- static, first-party fixture -->
+        <div class="typeset w-full" :style="typesetStyle" v-html="html" />
+      </div>
+      <!-- eslint-disable-next-line vue/no-v-html -- static, first-party fixture -->
+      <div v-else class="typeset w-full" :style="typesetStyle" v-html="html" />
+    </div>
+  </div>
+</template>
+
+<style>
+/* typeset.css itself is imported globally from assets/css/main.css — see the
+   comment there for why the layer order forces that. */
+html {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+
+html::-webkit-scrollbar {
+  display: none;
+}
+</style>

--- a/apps/v4/pages/preview/typeset/[name].vue
+++ b/apps/v4/pages/preview/typeset/[name].vue
@@ -10,7 +10,18 @@ import {
   TYPESET_MEASURES,
 } from '@/lib/typeset/params'
 
-definePageMeta({ layout: 'blank' })
+definePageMeta({
+  layout: 'blank',
+  // Nuxt re-runs `validate` on every param change. Checking in setup instead
+  // would only cover the first render: Vue Router reuses this component when
+  // just `[name]` changes, so navigating on to an unknown specimen would render
+  // `undefined` rather than 404.
+  validate(route) {
+    return AVAILABLE_CONTENT_OPTIONS.some(
+      option => option.value === route.params.name,
+    )
+  },
+})
 
 const route = useRoute()
 // Seeded from the URL, then driven by the designer over postMessage — see the
@@ -19,10 +30,6 @@ const params = useTypesetPreviewParams()
 const { loadFont } = useFontLoader()
 
 const name = computed(() => route.params.name as FixtureName)
-
-if (!AVAILABLE_CONTENT_OPTIONS.some(option => option.value === name.value)) {
-  throw createError({ statusCode: 404, statusMessage: 'Specimen not found', fatal: true })
-}
 
 const bodyFont = computed(() => findTypesetFont(params.body))
 const headingFont = computed(() =>

--- a/apps/v4/pages/typeset.vue
+++ b/apps/v4/pages/typeset.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+// Exactly one caller sets up the undo stack's recording watcher and its ⌘Z
+// shortcuts; every other component just reads the shared state.
+useTypesetHistory({ record: true })
+
+const title = 'Typeset'
+const description = 'Typography for markdown you don\'t control.'
+
+useSeoMeta({
+  title,
+  description,
+  ogTitle: title,
+  ogDescription: description,
+  twitterCard: 'summary_large_image',
+})
+</script>
+
+<template>
+  <div class="relative z-10 flex min-h-0 flex-1 flex-col overflow-hidden section-soft [--customizer-width:--spacing(48)] [--gap:--spacing(4)] md:[--gap:--spacing(6)] 2xl:[--customizer-width:--spacing(56)]">
+    <ClientOnly>
+      <div
+        data-slot="designer"
+        class="flex min-h-0 flex-1 flex-col items-start gap-(--gap) p-(--gap) pt-[calc(var(--gap)*0.25)] md:flex-row-reverse"
+      >
+        <TypesetDocsPanel />
+        <TypesetPreview />
+        <TypesetCustomizer />
+      </div>
+      <template #fallback>
+        <TypesetSkeleton />
+      </template>
+    </ClientOnly>
+  </div>
+</template>

--- a/apps/v4/public/typeset.css
+++ b/apps/v4/public/typeset.css
@@ -1,0 +1,490 @@
+/*
+ * shadcn/typeset
+ * https://ui.shadcn.com/docs/typeset.
+ */
+
+@layer components {
+  .typeset {
+    --typeset-font-body: inherit;
+    --typeset-font-heading: var(--font-heading);
+    --typeset-font-mono: var(--font-mono);
+    --typeset-size: 1em;
+    --typeset-leading: 1.75;
+    --typeset-flow: 1.25em;
+  }
+}
+
+@layer components {
+  .typeset {
+    font-family: var(--typeset-font-body);
+    font-size: calc(var(--typeset-size) * 1.125);
+    line-height: var(--typeset-leading);
+    color: var(--color-foreground, currentColor);
+    overflow-wrap: break-word;
+    margin-trim: block-start;
+
+    @media (min-width: 48rem), print {
+      font-size: var(--typeset-size);
+    }
+
+    --typeset-muted: var(
+      --color-muted-foreground,
+      color-mix(in oklab, currentColor 60%, transparent)
+    );
+    --typeset-rule: var(
+      --color-border,
+      color-mix(in oklab, currentColor 20%, transparent)
+    );
+  }
+
+  .typeset
+    *:not(
+      :where(
+        .not-typeset,
+        [data-not-typeset],
+        .not-typeset *,
+        [data-not-typeset] *
+      )
+    ) {
+    /* Paragraphs. */
+    &:where(p) {
+      margin-block-start: var(--typeset-flow);
+      margin-block-end: 0;
+    }
+
+    /* Headings. */
+    &:where(h1, h2, h3, h4, h5, h6) {
+      color: var(--color-foreground, currentColor);
+      font-family: var(--typeset-font-heading);
+      font-weight: 600;
+      margin-block-end: 0;
+    }
+    &:where(h1) {
+      font-size: 1.75em;
+      line-height: 1.3;
+      margin-block-start: var(--typeset-flow);
+    }
+    &:where(h2) {
+      font-size: 1.25em;
+      line-height: 1.4;
+      margin-block-start: calc(var(--typeset-flow) * 1.4);
+    }
+    &:where(h3) {
+      font-size: 1.125em;
+      line-height: 1.45;
+      margin-block-start: var(--typeset-flow);
+    }
+    &:where(h4) {
+      font-size: 1em;
+      line-height: 1.5;
+      margin-block-start: var(--typeset-flow);
+    }
+    &:where(h5) {
+      font-size: 0.875em;
+      line-height: 1.5;
+      font-weight: 500;
+      color: var(--typeset-muted);
+      margin-block-start: calc(var(--typeset-flow) / 0.875);
+    }
+    &:where(h6) {
+      font-size: 0.8125em;
+      line-height: 1.5;
+      font-weight: 500;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--typeset-muted);
+      margin-block-start: calc(var(--typeset-flow) / 0.8125);
+    }
+    /* Anchors. */
+    &:where([id]) {
+      scroll-margin-block-start: var(--typeset-flow);
+    }
+
+    /* Headings own the space below them. */
+    &:where(h1 + *, h2 + *, h3 + *, h4 + *, h5 + *, h6 + *) {
+      margin-block-start: 1em;
+    }
+    &:where(:is(h1, h2, h3, h4) :is(code)) {
+      font-size: 0.9em;
+    }
+
+    /* Links. */
+    &:where(a) {
+      color: inherit;
+      font-weight: 500;
+      text-decoration-line: underline;
+      text-decoration-color: color-mix(in oklab, currentColor 30%, transparent);
+    }
+    &:where(a:hover) {
+      text-decoration-color: currentColor;
+    }
+    &:where(a:focus-visible) {
+      outline: 2px solid var(--color-ring, currentColor);
+      outline-offset: 2px;
+      border-radius: 0.125em;
+    }
+    &:where(:is(h1, h2, h3, h4, h5, h6) :is(a)) {
+      font-weight: inherit;
+    }
+
+    /* Inline semantics. */
+    &:where(strong, b) {
+      font-weight: 600;
+    }
+    &:where(:is(h1, h2, h3, h4) :is(strong, b)) {
+      font-weight: 600;
+    }
+    &:where(mark) {
+      background-color: color-mix(
+        in oklab,
+        oklch(0.86 0.17 95) 40%,
+        transparent
+      );
+      color: inherit;
+      padding: 0.05em 0.15em;
+      border-radius: 0.2em;
+    }
+    &:where(abbr[title]) {
+      text-decoration-line: underline;
+      text-decoration-style: dotted;
+      text-underline-offset: 0.2em;
+      cursor: help;
+    }
+    &:where(del, s) {
+      color: var(--typeset-muted);
+      text-decoration-line: line-through;
+    }
+    &:where(sup, sub) {
+      font-size: 0.75em;
+      line-height: 0;
+      position: relative;
+      vertical-align: baseline;
+    }
+    &:where(sup) {
+      top: -0.5em;
+    }
+    &:where(sub) {
+      bottom: -0.25em;
+    }
+    &:where(sup a) {
+      text-decoration-line: none;
+      font-weight: 500;
+    }
+
+    /* Lists. */
+    &:where(ul) {
+      list-style-type: disc;
+    }
+    &:where(ol) {
+      list-style-type: decimal;
+    }
+    &:where(ul ul) {
+      list-style-type: circle;
+    }
+    &:where(ul ul ul) {
+      list-style-type: square;
+    }
+    &:where(ol[type="a" i]) {
+      list-style-type: lower-alpha;
+    }
+    &:where(ol[type="i" i]) {
+      list-style-type: lower-roman;
+    }
+    &:where(ol[type="A" s]) {
+      list-style-type: upper-alpha;
+    }
+    &:where(ol[type="I" s]) {
+      list-style-type: upper-roman;
+    }
+    &:where(ul, ol) {
+      margin-block-start: var(--typeset-flow);
+      margin-block-end: 0;
+      padding-inline-start: 1.5em;
+    }
+    &:where(li) {
+      margin-block-start: 0.5em;
+      padding-inline-start: 0.4em;
+    }
+    &:where(li > p, li > ul, li > ol) {
+      margin-block-start: 0.5em;
+    }
+    &:where(ul > li)::marker {
+      color: var(--typeset-muted);
+    }
+    &:where(ol > li)::marker {
+      color: var(--typeset-muted);
+    }
+
+    /* GFM task lists. */
+    &:where(ul.contains-task-list) {
+      list-style-type: none;
+      padding-inline-start: 0.25em;
+    }
+    &:where(li.task-list-item > input[type="checkbox"]) {
+      margin-inline-end: 0.5em;
+      vertical-align: -0.1em;
+      accent-color: var(--color-primary, currentColor);
+    }
+
+    /* Disclosures. */
+    &:where(details) {
+      margin-block-start: var(--typeset-flow);
+      margin-block-end: 0;
+    }
+    &:where(summary) {
+      cursor: pointer;
+      font-weight: 500;
+    }
+    &:where(summary)::marker {
+      color: var(--typeset-muted);
+    }
+
+    /* Keyboard keys. */
+    &:where(kbd) {
+      font-family: inherit;
+      font-size: 0.85em;
+      font-weight: 500;
+      border: 1px solid var(--typeset-rule);
+      border-block-end-width: 2px;
+      border-radius: min(calc(var(--radius, 0.5em) * 0.6), 0.35em);
+      padding: 0.0625em 0.35em;
+    }
+
+    /* Definition lists. */
+    &:where(dl) {
+      margin-block-start: var(--typeset-flow);
+      margin-block-end: 0;
+    }
+    &:where(dt) {
+      font-weight: 500;
+      margin-block-start: 1em;
+    }
+    &:where(dt + dt) {
+      margin-block-start: 0.25em;
+    }
+    &:where(dd) {
+      margin-block-start: 0.25em;
+      margin-inline-start: 0;
+      padding-inline-start: 1em;
+      color: var(--typeset-muted);
+    }
+
+    /* Inline code. */
+    &:where(:not(pre) > code) {
+      background-color: var(
+        --color-muted,
+        color-mix(in oklab, currentColor 8%, transparent)
+      );
+      font-family: var(--typeset-font-mono);
+      font-size: 0.85em;
+      border-radius: min(calc(var(--radius, 0.5em) * 0.6), 0.35em);
+      padding: 0.125em 0.3em;
+    }
+
+    /* Code blocks. */
+    &:where(pre) {
+      background-color: var(
+        --color-muted,
+        color-mix(in oklab, currentColor 8%, transparent)
+      );
+      font-family: var(--typeset-font-mono);
+      font-size: 0.875em;
+      line-height: 1.5;
+      tab-size: 2;
+      direction: ltr;
+      border-radius: var(--radius, 0.5em);
+      padding: 0.75em 1em;
+      overflow-x: auto;
+      margin-block-start: calc(var(--typeset-flow) / 0.875);
+      margin-block-end: 0;
+    }
+    &:where(pre code) {
+      background-color: transparent;
+      font-family: inherit;
+      font-size: inherit;
+      padding: 0;
+      border-radius: 0;
+    }
+
+    /* Blockquote. */
+    &:where(blockquote) {
+      border-inline-start: 2px solid var(--typeset-rule);
+      padding-inline-start: 1em;
+      margin-block-start: var(--typeset-flow);
+      margin-block-end: 0;
+      margin-inline: 0;
+    }
+
+    /* Dividers. */
+    &:where(hr) {
+      border: 0;
+      border-block-start: 1px solid var(--typeset-rule);
+      margin-block-start: calc(var(--typeset-flow) * 2.4);
+      margin-block-end: 0;
+    }
+    &:where(hr + h1, hr + h2, hr + h3, hr + h4) {
+      margin-block-start: var(--typeset-flow);
+    }
+
+    /* GFM footnotes. */
+    &:where(.footnotes, [data-footnotes]) {
+      margin-block-start: calc(var(--typeset-flow) * 2);
+      border-block-start: 1px solid var(--typeset-rule);
+      padding-block-start: var(--typeset-flow);
+      font-size: 0.875em;
+      color: var(--typeset-muted);
+    }
+
+    /* Math. */
+    &:where(math[display="block"]) {
+      margin-block-start: var(--typeset-flow);
+      margin-block-end: 0;
+      overflow-x: auto;
+      overflow-y: hidden;
+      padding-block: 0.25em;
+    }
+
+    /* Media. */
+    &:where(img, video) {
+      border-radius: var(--radius, 0.5em);
+      max-width: 100%;
+      height: auto;
+      margin-block-start: var(--typeset-flow);
+      margin-block-end: 0;
+    }
+    &:where(p img) {
+      margin-block-start: 0;
+    }
+    &:where(figure) {
+      margin-block-start: var(--typeset-flow);
+      margin-block-end: 0;
+      margin-inline: 0;
+    }
+    &:where(figcaption, caption) {
+      color: var(--typeset-muted);
+      font-size: 0.875em;
+      text-align: center;
+      margin-block-start: calc(0.75em / 0.875);
+    }
+    &:where(caption) {
+      caption-side: bottom;
+    }
+
+    /* Tables. Separators sit on cells, not tr:last-child: append-safe.
+       Bare tables stay real tables (keep their semantics) and wrap to fit. */
+    &:where(table) {
+      max-width: 100%;
+      font-size: 1em;
+      line-height: 1.5;
+      font-variant-numeric: tabular-nums;
+      border-collapse: separate;
+      border-spacing: 0;
+      border-block-end: 1px solid var(--typeset-rule);
+      margin-block-start: var(--typeset-flow);
+      margin-block-end: 0;
+    }
+
+    /* Horizontal scroll for any wide block. Wrap it and the wrapper owns the
+       flow margin. Tables shrink to fit, so widen the table to make it scroll
+       instead of compress. */
+    &:where(.typeset-scroll) {
+      overflow-x: auto;
+      margin-block-start: var(--typeset-flow);
+    }
+    &:where(.typeset-scroll > *) {
+      margin-block-start: 0;
+    }
+    &:where(.typeset-scroll table) {
+      width: max-content;
+      max-width: none;
+    }
+    &:where(thead th) {
+      font-weight: 500;
+      text-align: start;
+      white-space: nowrap;
+      padding: 0.65em 1em;
+    }
+    &:where(:is(tbody, tfoot) :is(td, th)) {
+      padding: 0.75em 1em;
+      text-align: start;
+      vertical-align: top;
+      border-block-start: 1px solid var(--typeset-rule);
+    }
+    &:where(tbody th, tfoot th) {
+      font-weight: 500;
+    }
+    &:where(th:first-child, td:first-child) {
+      padding-inline-start: 0;
+    }
+    &:where(th[align="center"], td[align="center"]) {
+      text-align: center;
+    }
+    &:where(th[align="right"], td[align="right"]) {
+      text-align: end;
+    }
+
+    /* Blocks inside list items keep the list's tighter rhythm. */
+    &:where(li > blockquote, li > table, li > figure) {
+      margin-block-start: 0.5em;
+    }
+    &:where(li > pre) {
+      margin-block-start: calc(0.5em / 0.875);
+    }
+
+    @media print {
+      &:where(pre, table, blockquote, figure) {
+        break-inside: avoid;
+      }
+      &:where(h1, h2, h3, h4) {
+        break-after: avoid;
+      }
+    }
+
+    /* Forced colors strips the code background, so give it a border. */
+    @media (forced-colors: active) {
+      &:where(:not(pre) > code) {
+        border: 1px solid;
+      }
+    }
+  }
+
+  /* First child adds no space above. Last so it wins ties. */
+  .typeset
+    > :where(:first-child):not(
+      :where(
+        .not-typeset,
+        [data-not-typeset],
+        .not-typeset *,
+        [data-not-typeset] *
+      )
+    ),
+  .typeset
+    > :where(:first-child)
+    > :where(:first-child):not(
+      :where(
+        .not-typeset,
+        [data-not-typeset],
+        .not-typeset *,
+        [data-not-typeset] *
+      )
+    ),
+  .typeset
+    :where(
+      li > :first-child,
+      blockquote > :first-child,
+      td > :first-child,
+      th > :first-child,
+      dd > :first-child,
+      figure > :first-child,
+      figure > picture > img
+    ):not(
+      :where(
+        .not-typeset,
+        [data-not-typeset],
+        .not-typeset *,
+        [data-not-typeset] *
+      )
+    ) {
+    margin-block-start: 0;
+  }
+}


### PR DESCRIPTION
Ports [Typeset](https://ui.shadcn.com/typeset) from upstream shadcn-ui: the designer at `/typeset`, the `typeset.css` stylesheet, and the docs page at `/docs/typeset`.

Typeset is one stylesheet that styles rendered markdown — wrap content in a `typeset` container and everything inside (headings, lists, tables, code, blockquotes) is styled, with three controls (size, leading, flow) driving the rhythm.

## What's here

| Area | Files |
| --- | --- |
| Stylesheet | `public/typeset.css` (+ import in `assets/css/main.css`) |
| Data model | `lib/typeset/{params,fonts,code,icons,keyboard}.ts` + `lib/typeset/fixtures/` |
| State | `composables/useTypeset{SearchParams,PreviewParams,History,Locks,Shuffle,PreviewOverride,ThemeToggle}.ts` |
| UI | `components/typeset/` (13 components) |
| Routes | `pages/typeset.vue`, `pages/preview/typeset/[name].vue` |
| Docs & nav | `content/docs/typeset.md`, `lib/config.ts`, `components/DocsSidebar.vue` |

## Notes on the port

**`typeset.css` is byte-identical to upstream** and lives in `public/`, so it is served verbatim at `/typeset.css` — the same file the "Copy typeset.css" button hands users and the generated prompt tells agents to download. One source, no drift.

It is imported globally from `assets/css/main.css`, after Tailwind, and that placement is load-bearing. CSS orders `@layer` by first appearance, so loading typeset as a `<link>` or a route-level chunk registers `components` *ahead of* `base` and Tailwind preflight silently kills every typeset rule — the custom properties still look correct in the DOM while nothing is actually styled. The resulting order differs between dev and the production build, so it cannot be left to load order. Its rules only match inside `.typeset`, so importing it globally styles nothing on its own.

**URL state** uses one query key per param via `useRouteQuery`, rather than `/create`'s single encoded `preset` blob — a typeset link is meant to be readable and hand-editable. Reads are validated against the param model and writes drop values equal to the default.

**Undo/redo keeps its own stack** of URL snapshots. Every picker writes with `replace` (otherwise each pick would push a browser history entry), so there is nothing for the browser to pop. Exactly one caller — the page — passes `record: true` to own the recording watcher and the ⌘Z bindings.

**The preview iframe is driven entirely over postMessage.** Its `src` is set once to seed the first paint and only rewritten when `item` changes (a different specimen route); recomputing it per param would navigate the iframe on every pick *and every hover preview*. The iframe posts a ready message once its listener is attached rather than the designer posting on `load` — `load` fires before Vue hydrates, so that message is dropped and deep links paint defaults.

**The preview holds params in local reactive state** (`useTypesetPreviewParams`) instead of writing them back through its own router. The iframe's first `router.replace` lands while Vue Router is still settling its initial navigation and is silently dropped, so the first pick after load never applied. It applies typeset's own custom properties — the exact API the docs hand to users — instead of upstream's private `--preview-*` indirection.

**Hover previews stay out of the URL.** The URL is what the undo stack snapshots, so committing hovers would record a phantom entry per hovered item.

## Deliberate deviations

- **Fonts** resolve through the existing `useFontLoader` (unifont/Bunny) instead of upstream's `next/font` preview variables. `playfair-display` is excluded as display-only; upstream's other two exclusions don't exist in this repo's font list.
- **Get Code** emits `@nuxt/fonts` config for Nuxt and Fontsource for Vite/Laravel/Astro, replacing upstream's `next/font` branch. Snippets use `class=` and Vue templates.
- **Locks** use `useState` so every LockButton and the shuffle action share one store without leaking across SSR requests. (Note: the existing `composables/useLocks.ts` used by `/create` builds a fresh `reactive(new Set())` per call, so its locks don't actually share across components — left untouched here, but worth a follow-up.)
- **`anchorRef`** is dropped from the pickers. `/create` threads it through to `PickerContent`, but reka-ui's `DropdownMenuContent` has no `anchor` prop, so it was inert; mobile popups position off the trigger with `side="top"`.

## Verification

Driven in real Chrome (playwright-core) against **both the dev server and the production build** — 25/25 in each. Several of these bugs only reproduced in one of the two, so both runs matter.

Cascade (not just "the vars are set" — this is what caught the layer-ordering bug):
- paragraphs get block spacing from `--typeset-flow` (`margin-block-start: 15px`)
- headings outrank body text (18.75px/600 vs 15px/400)
- code resolves to the mono family; container line-height matches `--typeset-leading`

Behaviour:
- picker commits to the URL and the iframe restyles over postMessage
- iframe is **not** reloaded on param change (DOM sentinel survives)
- hover preview applies to the iframe, never touches the URL, reverts on close
- lock + shuffle: `R` changes params, the locked one survives
- undo/redo via ⌘Z / ⇧⌘Z round-trips exactly
- `R` pressed *inside* the iframe forwards to the parent
- toolbar switches specimen (URL + the chat specimen's question bubble renders)
- `D` toggles theme; deep links restore full state on cold load
- no uncaught page errors

Also: `pnpm typecheck` clean for all new files (the repo has pre-existing errors elsewhere — pagination examples, dnd-kit version skew, `scripts/build-icons*`; `useFontLoader`/`useDesignSystemProvider` were already failing). `pnpm eslint` clean. `pnpm build` succeeds and prerenders `/typeset` and `/docs/typeset`.

Two environment notes for reviewers: `typecheck` needs `NODE_OPTIONS=--max-old-space-size=16384` to avoid an OOM (same as `build`), and `@formisch/vue` was declared but missing from `node_modules` on my checkout — a `pnpm install` fixes it, lockfile unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Typeset page with interactive controls for fonts, size, leading, flow, and measure, plus live previews across multiple content examples.
  * Introduced shuffle, lock/unlock, undo/redo, reset, theme switching, and keyboard shortcuts.
  * Added Typeset documentation, navigation, responsive controls, and open-in-new-tab previews.
  * Added “Get Code” guidance with copyable stylesheet, prompts, and framework-aware setup snippets.
* **Style**
  * Added comprehensive Typeset styling for headings, lists, code, tables, media, math, dark mode, accessibility, and responsive layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->