### PR TITLE
fix(cli): let projects opt out of font imports

### DIFF
--- a/apps/v4/content/docs/03.components-json.md
+++ b/apps/v4/content/docs/03.components-json.md
@@ -44,6 +44,30 @@ The style for your components. **This cannot be changed after initialization.**
 
 The `default` style has been deprecated. Use the `new-york` style instead.
 
+## font
+
+The font for your components. The CLI keeps the matching Google Fonts `@import`
+in your CSS file in sync with this value every time you add a component.
+
+```json title="components.json"
+{
+  "font": "inter"
+}
+```
+
+Set it to `none` if you load fonts yourself — with `@nuxt/fonts`, `unplugin-fonts`,
+or self-hosted font files. The CLI then adds no font `@import` to your CSS and
+removes the ones it added on previous runs. Imports for fonts the CLI doesn't
+ship are always left alone.
+
+```json title="components.json"
+{
+  "font": "none"
+}
+```
+
+You can also set this at init time with `npx shadcn-vue@latest init --font none`.
+
 ## tailwind
 
 Configuration to help the CLI understand how Tailwind CSS is set up in your project.

--- a/apps/v4/content/docs/03.components-json.md
+++ b/apps/v4/content/docs/03.components-json.md
@@ -57,8 +57,8 @@ in your CSS file in sync with this value every time you add a component.
 
 Set it to `none` if you load fonts yourself — with `@nuxt/fonts`, `unplugin-fonts`,
 or self-hosted font files. The CLI then adds no font `@import` to your CSS and
-removes the ones it added on previous runs. Imports for fonts the CLI doesn't
-ship are always left alone.
+removes the ones it added on previous runs. Font imports you wrote yourself are
+always left alone, even for a family the CLI also ships.
 
 ```json title="components.json"
 {

--- a/apps/v4/content/docs/06.cli.md
+++ b/apps/v4/content/docs/06.cli.md
@@ -29,7 +29,7 @@ Options:
   --base <base>                  the component library base to use. (reka)
   --style <style>                the visual style to use. (vega, nova, maia, lyra, mira, luma, sera)
   --icon-library <icon-library>  the icon library to use. (lucide, tabler, hugeicons, phosphor, remixicon)
-  --font <font>                  the font to use. (inter, figtree, jetbrains-mono, geist, geist-mono)
+  --font <font>                  the font to use, or "none" to manage fonts yourself. (inter, figtree, jetbrains-mono, geist, geist-mono, none)
   -b, --base-color <base-color>  the base color to use. (neutral, gray, zinc, stone, slate)
   -n, --name <name>              the name for the new project.
   -d, --defaults                 use default configuration. (default: false)

--- a/apps/v4/public/schema.json
+++ b/apps/v4/public/schema.json
@@ -10,7 +10,8 @@
       "type": "string"
     },
     "font": {
-      "type": "string"
+      "type": "string",
+      "description": "The font to use. Set to \"none\" to opt out of CLI-managed font imports."
     },
     "typescript": {
       "type": "boolean",

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -930,7 +930,10 @@ async function promptForMinimalConfig(
     $schema: defaultConfig?.$schema,
     style: composeStyleId(base, style),
     font,
-    ...(defaultConfig.fontHeading
+    // Opting out of fonts drops the heading font with it, so a leftover
+    // `fontHeading` doesn't keep the CLI managing fonts for the project.
+    ...(font !== FONT_NONE
+      && defaultConfig.fontHeading
       && { fontHeading: defaultConfig.fontHeading }),
     iconLibrary,
     rtl: opts.rtl ?? defaultConfig.rtl ?? false,

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -43,6 +43,7 @@ import {
   FILE_BACKUP_SUFFIX,
   restoreFileBackup,
 } from '@/src/utils/file-helper'
+import { FONT_NONE } from '@/src/utils/fonts'
 import {
   createConfig,
   DEFAULT_COMPONENTS,
@@ -75,6 +76,20 @@ process.on('exit', (code) => {
   // Restore backup if error.
   return restoreFileBackup(filePath)
 })
+
+// Font prompt choices. `none` opts out of CLI-managed fonts for projects that
+// load fonts themselves (`@nuxt/fonts`, `unplugin-fonts`, self-hosted, ...).
+const FONT_CHOICES = [
+  ...FONTS.map(font => ({
+    title: font.label,
+    value: font.name,
+  })),
+  {
+    title: 'None',
+    value: FONT_NONE,
+    description: 'Do not add font imports to your CSS file.',
+  },
+]
 
 export const initOptionsSchema = z.object({
   cwd: z.string(),
@@ -152,12 +167,12 @@ export const initOptionsSchema = z.object({
     .refine(
       (val) => {
         if (val) {
-          return FONTS.find(font => font.name === val)
+          return val === FONT_NONE || FONTS.find(font => font.name === val)
         }
         return true
       },
       {
-        message: `Invalid font. Please use '${FONTS.map(font => font.name).join('\', \'')}'`,
+        message: `Invalid font. Please use '${[...FONTS.map(font => font.name), FONT_NONE].join('\', \'')}'`,
       },
     ),
   baseColor: z
