### PR TITLE
fix(docs): restore component playground links

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -20,7 +20,9 @@ body:
       description: |
         A [minimal reproduction](https://stackoverflow.com/help/minimal-reproducible-example) is **required**, otherwise the issue might be closed without further notice. [**Why?**](https://antfu.me/posts/why-reproductions-are-required)
 
-        You can build a reproduction using these template presets
+        For component-specific bugs, use the **Open in StackBlitz** action on the relevant [component documentation](https://shadcn-vue.com/docs/components) page.
+
+        You can also build a reproduction using these template presets:
         https://vite.new
         https://nuxt.new
       placeholder: Reproduction

--- a/apps/v4/components/ComponentPreviewTabs.vue
+++ b/apps/v4/components/ComponentPreviewTabs.vue
@@ -9,6 +9,7 @@ const props = withDefaults(defineProps<{
   previewClass?: HTMLAttributes['class']
   hideCode?: boolean
   chromeLessOnMobile?: boolean
+  playgroundUrl?: string
   align?: 'center' | 'start' | 'end'
 }>(), {
   align: 'center',
@@ -39,6 +40,23 @@ const isMobileCodeVisible = ref(false)
             props.previewClass,
           )"
         >
+          <Button
+            v-if="playgroundUrl"
+            as-child
+            size="sm"
+            variant="outline"
+            class="absolute top-3 right-3 z-10 gap-1.5 bg-background/95 shadow-sm backdrop-blur"
+          >
+            <a
+              :href="playgroundUrl"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <UiIcon name="lucide:external-link" class="size-4" />
+              <span class="hidden sm:inline">Open in StackBlitz</span>
+              <span class="sr-only sm:hidden">Open in StackBlitz</span>
+            </a>
+          </Button>
           <component :is="component" />
         </div>
       </div>

--- a/apps/v4/components/content/ComponentPreview.vue
+++ b/apps/v4/components/content/ComponentPreview.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { HTMLAttributes } from 'vue'
+import { getComponentPlaygroundUrl } from '~/lib/component-playground'
 
 const props = defineProps<{
   name: string
@@ -12,17 +13,26 @@ const props = defineProps<{
   previewClass?: HTMLAttributes['class']
 }>()
 
+const isChart = props.name.toLowerCase().includes('chart')
+  && !props.name.toLocaleLowerCase().includes('demo')
+
+const sourcePath = isChart
+  ? `apps/v4/registry/new-york-v4/charts/${props.name}.vue`
+  : `apps/v4/components/demo/${props.name}.vue`
+
 const Component = props.type === 'block'
   ? defineAsyncComponent({
       loader: () => import(`@/registry/new-york-v4/blocks/${props.name}/page.vue`),
     })
-  : props.name.toLowerCase().includes('chart') && !props.name.toLocaleLowerCase().includes('demo')
+  : isChart
     ? defineAsyncComponent({
         loader: () => import(`@/registry/new-york-v4/charts/${props.name}.vue`),
       })
     : defineAsyncComponent({
         loader: () => import(`@/components/demo/${props.name}.vue`),
       })
+
+const playgroundUrl = computed(() => getComponentPlaygroundUrl(sourcePath))
 </script>
 
 <template>
@@ -62,6 +72,7 @@ const Component = props.type === 'block'
     :hide-code
     :chrome-less-on-mobile="chromeLessOnMobile"
     :component="Component"
+    :playground-url="playgroundUrl"
   >
     <ComponentSource v-if="!hideCode" :name :collapsible="false" />
   </ComponentPreviewTabs>

--- a/apps/v4/lib/component-playground.ts
+++ b/apps/v4/lib/component-playground.ts
@@ -1,0 +1,11 @@
+const STACKBLITZ_REPOSITORY = 'unovue/shadcn-vue'
+const STACKBLITZ_BRANCH = 'dev'
+
+export function getComponentPlaygroundUrl(file: string) {
+  const query = new URLSearchParams({
+    file,
+    startScript: 'dev',
+  })
+
+  return `https://stackblitz.com/github/${STACKBLITZ_REPOSITORY}/tree/${STACKBLITZ_BRANCH}?${query.toString()}`
+}

--- a/apps/v4/package.json
+++ b/apps/v4/package.json
@@ -8,7 +8,7 @@
     "generate": "nuxt generate",
     "preview": "nuxt preview",
     "postinstall": "nuxt prepare",
-    "test": "tsx scripts/lib/command-item-tailwind.test.ts && vitest run scripts/build-icons.test.ts",
+    "test": "tsx scripts/lib/command-item-tailwind.test.ts && vitest run scripts/build-icons.test.ts scripts/lib/component-playground.test.ts",
     "typecheck": "vue-tsc -b",
     "deploy": "pnpm build && npx tsx ./scripts/seed-d1.ts && npx wrangler --cwd .output/ deploy && npx tsx ./scripts/purge-cache.ts",
     "registry:build": "tsx --tsconfig ./tsconfig.json ./scripts/build-registry.ts && pnpm registry:build:index",

--- a/apps/v4/scripts/lib/component-playground.test.ts
+++ b/apps/v4/scripts/lib/component-playground.test.ts
@@ -1,0 +1,12 @@
+import assert from 'node:assert/strict'
+import { it } from 'vitest'
+import { getComponentPlaygroundUrl } from '../../lib/component-playground'
+
+it('opens the selected source file from the upstream dev branch', () => {
+  const url = new URL(getComponentPlaygroundUrl('apps/v4/components/demo/AccordionDemo.vue'))
+
+  assert.equal(url.origin, 'https://stackblitz.com')
+  assert.equal(url.pathname, '/github/unovue/shadcn-vue/tree/dev')
+  assert.equal(url.searchParams.get('file'), 'apps/v4/components/demo/AccordionDemo.vue')
+  assert.equal(url.searchParams.get('startScript'), 'dev')
+})


### PR DESCRIPTION
### 🔗 Linked issue

Closes #1678

### ❓ Type of change

- [x] 📖 Documentation
- [x] 🐞 Bug fix

### 📚 Description

Restores an **Open in StackBlitz** action to component previews.

The link imports the public `unovue/shadcn-vue` `dev` branch, starts the existing docs app, and opens the exact demo or chart source file instead of installing components from the registry inside the sandbox.

The bug-report template now points component-specific reports to this action, and the URL builder has focused regression coverage.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

### Testing

GitHub Actions passed on commit `54663b0dfae68d2ea0e172d0fdb613c4274c5517`:
- dependency installation
- `pnpm test`
- component playground regression test
- icon-map consistency

### AI assistance

Prepared with OpenAI assistance. The issue context, generated URL, commit, final diff, and CI result were verified before submission.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an “Open in StackBlitz” button to component previews when an online playground is available.
  * Component previews now link directly to the relevant source file in a development playground.
* **Documentation**
  * Updated bug-report instructions with a StackBlitz workflow for component-specific issues.
  * Clarified the available template presets.
* **Tests**
  * Added coverage to verify generated playground links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->