### PR TITLE
fix(docs): prevent component preview clipping

### DIFF
--- a/apps/v4/components/ComponentPreviewTabs.vue
+++ b/apps/v4/components/ComponentPreviewTabs.vue
@@ -35,7 +35,7 @@ const isMobileCodeVisible = ref(false)
           :data-align="align"
           :data-chromeless="chromeLessOnMobile"
           :class="cn(
-            'preview relative flex h-72 w-full justify-center p-10 data-[align=center]:items-center data-[align=end]:items-start data-[align=start]:items-start data-[chromeless=true]:h-auto data-[chromeless=true]:p-0 sm:data-[align=end]:items-end',
+            'preview relative flex min-h-72 w-full justify-center p-10 data-[align=center]:items-center data-[align=end]:items-start data-[align=start]:items-start data-[chromeless=true]:h-auto data-[chromeless=true]:p-0 sm:data-[align=end]:items-end',
             props.previewClass,
           )"
         >


### PR DESCRIPTION
Fixes component demos whose content is taller than the default preview area being clipped before it reaches the code panel. Commit `03554c98` changed the shared preview wrapper in `ComponentPreviewTabs.vue` from `min-h-72` to the fixed height `h-72`; because the outer preview card uses `overflow-hidden`, taller demos such as Table lost their final rows, footer, and caption.

This restores `min-h-72`, preserving the 18rem default while allowing the preview wrapper to grow with its rendered component. The alignment changes from the original commit remain unchanged.

![Table component preview clipped at the code panel boundary](https://raw.githubusercontent.com/jevin98/shadcn-vue/b0ffd86d51ef757f2f457dbfdef8c72710cb9af5/.github/pr-assets/1935-component-preview-clipping.png)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the component preview area to expand when its content exceeds the minimum height, preventing content from being constrained or clipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