@@ -235,7 +250,7 @@ export const init = new Command()
   )
   .option(
     '--font <font>',
-    'the font to use. (inter, figtree, jetbrains-mono, geist, geist-mono)',
+    'the font to use, or "none" to manage fonts yourself. (inter, figtree, jetbrains-mono, geist, geist-mono, none)',
     undefined,
   )
   .option(
@@ -721,10 +736,7 @@ async function promptForConfig(defaultConfig: Config | null = null, opts?: z.inf
         type: 'select',
         name: 'font',
         message: `Which ${highlighter.info('font')} would you like to use?`,
-        choices: FONTS.map(f => ({
-          title: f.label,
-          value: f.name,
-        })),
+        choices: FONT_CHOICES,
         initial: 0,
       },
       {
@@ -890,10 +902,7 @@ async function promptForMinimalConfig(
         type: opts.font ? null : 'select',
         name: 'font',
         message: `Which ${highlighter.info('font')} would you like to use?`,
-        choices: FONTS.map(f => ({
-          title: f.label,
-          value: f.name,
-        })),
+        choices: FONT_CHOICES,
         initial: 0,
       },
       {

--- a/packages/cli/src/utils/add-components.ts
+++ b/packages/cli/src/utils/add-components.ts
@@ -224,25 +224,35 @@ async function addWorkspaceComponents(
     )
   }
 
-  // 2. Update css vars.
-  if (tree.cssVars) {
+  // 2. Update css vars. This also runs without `tree.cssVars` so the font
+  // imports stay in sync with `components.json` on every install.
+  {
     const overwriteCssVars = await shouldOverwriteCssVars(components, config)
     const fontImports = resolveFontImports(mainTargetConfig)
     const cssVarsWithFontHeading = overlayFontHeadingVar(
       tree.cssVars,
       mainTargetConfig,
     )
-    await updateCssVars(cssVarsWithFontHeading, mainTargetConfig, {
-      silent: true,
-      tailwindVersion,
-      tailwindConfig: tree.tailwind?.config,
-      overwriteCssVars,
-      fontImports,
-      pruneFontImports: true,
-    })
-    filesUpdated.push(
-      path.relative(workspaceRoot, mainTargetConfig.resolvedPaths.tailwindCss),
+    const cssVarsUpdated = await updateCssVars(
+      cssVarsWithFontHeading,
+      mainTargetConfig,
+      {
+        silent: true,
+        tailwindVersion,
+        tailwindConfig: tree.tailwind?.config,
+        overwriteCssVars,
+        fontImports,
+        pruneFontImports: true,
+      },
     )
+    if (cssVarsUpdated) {
+      filesUpdated.push(
+        path.relative(
+          workspaceRoot,
+          mainTargetConfig.resolvedPaths.tailwindCss,
+        ),
+      )
+    }
   }
 
   // 3. Update CSS
@@ -395,9 +405,16 @@ async function addWorkspaceComponents(
 /**
  * Collects the Google Fonts `@import` strings that should be present in the
  * project's CSS file for the active config. Body font + (optional) heading
- * font, de-duplicated. Empty and disabled (`none`) fonts are skipped.
+ * font, de-duplicated. A disabled (`none`) or missing body font turns off font
+ * management for the project as a whole, heading font included — otherwise a
+ * `fontHeading` left over in `components.json` would keep the CLI writing
+ * imports after the project opted out.
  */
-function resolveFontImports(config: Config): string[] {
+export function resolveFontImports(config: Config): string[] {
+  if (isFontDisabled(config.font)) {
+    return []
+  }
+
   const imports: string[] = []
   const push = (name: string | undefined) => {
     if (isFontDisabled(name)) {
@@ -429,8 +446,13 @@ function resolveFontImports(config: Config): string[] {
  *
  * Returns `undefined` when there's no font configured at all, or when font
  * management is disabled (`none`) — the project owns its own font stack then.
+ * As with the imports, a disabled body font disables the heading too.
  */
-function resolveFontHeadingVar(config: Config): string | undefined {
+export function resolveFontHeadingVar(config: Config): string | undefined {
+  if (isFontDisabled(config.font)) {
+    return undefined
+  }
+
   const fontHeading = config.fontHeading
   // `inherit` / unset / same-as-body all alias to the body font's CSS var so
   // `font-heading` utility always resolves to something.
@@ -439,9 +461,6 @@ function resolveFontHeadingVar(config: Config): string | undefined {
     || fontHeading === 'inherit'
     || fontHeading === config.font
   ) {
-    if (isFontDisabled(config.font)) {
-      return undefined
-    }
     const bodyVar = getFontVariable(config.font!)
     return `var(${bodyVar})`
   }

--- a/packages/cli/src/utils/add-components.ts
+++ b/packages/cli/src/utils/add-components.ts
@@ -13,7 +13,12 @@ import { resolveRegistryTree } from '@/src/registry/resolver'
 import {
   registryItemSchema,
 } from '@/src/schema'
-import { getFont, getFontImport, getFontVariable } from '@/src/utils/fonts'
+import {
+  getFont,
+  getFontImport,
+  getFontVariable,
+  isFontDisabled,
+} from '@/src/utils/fonts'
 import {
   findCommonRoot,
   findPackageRoot,
@@ -121,6 +126,7 @@ async function addProjectComponents(
     overwriteCssVars,
     initIndex: options.baseStyle,
     fontImports,
+    pruneFontImports: true,
   })
 
   // Add CSS updater
@@ -232,6 +238,7 @@ async function addWorkspaceComponents(
       tailwindConfig: tree.tailwind?.config,
       overwriteCssVars,
       fontImports,
+      pruneFontImports: true,
     })
     filesUpdated.push(
       path.relative(workspaceRoot, mainTargetConfig.resolvedPaths.tailwindCss),
@@ -388,15 +395,15 @@ async function addWorkspaceComponents(
 /**
  * Collects the Google Fonts `@import` strings that should be present in the
  * project's CSS file for the active config. Body font + (optional) heading
- * font, de-duplicated. Empty fonts are skipped.
+ * font, de-duplicated. Empty and disabled (`none`) fonts are skipped.
  */
 function resolveFontImports(config: Config): string[] {
   const imports: string[] = []
   const push = (name: string | undefined) => {
-    if (!name) {
+    if (isFontDisabled(name)) {
       return
     }
-    const imp = getFontImport(name)
+    const imp = getFontImport(name!)
     if (imp && !imports.includes(imp)) {
       imports.push(imp)
     }
@@ -420,13 +427,10 @@ function resolveFontImports(config: Config): string[] {
  * redeployed this becomes redundant — the server's authoritative value will
  * overwrite it via `updateCssVarsPluginV4` with `overwriteCssVars: true`.
  *
- * Returns `undefined` when there's no font configured at all.
+ * Returns `undefined` when there's no font configured at all, or when font
+ * management is disabled (`none`) — the project owns its own font stack then.
  */
 function resolveFontHeadingVar(config: Config): string | undefined {
-  if (!config.font) {
-    return undefined
-  }
-
   const fontHeading = config.fontHeading
   // `inherit` / unset / same-as-body all alias to the body font's CSS var so
   // `font-heading` utility always resolves to something.
@@ -435,8 +439,15 @@ function resolveFontHeadingVar(config: Config): string | undefined {
     || fontHeading === 'inherit'
     || fontHeading === config.font
   ) {
-    const bodyVar = getFontVariable(config.font)
+    if (isFontDisabled(config.font)) {
+      return undefined
+    }
+    const bodyVar = getFontVariable(config.font!)
     return `var(${bodyVar})`
+  }
+
+  if (isFontDisabled(fontHeading)) {
+    return undefined
   }
 
   const headingFont = getFont(fontHeading)

--- a/packages/cli/src/utils/fonts.ts
+++ b/packages/cli/src/utils/fonts.ts
@@ -3,6 +3,22 @@ import { FONTS } from '@/src/registry/constants'
 export type FontConfig = (typeof FONTS)[number]
 
 /**
+ * Sentinel value for `font` / `fontHeading` in `components.json` that opts the
+ * project out of CLI-managed fonts: no Google Fonts `@import` is written to the
+ * CSS file and no `--font-heading` theme var is synthesized. For projects that
+ * handle fonts themselves (`@nuxt/fonts`, `unplugin-fonts`, self-hosted files).
+ */
+export const FONT_NONE = 'none'
+
+/**
+ * Whether font management is disabled for the given config value — either
+ * unset or explicitly set to `none`.
+ */
+export function isFontDisabled(name: string | undefined): boolean {
+  return !name || name === FONT_NONE
+}
+
+/**
  * Get font configuration by name.
  */
 export function getFont(name: string): FontConfig | undefined {
@@ -15,6 +31,38 @@ export function getFont(name: string): FontConfig | undefined {
 export function getFontImport(name: string): string {
   const font = getFont(name)
   return font?.import ?? ''
+}
+
+/**
+ * Extract the `family=` values of a Google Fonts URL, normalized back to the
+ * family name (`Noto+Sans:wght@400` -> `Noto Sans`). One URL can request
+ * several families.
+ */
+function getFontImportFamilies(value: string): string[] {
+  const families: string[] = []
+  const regex = /[?&]family=([^&:'")]+)/g
+  let match = regex.exec(value)
+  while (match) {
+    families.push(decodeURIComponent(match[1]!.replace(/\+/g, ' ')))
+    match = regex.exec(value)
+  }
+  return families
+}
+
+/**
+ * Whether a Google Fonts `@import` (or its raw URL) refers only to fonts the
+ * CLI itself knows how to write. Used to tell an import the CLI added on a
+ * previous run — safe to replace when the font config changes — apart from one
+ * the user hand-wrote, which must be left alone.
+ */
+export function isManagedFontImport(value: string): boolean {
+  const families = getFontImportFamilies(value)
+  if (families.length === 0) {
+    return false
+  }
+  return families.every(family =>
+    FONTS.some(font => font.family === family),
+  )
 }
 
 /**

--- a/packages/cli/src/utils/fonts.ts
+++ b/packages/cli/src/utils/fonts.ts
@@ -34,35 +34,29 @@ export function getFontImport(name: string): string {
 }
 
 /**
- * Extract the `family=` values of a Google Fonts URL, normalized back to the
- * family name (`Noto+Sans:wght@400` -> `Noto Sans`). One URL can request
- * several families.
+ * Extract the raw URL out of an `@import url('...')` statement.
  */
-function getFontImportFamilies(value: string): string[] {
-  const families: string[] = []
-  const regex = /[?&]family=([^&:'")]+)/g
-  let match = regex.exec(value)
-  while (match) {
-    families.push(decodeURIComponent(match[1]!.replace(/\+/g, ' ')))
-    match = regex.exec(value)
-  }
-  return families
+export function getFontImportUrl(value: string): string | undefined {
+  return value.match(/url\(['"]?([^'"()]+)['"]?\)/)?.[1]
 }
 
+// Every URL the CLI is able to write, i.e. the exact `@import` targets of the
+// font registry. An import in a project's CSS file that isn't one of these was
+// written by someone else.
+const MANAGED_FONT_IMPORT_URLS = FONTS.map(font =>
+  getFontImportUrl(font.import),
+).filter((url): url is string => !!url)
+
 /**
- * Whether a Google Fonts `@import` (or its raw URL) refers only to fonts the
- * CLI itself knows how to write. Used to tell an import the CLI added on a
- * previous run — safe to replace when the font config changes — apart from one
- * the user hand-wrote, which must be left alone.
+ * Whether a Google Fonts `@import` (or its raw URL) is one the CLI writes
+ * verbatim. Used to tell an import the CLI added on a previous run — safe to
+ * replace when the font config changes — apart from one the user wrote, which
+ * must be left alone even when it requests the same family. Anything the user
+ * tweaked (different weights, axes, subsets, ...) no longer matches.
  */
 export function isManagedFontImport(value: string): boolean {
-  const families = getFontImportFamilies(value)
-  if (families.length === 0) {
-    return false
-  }
-  return families.every(family =>
-    FONTS.some(font => font.family === family),
-  )
+  const url = getFontImportUrl(value) ?? value
+  return MANAGED_FONT_IMPORT_URLS.includes(url)
 }
 
 /**

--- a/packages/cli/src/utils/updaters/update-css-vars.ts
+++ b/packages/cli/src/utils/updaters/update-css-vars.ts
@@ -11,6 +11,7 @@ import path from 'pathe'
 import postcss from 'postcss'
 import AtRule from 'postcss/lib/at-rule'
 import { z } from 'zod'
+import { isManagedFontImport } from '@/src/utils/fonts'
 import { getPackageInfo } from '@/src/utils/get-package-info'
 import { highlighter } from '@/src/utils/highlighter'
 import { spinner } from '@/src/utils/spinner'
@@ -26,6 +27,7 @@ export async function updateCssVars(
     tailwindVersion?: TailwindVersion
     tailwindConfig?: z.infer<typeof registryItemTailwindSchema>['config']
     fontImports?: string[]
+    pruneFontImports?: boolean
   },
 ) {
   if (!config.resolvedPaths.tailwindCss || !Object.keys(cssVars ?? {}).length) {
@@ -59,6 +61,7 @@ export async function updateCssVars(
     overwriteCssVars: options.overwriteCssVars,
     initIndex: options.initIndex,
     fontImports: options.fontImports,
+    pruneFontImports: options.pruneFontImports,
   })
   await fs.writeFile(cssFilepath, output, 'utf8')
   cssVarsSpinner.succeed()
@@ -75,6 +78,7 @@ export async function transformCssVars(
     overwriteCssVars?: boolean
     initIndex?: boolean
     fontImports?: string[]
+    pruneFontImports?: boolean
   } = {
     cleanupDefaultNextStyles: false,
     tailwindVersion: 'v3',
@@ -94,10 +98,14 @@ export async function transformCssVars(
 
   let plugins = [updateCssVarsPlugin(cssVars)]
 
-  // Add font imports if provided
+  // Sync font imports. With no fonts configured the plugin still runs when
+  // pruning is on, so switching a project to `font: "none"` cleans up the
+  // imports the CLI wrote on previous runs.
   const fontImports = options.fontImports ?? []
-  if (fontImports.length > 0) {
-    plugins.unshift(addFontImportPlugin({ fontImports }))
+  const pruneFontImports = options.pruneFontImports ?? false
+  const syncFontImports = fontImports.length > 0 || pruneFontImports
+  if (syncFontImports) {
+    plugins.unshift(addFontImportPlugin({ fontImports, pruneFontImports }))
   }
 
   if (options.cleanupDefaultNextStyles) {
@@ -108,8 +116,8 @@ export async function transformCssVars(
     plugins = []
 
     // Add font imports at the very beginning if provided
-    if (fontImports.length > 0) {
-      plugins.push(addFontImportPlugin({ fontImports }))
+    if (syncFontImports) {
+      plugins.push(addFontImportPlugin({ fontImports, pruneFontImports }))
     }
 
     // Only add tw-animate-css if project does not have tailwindcss-animate
@@ -723,32 +731,37 @@ function addCustomImport({ params }: { params: string }) {
 /**
  * Sync Google Fonts `@import` statements at the top of the CSS file with the
  * active font set (body + heading). The full set of target URLs is passed in
- * each call — any existing `fonts.googleapis.com` imports not in the set are
- * removed, any missing ones are added. This is replace-all semantics so that
- * swapping to a new preset actually reflects the new fonts instead of
- * accumulating dead imports from previous runs.
+ * each call — existing `fonts.googleapis.com` imports the CLI manages but that
+ * aren't in the set are removed, any missing ones are added. This is
+ * replace-all semantics so that swapping to a new preset actually reflects the
+ * new fonts instead of accumulating dead imports from previous runs.
+ *
+ * "Manages" means the import only requests families the CLI itself can write
+ * (see `isManagedFontImport`). Imports for any other family were hand-written
+ * by the user and are left untouched.
+ *
+ * With `pruneFontImports` the plugin also runs for an empty target set, which
+ * is how `font: "none"` clears out imports written by earlier runs.
  */
 export function addFontImportPlugin({
   fontImports,
+  pruneFontImports = false,
 }: {
   fontImports: string[]
+  pruneFontImports?: boolean
 }) {
   return {
     postcssPlugin: 'add-font-import',
     Once(root: Root) {
-      if (!fontImports || fontImports.length === 0) {
-        return
-      }
-
       // Dedup + extract raw URLs from the `@import url('...')` strings.
       const targetUrls: string[] = []
-      for (const fontImport of fontImports) {
+      for (const fontImport of fontImports ?? []) {
         const match = fontImport.match(/url\(['"]?([^'"]+)['"]?\)/)
         if (match && !targetUrls.includes(match[1]!)) {
           targetUrls.push(match[1]!)
         }
       }
-      if (targetUrls.length === 0) {
+      if (targetUrls.length === 0 && !pruneFontImports) {
         return
       }
 
@@ -759,15 +772,17 @@ export function addFontImportPlugin({
           && node.params.includes('fonts.googleapis.com'),
       )
 
-      // Drop any existing Google Fonts imports that aren't in the target
-      // set — those are left over from a previous preset.
+      // Drop existing Google Fonts imports that aren't in the target set, but
+      // only the ones the CLI could have written itself — those are left over
+      // from a previous font config. Anything else is the user's own import.
       const keptByUrl = new Map<string, AtRule>()
       for (const node of existingGoogleFontsImports) {
         const url = targetUrls.find(u => node.params.includes(u))
         if (url && !keptByUrl.has(url)) {
           keptByUrl.set(url, node)
+          continue
         }
-        else {
+        if (url || isManagedFontImport(node.params)) {
           node.remove()
         }
       }

--- a/packages/cli/src/utils/updaters/update-css-vars.ts
+++ b/packages/cli/src/utils/updaters/update-css-vars.ts
@@ -29,9 +29,21 @@ export async function updateCssVars(
     fontImports?: string[]
     pruneFontImports?: boolean
   },
-) {
-  if (!config.resolvedPaths.tailwindCss || !Object.keys(cssVars ?? {}).length) {
-    return
+): Promise<boolean> {
+  if (!config.resolvedPaths.tailwindCss) {
+    return false
+  }
+
+  const hasCssVars = !!Object.keys(cssVars ?? {}).length
+  const fontImports = options.fontImports ?? []
+  const pruneFontImports = options.pruneFontImports ?? false
+  // Font imports are synced from `components.json`, not from the registry
+  // item, so they still need a pass over the CSS file when the item being
+  // added carries no CSS variables of its own.
+  const hasFontImports = fontImports.length > 0 || pruneFontImports
+
+  if (!hasCssVars && !hasFontImports) {
+    return false
   }
 
   options = {
@@ -54,17 +66,47 @@ export async function updateCssVars(
     },
   ).start()
   const raw = await fs.readFile(cssFilepath, 'utf8')
-  const output = await transformCssVars(raw, cssVars ?? {}, config, {
-    cleanupDefaultNextStyles: options.cleanupDefaultNextStyles,
-    tailwindVersion: options.tailwindVersion,
-    tailwindConfig: options.tailwindConfig,
-    overwriteCssVars: options.overwriteCssVars,
-    initIndex: options.initIndex,
-    fontImports: options.fontImports,
-    pruneFontImports: options.pruneFontImports,
-  })
+  // Without CSS variables to write, only touch the font imports — running the
+  // full pipeline would let the other plugins edit a file we were never asked
+  // to change.
+  const output = hasCssVars
+    ? await transformCssVars(raw, cssVars ?? {}, config, {
+        cleanupDefaultNextStyles: options.cleanupDefaultNextStyles,
+        tailwindVersion: options.tailwindVersion,
+        tailwindConfig: options.tailwindConfig,
+        overwriteCssVars: options.overwriteCssVars,
+        initIndex: options.initIndex,
+        fontImports: options.fontImports,
+        pruneFontImports: options.pruneFontImports,
+      })
+    : await transformFontImports(raw, { fontImports, pruneFontImports })
+
+  if (output === raw) {
+    cssVarsSpinner.succeed()
+    return false
+  }
+
   await fs.writeFile(cssFilepath, output, 'utf8')
   cssVarsSpinner.succeed()
+  return true
+}
+
+/**
+ * Sync only the Google Fonts `@import` statements of a CSS file, leaving the
+ * rest of it untouched.
+ */
+export async function transformFontImports(
+  input: string,
+  options: { fontImports?: string[], pruneFontImports?: boolean } = {},
+) {
+  const result = await postcss([
+    addFontImportPlugin({
+      fontImports: options.fontImports ?? [],
+      pruneFontImports: options.pruneFontImports ?? false,
+    }),
+  ]).process(input, { from: undefined })
+
+  return result.css.replace(/\/\* ---break--- \*\//g, '')
 }
 
 export async function transformCssVars(

--- a/packages/cli/test/utils/fonts.test.ts
+++ b/packages/cli/test/utils/fonts.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
+import { FONTS } from '../../src/registry/constants'
 import { isFontDisabled, isManagedFontImport } from '../../src/utils/fonts'
 
 describe('isFontDisabled', () => {
@@ -16,28 +17,26 @@ describe('isFontDisabled', () => {
 })
 
 describe('isManagedFontImport', () => {
-  it('should match imports for fonts the cli knows', () => {
+  it('should match the imports the cli writes', () => {
+    for (const font of FONTS) {
+      expect(isManagedFontImport(font.import)).toBe(true)
+    }
+  })
+
+  it('should match a bare url', () => {
     expect(
       isManagedFontImport(
-        '@import url(\'https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap\');',
+        'url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap")',
       ),
     ).toBe(true)
   })
 
-  it('should match regardless of the requested weights', () => {
+  it('should not match a user import of the same family', () => {
     expect(
       isManagedFontImport(
-        'url("https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap")',
+        'url(\'https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900&display=swap\')',
       ),
-    ).toBe(true)
-  })
-
-  it('should match multi-word families', () => {
-    expect(
-      isManagedFontImport(
-        'url(\'https://fonts.googleapis.com/css2?family=Noto+Sans:wght@400&display=swap\')',
-      ),
-    ).toBe(true)
+    ).toBe(false)
   })
 
   it('should not match a font outside the cli registry', () => {
@@ -48,15 +47,15 @@ describe('isManagedFontImport', () => {
     ).toBe(false)
   })
 
-  it('should not match when a single import mixes known and unknown families', () => {
+  it('should not match an import for several families', () => {
     expect(
       isManagedFontImport(
-        'url(\'https://fonts.googleapis.com/css2?family=Inter:wght@400&family=Fira+Code:wght@400&display=swap\')',
+        'url(\'https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Fira+Code:wght@400&display=swap\')',
       ),
     ).toBe(false)
   })
 
-  it('should not match an import without a family', () => {
+  it('should not match a stylesheet from elsewhere', () => {
     expect(isManagedFontImport('url(\'https://example.com/styles.css\')')).toBe(
       false,
     )

--- a/packages/cli/test/utils/fonts.test.ts
+++ b/packages/cli/test/utils/fonts.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+
+import { isFontDisabled, isManagedFontImport } from '../../src/utils/fonts'
+
+describe('isFontDisabled', () => {
+  it('should be disabled when unset or none', () => {
+    expect(isFontDisabled(undefined)).toBe(true)
+    expect(isFontDisabled('')).toBe(true)
+    expect(isFontDisabled('none')).toBe(true)
+  })
+
+  it('should not be disabled for a font name', () => {
+    expect(isFontDisabled('inter')).toBe(false)
+    expect(isFontDisabled('geist-sans')).toBe(false)
+  })
+})
+
+describe('isManagedFontImport', () => {
+  it('should match imports for fonts the cli knows', () => {
+    expect(
+      isManagedFontImport(
+        '@import url(\'https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap\');',
+      ),
+    ).toBe(true)
+  })
+
+  it('should match regardless of the requested weights', () => {
+    expect(
+      isManagedFontImport(
+        'url("https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap")',
+      ),
+    ).toBe(true)
+  })
+
+  it('should match multi-word families', () => {
+    expect(
+      isManagedFontImport(
+        'url(\'https://fonts.googleapis.com/css2?family=Noto+Sans:wght@400&display=swap\')',
+      ),
+    ).toBe(true)
+  })
+
+  it('should not match a font outside the cli registry', () => {
+    expect(
+      isManagedFontImport(
+        'url(\'https://fonts.googleapis.com/css2?family=Fira+Code:wght@400&display=swap\')',
+      ),
+    ).toBe(false)
+  })
+
+  it('should not match when a single import mixes known and unknown families', () => {
+    expect(
+      isManagedFontImport(
+        'url(\'https://fonts.googleapis.com/css2?family=Inter:wght@400&family=Fira+Code:wght@400&display=swap\')',
+      ),
+    ).toBe(false)
+  })
+
+  it('should not match an import without a family', () => {
+    expect(isManagedFontImport('url(\'https://example.com/styles.css\')')).toBe(
+      false,
+    )
+  })
+})

--- a/packages/cli/test/utils/resolve-fonts.test.ts
+++ b/packages/cli/test/utils/resolve-fonts.test.ts
@@ -1,0 +1,57 @@
+import type { Config } from '../../src/utils/get-config'
+import { describe, expect, it } from 'vitest'
+
+import {
+  resolveFontHeadingVar,
+  resolveFontImports,
+} from '../../src/utils/add-components'
+
+function config(font?: string, fontHeading?: string) {
+  return { font, fontHeading } as Config
+}
+
+describe('resolveFontImports', () => {
+  it('should import the configured font', () => {
+    expect(resolveFontImports(config('inter'))).toEqual([
+      expect.stringContaining('family=Inter'),
+    ])
+  })
+
+  it('should import the heading font alongside the body font', () => {
+    const imports = resolveFontImports(config('inter', 'playfair-display'))
+
+    expect(imports).toHaveLength(2)
+    expect(imports[1]).toContain('family=Playfair+Display')
+  })
+
+  it('should import nothing when fonts are disabled', () => {
+    expect(resolveFontImports(config('none'))).toEqual([])
+    expect(resolveFontImports(config(undefined))).toEqual([])
+  })
+
+  it('should import nothing when a heading font outlives a disabled body font', () => {
+    expect(resolveFontImports(config('none', 'geist-sans'))).toEqual([])
+  })
+})
+
+describe('resolveFontHeadingVar', () => {
+  it('should alias the body font when no heading font is set', () => {
+    expect(resolveFontHeadingVar(config('inter'))).toBe('var(--font-sans)')
+    expect(resolveFontHeadingVar(config('inter', 'inherit'))).toBe(
+      'var(--font-sans)',
+    )
+  })
+
+  it('should use the heading font when set', () => {
+    expect(resolveFontHeadingVar(config('inter', 'playfair-display'))).toBe(
+      '\'Playfair Display Variable\', sans-serif',
+    )
+  })
+
+  it('should be undefined when fonts are disabled', () => {
+    expect(resolveFontHeadingVar(config('none'))).toBeUndefined()
+    expect(resolveFontHeadingVar(config(undefined))).toBeUndefined()
+    expect(resolveFontHeadingVar(config('none', 'geist-sans'))).toBeUndefined()
+    expect(resolveFontHeadingVar(config('inter', 'none'))).toBeUndefined()
+  })
+})

--- a/packages/cli/test/utils/updaters/update-css-vars-fonts.test.ts
+++ b/packages/cli/test/utils/updaters/update-css-vars-fonts.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest'
+
+import { transformCssVars } from '../../../src/utils/updaters/update-css-vars'
+
+const INTER_IMPORT
+  = '@import url(\'https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap\');'
+const GEIST_IMPORT
+  = '@import url(\'https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&display=swap\');'
+// Not part of the CLI font registry i.e. only a user could have written it.
+const FIRA_CODE_IMPORT
+  = '@import url(\'https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500&display=swap\');'
+
+const CSS_VARS = {
+  light: { background: '0 0% 100%' },
+  dark: { background: '240 10% 3.9%' },
+}
+
+const CONFIG = { tailwind: { cssVariables: true } }
+
+async function transform(
+  input: string,
+  options: { fontImports?: string[], pruneFontImports?: boolean },
+) {
+  return transformCssVars(input, CSS_VARS, CONFIG as any, {
+    tailwindVersion: 'v4',
+    ...options,
+  })
+}
+
+describe('transformCssVars: font imports', () => {
+  it('should add the configured font import', async () => {
+    const output = await transform('@import "tailwindcss";\n', {
+      fontImports: [INTER_IMPORT],
+    })
+
+    expect(output).toContain('family=Inter')
+  })
+
+  it('should replace a stale font import when the font changes', async () => {
+    const output = await transform(
+      `${INTER_IMPORT}\n@import "tailwindcss";\n`,
+      { fontImports: [GEIST_IMPORT] },
+    )
+
+    expect(output).toContain('family=Geist')
+    expect(output).not.toContain('family=Inter')
+  })
+
+  it('should keep font imports the cli does not manage', async () => {
+    const output = await transform(
+      `${FIRA_CODE_IMPORT}\n${INTER_IMPORT}\n@import "tailwindcss";\n`,
+      { fontImports: [GEIST_IMPORT] },
+    )
+
+    expect(output).toContain('family=Fira+Code')
+    expect(output).toContain('family=Geist')
+    expect(output).not.toContain('family=Inter')
+  })
+
+  it('should remove managed font imports when fonts are disabled', async () => {
+    const output = await transform(
+      `${INTER_IMPORT}\n@import "tailwindcss";\n`,
+      { fontImports: [], pruneFontImports: true },
+    )
+
+    expect(output).not.toContain('fonts.googleapis.com')
+  })
+
+  it('should not touch user font imports when fonts are disabled', async () => {
+    const output = await transform(
+      `${FIRA_CODE_IMPORT}\n@import "tailwindcss";\n`,
+      { fontImports: [], pruneFontImports: true },
+    )
+
+    expect(output).toContain('family=Fira+Code')
+  })
+
+  it('should not add or remove font imports when not managing fonts', async () => {
+    const output = await transform(
+      `${INTER_IMPORT}\n@import "tailwindcss";\n`,
+      {},
+    )
+
+    expect(output).toContain('family=Inter')
+  })
+})

--- a/packages/cli/test/utils/updaters/update-css-vars-fonts.test.ts
+++ b/packages/cli/test/utils/updaters/update-css-vars-fonts.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest'
 
-import { transformCssVars } from '../../../src/utils/updaters/update-css-vars'
+import {
+  transformCssVars,
+  transformFontImports,
+} from '../../../src/utils/updaters/update-css-vars'
 
 const INTER_IMPORT
   = '@import url(\'https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap\');'
@@ -9,6 +12,9 @@ const GEIST_IMPORT
 // Not part of the CLI font registry i.e. only a user could have written it.
 const FIRA_CODE_IMPORT
   = '@import url(\'https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500&display=swap\');'
+// Same family as one the CLI ships, but with the user's own axes.
+const USER_INTER_IMPORT
+  = '@import url(\'https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900&display=swap\');'
 
 const CSS_VARS = {
   light: { background: '0 0% 100%' },
@@ -75,6 +81,15 @@ describe('transformCssVars: font imports', () => {
     expect(output).toContain('family=Fira+Code')
   })
 
+  it('should keep a user import of a font family the cli also ships', async () => {
+    const output = await transform(
+      `${USER_INTER_IMPORT}\n@import "tailwindcss";\n`,
+      { fontImports: [], pruneFontImports: true },
+    )
+
+    expect(output).toContain('opsz,wght@0,14..32,100..900')
+  })
+
   it('should not add or remove font imports when not managing fonts', async () => {
     const output = await transform(
       `${INTER_IMPORT}\n@import "tailwindcss";\n`,
@@ -82,5 +97,43 @@ describe('transformCssVars: font imports', () => {
     )
 
     expect(output).toContain('family=Inter')
+  })
+})
+
+describe('transformFontImports', () => {
+  it('should sync font imports without touching the rest of the file', async () => {
+    const input = `${INTER_IMPORT}
+@import "tailwindcss";
+
+:root {
+  --radius: 0.625rem;
+}
+`
+
+    const output = await transformFontImports(input, {
+      fontImports: [GEIST_IMPORT],
+      pruneFontImports: true,
+    })
+
+    expect(output).toContain('family=Geist')
+    expect(output).not.toContain('family=Inter')
+    expect(output).toContain('@import "tailwindcss";')
+    expect(output).toContain('--radius: 0.625rem;')
+  })
+
+  it('should leave a file with nothing to sync untouched', async () => {
+    const input = `@import "tailwindcss";
+
+:root {
+  --radius: 0.625rem;
+}
+`
+
+    expect(
+      await transformFontImports(input, {
+        fontImports: [],
+        pruneFontImports: true,
+      }),
+    ).toBe(input)
   })
 })


### PR DESCRIPTION
Closes #1937

## Problem

The CLI re-derives Google Fonts `@import` statements from `components.json#font` on **every** `add` run and writes them into the project's CSS file (`resolveFontImports` → `addFontImportPlugin`). Since `init` always writes a font (default `inter`), projects that load fonts themselves — `@nuxt/fonts`, `unplugin-fonts`, self-hosted files — had no way to turn this off short of hand-deleting the `font` key from `components.json`.

There was a second, quieter problem: the import sync used replace-all semantics over *any* `fonts.googleapis.com` import in the file, so a user's own hand-written font import was deleted on the next `add`.

## Changes

**`font: "none"` opts out of CLI-managed fonts.**
- Accepted by `init --font none`, and offered as a "None" choice in both init prompts.
- No `@import` is written, and no `--font-heading` theme var is synthesized. A disabled body font disables the heading font too, so a `fontHeading` left over in `components.json` can't keep the CLI writing imports after the project opted out — and `init --font none` drops `fontHeading` from the config it writes.
- Switching an existing project to `none` also *removes* the imports the CLI added on previous runs (new `pruneFontImports` option, set by the two `add-components` call sites). This runs even when the installed item carries no `cssVars` of its own — that pass touches only the `@import` statements, and the CSS file is left alone entirely when nothing changes.

**Import sync no longer touches imports the CLI doesn't own.**
- An existing Google Fonts import is only replaced when its URL is one the CLI writes verbatim (`isManagedFontImport` against the `FONTS` registry's own import URLs). Stale imports from a previous font/preset are still cleaned up as before; an import the user wrote — including one for a family the CLI also ships, with their own weights or axes — is left alone.

**Docs**: new `font` section in the `components.json` docs covering `none`, updated `--font` flag help, and a description on the published `schema.json`.

## Tests

- `test/utils/updaters/update-css-vars-fonts.test.ts` — add / replace / keep-user-imports / prune-on-disable, plus the font-only pass.
- `test/utils/resolve-fonts.test.ts` — import and `--font-heading` resolution across the `none` combinations.
- `test/utils/fonts.test.ts` — `isFontDisabled` and `isManagedFontImport`.

The new behaviors fail on `dev` and pass here. Full CLI suite passes (`pnpm test`, 554 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - CLI initialization now supports `--font none` for projects managing fonts independently.
  - Interactive setup includes a “None” font option.
  - CLI-managed Google Font imports are synchronized, updated, or removed as configuration changes.
  - User-managed font imports are preserved.
  - Font-related settings are cleaned up when management is disabled.

- **Documentation**
  - Documented font configuration, external font management, cleanup behavior, and the `none` option in CLI and schema references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->