### PR TITLE
fix(cli): derive the full radius scale from --radius

### DIFF
--- a/apps/v4/content/docs/installation/05.manual.md
+++ b/apps/v4/content/docs/installation/05.manual.md
@@ -144,10 +144,13 @@ Add the following to your styles/globals.css file. You can learn more about usin
   --color-chart-3: var(--chart-3);
   --color-chart-4: var(--chart-4);
   --color-chart-5: var(--chart-5);
-  --radius-sm: calc(var(--radius) - 4px);
-  --radius-md: calc(var(--radius) - 2px);
+  --radius-sm: calc(var(--radius) * 0.6);
+  --radius-md: calc(var(--radius) * 0.8);
   --radius-lg: var(--radius);
-  --radius-xl: calc(var(--radius) + 4px);
+  --radius-xl: calc(var(--radius) * 1.4);
+  --radius-2xl: calc(var(--radius) * 1.8);
+  --radius-3xl: calc(var(--radius) * 2.2);
+  --radius-4xl: calc(var(--radius) * 2.6);
   --color-sidebar: var(--sidebar);
   --color-sidebar-foreground: var(--sidebar-foreground);
   --color-sidebar-primary: var(--sidebar-primary);

--- a/packages/cli/src/utils/updaters/update-css-vars.ts
+++ b/packages/cli/src/utils/updaters/update-css-vars.ts
@@ -547,11 +547,16 @@ function updateThemePlugin(cssVars: z.infer<typeof registryItemCssVarsSchema>) {
         }
 
         if (variable === 'radius') {
+          // Derived multiplicatively so `--radius: 0` collapses the whole
+          // scale to square and every other value scales proportionally.
           const radiusVariables = {
-            sm: 'calc(var(--radius) - 4px)',
-            md: 'calc(var(--radius) - 2px)',
-            lg: 'var(--radius)',
-            xl: 'calc(var(--radius) + 4px)',
+            'sm': 'calc(var(--radius) * 0.6)',
+            'md': 'calc(var(--radius) * 0.8)',
+            'lg': 'var(--radius)',
+            'xl': 'calc(var(--radius) * 1.4)',
+            '2xl': 'calc(var(--radius) * 1.8)',
+            '3xl': 'calc(var(--radius) * 2.2)',
+            '4xl': 'calc(var(--radius) * 2.6)',
           }
           for (const [key, value] of Object.entries(radiusVariables)) {
             const cssVarNode = postcss.decl({

--- a/packages/cli/test/utils/updaters/update-css-vars.test.ts
+++ b/packages/cli/test/utils/updaters/update-css-vars.test.ts
@@ -683,10 +683,13 @@ describe('transformCssVarsV4', () => {
       }
 
       @theme inline {
-        --radius-sm: calc(var(--radius) - 4px);
-        --radius-md: calc(var(--radius) - 2px);
+        --radius-sm: calc(var(--radius) * 0.6);
+        --radius-md: calc(var(--radius) * 0.8);
         --radius-lg: var(--radius);
-        --radius-xl: calc(var(--radius) + 4px);
+        --radius-xl: calc(var(--radius) * 1.4);
+        --radius-2xl: calc(var(--radius) * 1.8);
+        --radius-3xl: calc(var(--radius) * 2.2);
+        --radius-4xl: calc(var(--radius) * 2.6);
       }
 
       @layer base {
@@ -710,10 +713,13 @@ describe('transformCssVarsV4', () => {
         --radius: 0.125rem;
       }
       @theme inline {
-        --radius-sm: calc(var(--radius) - 4px);
-        --radius-md: calc(var(--radius) - 2px);
+        --radius-sm: calc(var(--radius) * 0.6);
+        --radius-md: calc(var(--radius) * 0.8);
         --radius-lg: var(--radius);
-        --radius-xl: calc(var(--radius) + 4px);
+        --radius-xl: calc(var(--radius) * 1.4);
+        --radius-2xl: calc(var(--radius) * 1.8);
+        --radius-3xl: calc(var(--radius) * 2.2);
+        --radius-4xl: calc(var(--radius) * 2.6);
       }
         `,
         {
@@ -731,10 +737,67 @@ describe('transformCssVarsV4', () => {
               --radius: 0.125rem;
             }
             @theme inline {
+              --radius-sm: calc(var(--radius) * 0.6);
+              --radius-md: calc(var(--radius) * 0.8);
+              --radius-lg: var(--radius);
+              --radius-xl: calc(var(--radius) * 1.4);
+              --radius-2xl: calc(var(--radius) * 1.8);
+              --radius-3xl: calc(var(--radius) * 2.2);
+              --radius-4xl: calc(var(--radius) * 2.6);
+            }
+
+      @layer base {
+        * {
+          @apply border-border outline-ring/50;
+              }
+        body {
+          @apply bg-background text-foreground;
+              }
+      }
+              "
+    `)
+  })
+
+  // Styles use rounded-2xl/3xl/4xl heavily. A project scaffolded before the
+  // extended scale existed only has sm–xl, so those steps must be appended
+  // instead of falling back to Tailwind's hardcoded defaults.
+  it('should add the extended --radius-* steps to a legacy theme', async () => {
+    expect(
+      await transformCssVars(
+        `@import "tailwindcss";
+      @custom-variant dark (&:is(.dark *));
+      :root {
+        --radius: 0;
+      }
+      @theme inline {
+        --radius-sm: calc(var(--radius) - 4px);
+        --radius-md: calc(var(--radius) - 2px);
+        --radius-lg: var(--radius);
+        --radius-xl: calc(var(--radius) + 4px);
+      }
+        `,
+        {
+          light: {
+            radius: '0',
+          },
+        },
+        { tailwind: { cssVariables: true } },
+        { tailwindVersion: 'v4' },
+      ),
+    ).toMatchInlineSnapshot(`
+      "@import "tailwindcss";
+            @custom-variant dark (&:is(.dark *));
+            :root {
+              --radius: 0;
+            }
+            @theme inline {
               --radius-sm: calc(var(--radius) - 4px);
               --radius-md: calc(var(--radius) - 2px);
               --radius-lg: var(--radius);
               --radius-xl: calc(var(--radius) + 4px);
+              --radius-2xl: calc(var(--radius) * 1.8);
+              --radius-3xl: calc(var(--radius) * 2.2);
+              --radius-4xl: calc(var(--radius) * 2.6);
             }
 
       @layer base {


### PR DESCRIPTION
Fixes #1936

### Problem

The theme written by `init`/`apply` only derives `--radius-sm` through `--radius-xl`, using px offsets:

```css
--radius-sm: calc(var(--radius) - 4px);
--radius-md: calc(var(--radius) - 2px);
--radius-lg: var(--radius);
--radius-xl: calc(var(--radius) + 4px);
```

But the shipped styles lean heavily on the extended steps — across the registry there are 108 `rounded-2xl`, 38 `rounded-3xl` and 38 `rounded-4xl` usages. Since the generated theme never defines those tokens, they fall back to Tailwind v4's hardcoded defaults (`1rem` / `1.5rem` / `2rem`) and ignore `--radius` entirely.

The visible symptom from the issue: a preset built with **Radius: None** still renders rounded cards, dialogs and popovers. It inverts for pill-shaped styles like `maia` — a small radius still yields pill buttons, because `rounded-4xl` is pinned to `2rem`.

The scale the styles are actually authored against already exists in this repo — [`apps/v4/assets/css/main.css`](https://github.com/unovue/shadcn-vue/blob/dev/apps/v4/assets/css/main.css#L53-L59), documented in `04.theming.md`. The CLI just never caught up to it.

### Fix

Emit that same 7-token multiplicative scale:

```css
--radius-sm: calc(var(--radius) * 0.6);
--radius-md: calc(var(--radius) * 0.8);
--radius-lg: var(--radius);
--radius-xl: calc(var(--radius) * 1.4);
--radius-2xl: calc(var(--radius) * 1.8);
--radius-3xl: calc(var(--radius) * 2.2);
--radius-4xl: calc(var(--radius) * 2.6);
```

I used the ratios already documented in `04.theming.md` rather than the ones suggested in the issue, so the CLI output and the docs site render identically.

**This is not a visual change for existing default-radius projects.** At `--radius: 0.625rem` the multiplicative sm/md/xl values are byte-identical to the old px-offset output (6px / 8px / 14px). It only changes behaviour away from the default, which is the bug.

Also updated the manual-installation snippet in `05.manual.md`, which still taught the old 4-token block and reproduced the bug for anyone following it.

### Upgrade path

Projects scaffolded with the old block keep their existing `sm`–`xl` declarations — the updater never overwrites — and get `2xl`/`3xl`/`4xl` appended. At `--radius: 0` the legacy `calc(0 - 4px)` is an invalid border-radius that browsers fall back to `0`, so the reported symptom is fixed either way. There's a new test covering this path.

### Note on `rounded-xs`

The issue also asks for `--radius-xs`. I left it out deliberately: the docs site doesn't define it either, and the 32 `rounded-xs` usages are all small decorative bits (tooltip arrows, chart legend swatches) that render at Tailwind's 2px on the site itself. Adding it CLI-side would make user projects diverge from the reference rendering. Happy to add it to both the CLI and `main.css` if you'd prefer the full collapse-to-square.

### Testing

Full CLI suite passes (531 tests). Two existing radius snapshots updated, one new regression test for the legacy-theme upgrade path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added extended border-radius sizes: `2xl`, `3xl`, and `4xl`.
  * Radius values now scale proportionally from the base radius for more consistent styling across themes.

* **Bug Fixes**
  * Improved radius variable updates for existing themes, including themes with a zero-radius base value.

* **Documentation**
  * Updated installation guidance to reflect the new radius scale.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->