### PR TITLE
fix(cli): explain Tailwind v4-only items instead of a bare 404

### DIFF
--- a/packages/cli/src/registry/errors.ts
+++ b/packages/cli/src/registry/errors.ts
@@ -101,7 +101,7 @@ export class RegistryStyleNotFoundError extends RegistryError {
     public readonly style: string,
     cause?: unknown,
   ) {
-    const message = `The item at ${url} was not found, but it does exist for the ${highlighter.info(style)} style. This usually means the item requires Tailwind v4 and your project is still configured for Tailwind v3.`
+    const message = `The item at ${url} was not found, but it does exist for the ${highlighter.info(style)} style at ${availableUrl}. This usually means the item requires Tailwind v4 and your components.json is still configured for Tailwind v3.`
 
     super(message, {
       code: RegistryErrorCode.STYLE_NOT_FOUND,

--- a/packages/cli/src/registry/errors.ts
+++ b/packages/cli/src/registry/errors.ts
@@ -6,6 +6,7 @@ export const RegistryErrorCode = {
   // Network errors
   NETWORK_ERROR: "NETWORK_ERROR",
   NOT_FOUND: "NOT_FOUND",
+  STYLE_NOT_FOUND: "STYLE_NOT_FOUND",
   UNAUTHORIZED: "UNAUTHORIZED",
   FORBIDDEN: "FORBIDDEN",
   FETCH_ERROR: "FETCH_ERROR",
@@ -90,6 +91,27 @@ export class RegistryNotFoundError extends RegistryError {
         "Check if the item name is correct and the registry URL is accessible.",
     })
     this.name = "RegistryNotFoundError"
+  }
+}
+
+export class RegistryStyleNotFoundError extends RegistryError {
+  constructor(
+    public readonly url: string,
+    public readonly availableUrl: string,
+    public readonly style: string,
+    cause?: unknown,
+  ) {
+    const message = `The item at ${url} was not found, but it does exist for the ${highlighter.info(style)} style. This usually means the item requires Tailwind v4 and your project is still configured for Tailwind v3.`
+
+    super(message, {
+      code: RegistryErrorCode.STYLE_NOT_FOUND,
+      statusCode: 404,
+      cause,
+      context: { url, availableUrl, style },
+      suggestion:
+        "If your project is on Tailwind v4, set \"tailwind.config\" to an empty string in components.json. If it is still on Tailwind v3, upgrade to Tailwind v4 first - the item uses v4-only utilities and will render unstyled otherwise.",
+    })
+    this.name = "RegistryStyleNotFoundError"
   }
 }
 

--- a/packages/cli/src/registry/fetcher.test.ts
+++ b/packages/cli/src/registry/fetcher.test.ts
@@ -1,0 +1,89 @@
+import { http, HttpResponse } from "msw"
+import { setupServer } from "msw/node"
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest"
+import { REGISTRY_URL } from "@/src/registry/constants"
+import {
+  RegistryErrorCode,
+  RegistryNotFoundError,
+  RegistryStyleNotFoundError,
+} from "@/src/registry/errors"
+import { clearRegistryCache, fetchRegistry } from "./fetcher"
+
+const server = setupServer()
+
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }))
+beforeEach(() => clearRegistryCache())
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
+
+describe("fetchRegistry - tailwind v4 style fallback", () => {
+  it("should throw RegistryStyleNotFoundError when the item only exists for new-york-v4", async () => {
+    server.use(
+      http.get(`${REGISTRY_URL}/styles/new-york/message.json`, () => {
+        return HttpResponse.json({ error: "Not found" }, { status: 404 })
+      }),
+      http.head(`${REGISTRY_URL}/styles/new-york-v4/message.json`, () => {
+        return new HttpResponse(null, { status: 200 })
+      }),
+    )
+
+    await expect(
+      fetchRegistry(["styles/new-york/message.json"], { useCache: false }),
+    ).rejects.toBeInstanceOf(RegistryStyleNotFoundError)
+  })
+
+  it("should expose the v4 url and style on the error", async () => {
+    server.use(
+      http.get(`${REGISTRY_URL}/styles/new-york/message.json`, () => {
+        return HttpResponse.json({ error: "Not found" }, { status: 404 })
+      }),
+      http.head(`${REGISTRY_URL}/styles/new-york-v4/message.json`, () => {
+        return new HttpResponse(null, { status: 200 })
+      }),
+    )
+
+    try {
+      await fetchRegistry(["styles/new-york/message.json"], { useCache: false })
+      expect.unreachable("expected fetchRegistry to throw")
+    }
+    catch (error) {
+      expect(error).toBeInstanceOf(RegistryStyleNotFoundError)
+      if (error instanceof RegistryStyleNotFoundError) {
+        expect(error.code).toBe(RegistryErrorCode.STYLE_NOT_FOUND)
+        expect(error.statusCode).toBe(404)
+        expect(error.style).toBe("new-york-v4")
+        expect(error.availableUrl).toContain("styles/new-york-v4/message.json")
+        expect(error.message).toContain("new-york-v4")
+        expect(error.suggestion).toContain("tailwind.config")
+      }
+    }
+  })
+
+  it("should throw RegistryNotFoundError when the item is missing from both styles", async () => {
+    server.use(
+      http.get(`${REGISTRY_URL}/styles/new-york/does-not-exist.json`, () => {
+        return HttpResponse.json({ error: "Not found" }, { status: 404 })
+      }),
+      http.head(`${REGISTRY_URL}/styles/new-york-v4/does-not-exist.json`, () => {
+        return new HttpResponse(null, { status: 404 })
+      }),
+    )
+
+    await expect(
+      fetchRegistry(["styles/new-york/does-not-exist.json"], { useCache: false }),
+    ).rejects.toBeInstanceOf(RegistryNotFoundError)
+  })
+
+  it("should not probe when the 404 is already on the new-york-v4 style", async () => {
+    server.use(
+      http.get(`${REGISTRY_URL}/styles/new-york-v4/missing.json`, () => {
+        return HttpResponse.json({ error: "Not found" }, { status: 404 })
+      }),
+    )
+
+    // onUnhandledRequest: "error" makes this fail if a fallback probe fires.
+    await expect(
+      fetchRegistry(["styles/new-york-v4/missing.json"], { useCache: false }),
+    ).rejects.toBeInstanceOf(RegistryNotFoundError)
+  })
+})

--- a/packages/cli/src/registry/fetcher.test.ts
+++ b/packages/cli/src/registry/fetcher.test.ts
@@ -3,6 +3,10 @@ import { setupServer } from "msw/node"
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest"
 import { REGISTRY_URL } from "@/src/registry/constants"
 import {
+  clearRegistryContext,
+  setRegistryHeaders,
+} from "@/src/registry/context"
+import {
   RegistryErrorCode,
   RegistryNotFoundError,
   RegistryStyleNotFoundError,
@@ -11,20 +15,52 @@ import { clearRegistryCache, fetchRegistry } from "./fetcher"
 
 const server = setupServer()
 
+// Every request msw sees, so a test can assert that no fallback probe fired.
+const requests: { method: string, url: string }[] = []
+
+server.events.on("request:start", ({ request }) => {
+  requests.push({ method: request.method, url: request.url })
+})
+
+function headRequests() {
+  return requests.filter(request => request.method === "HEAD")
+}
+
+function mockItem(
+  { style, name, status }: { style: string, name: string, status: number },
+) {
+  return [
+    http.get(`${REGISTRY_URL}/styles/${style}/${name}.json`, () =>
+      HttpResponse.json({ error: "Not found" }, { status })),
+  ]
+}
+
+function mockFallback(
+  { name, status }: { name: string, status: number },
+) {
+  return http.head(
+    `${REGISTRY_URL}/styles/new-york-v4/${name}.json`,
+    () => new HttpResponse(null, { status }),
+  )
+}
+
 beforeAll(() => server.listen({ onUnhandledRequest: "error" }))
-beforeEach(() => clearRegistryCache())
+beforeEach(() => {
+  clearRegistryCache()
+  clearRegistryContext()
+  requests.length = 0
+})
 afterEach(() => server.resetHandlers())
-afterAll(() => server.close())
+afterAll(() => {
+  server.events.removeAllListeners()
+  server.close()
+})
 
 describe("fetchRegistry - tailwind v4 style fallback", () => {
   it("should throw RegistryStyleNotFoundError when the item only exists for new-york-v4", async () => {
     server.use(
-      http.get(`${REGISTRY_URL}/styles/new-york/message.json`, () => {
-        return HttpResponse.json({ error: "Not found" }, { status: 404 })
-      }),
-      http.head(`${REGISTRY_URL}/styles/new-york-v4/message.json`, () => {
-        return new HttpResponse(null, { status: 200 })
-      }),
+      ...mockItem({ style: "new-york", name: "message", status: 404 }),
+      mockFallback({ name: "message", status: 200 }),
     )
 
     await expect(
@@ -34,12 +70,8 @@ describe("fetchRegistry - tailwind v4 style fallback", () => {
 
   it("should expose the v4 url and style on the error", async () => {
     server.use(
-      http.get(`${REGISTRY_URL}/styles/new-york/message.json`, () => {
-        return HttpResponse.json({ error: "Not found" }, { status: 404 })
-      }),
-      http.head(`${REGISTRY_URL}/styles/new-york-v4/message.json`, () => {
-        return new HttpResponse(null, { status: 200 })
-      }),
+      ...mockItem({ style: "new-york", name: "message", status: 404 }),
+      mockFallback({ name: "message", status: 200 }),
     )
 
     try {
@@ -59,14 +91,32 @@ describe("fetchRegistry - tailwind v4 style fallback", () => {
     }
   })
 
+  it("should probe with the headers resolved for the requested item", async () => {
+    const url = `${REGISTRY_URL}/styles/new-york/message.json`
+    setRegistryHeaders({ [url]: { Authorization: "Bearer token" } })
+
+    let probeAuthorization: string | null = null
+    server.use(
+      ...mockItem({ style: "new-york", name: "message", status: 404 }),
+      http.head(
+        `${REGISTRY_URL}/styles/new-york-v4/message.json`,
+        ({ request }) => {
+          probeAuthorization = request.headers.get("authorization")
+          return new HttpResponse(null, { status: 200 })
+        },
+      ),
+    )
+
+    await expect(
+      fetchRegistry(["styles/new-york/message.json"], { useCache: false }),
+    ).rejects.toBeInstanceOf(RegistryStyleNotFoundError)
+    expect(probeAuthorization).toBe("Bearer token")
+  })
+
   it("should throw RegistryNotFoundError when the item is missing from both styles", async () => {
     server.use(
-      http.get(`${REGISTRY_URL}/styles/new-york/does-not-exist.json`, () => {
-        return HttpResponse.json({ error: "Not found" }, { status: 404 })
-      }),
-      http.head(`${REGISTRY_URL}/styles/new-york-v4/does-not-exist.json`, () => {
-        return new HttpResponse(null, { status: 404 })
-      }),
+      ...mockItem({ style: "new-york", name: "does-not-exist", status: 404 }),
+      mockFallback({ name: "does-not-exist", status: 404 }),
     )
 
     await expect(
@@ -75,15 +125,23 @@ describe("fetchRegistry - tailwind v4 style fallback", () => {
   })
 
   it("should not probe when the 404 is already on the new-york-v4 style", async () => {
-    server.use(
-      http.get(`${REGISTRY_URL}/styles/new-york-v4/missing.json`, () => {
-        return HttpResponse.json({ error: "Not found" }, { status: 404 })
-      }),
-    )
+    server.use(...mockItem({ style: "new-york-v4", name: "missing", status: 404 }))
 
-    // onUnhandledRequest: "error" makes this fail if a fallback probe fires.
     await expect(
       fetchRegistry(["styles/new-york-v4/missing.json"], { useCache: false }),
     ).rejects.toBeInstanceOf(RegistryNotFoundError)
+    expect(headRequests()).toHaveLength(0)
+  })
+
+  it("should not probe a registry other than the shadcn-vue registry", async () => {
+    const url = "https://example.com/r/styles/new-york/message.json"
+    server.use(
+      http.get(url, () => HttpResponse.json({ error: "Not found" }, { status: 404 })),
+    )
+
+    await expect(
+      fetchRegistry([url], { useCache: false }),
+    ).rejects.toBeInstanceOf(RegistryNotFoundError)
+    expect(headRequests()).toHaveLength(0)
   })
 })

--- a/packages/cli/src/registry/fetcher.ts
+++ b/packages/cli/src/registry/fetcher.ts
@@ -5,7 +5,7 @@ import { ofetch } from "ofetch"
 import path from "pathe"
 import { z } from "zod"
 import { resolveRegistryUrl } from "@/src/registry/builder"
-import { FALLBACK_STYLE } from "@/src/registry/constants"
+import { FALLBACK_STYLE, REGISTRY_URL } from "@/src/registry/constants"
 import { getRegistryHeadersFromContext } from "@/src/registry/context"
 import {
   RegistryFetchError,
@@ -22,22 +22,29 @@ import { registryItemSchema } from "@/src/schema"
 const registryCache = new Map<string, Promise<any>>()
 
 // Tailwind v4-only items are absent from the legacy `new-york` registry.
+const LEGACY_STYLE_SEGMENT = /\/styles\/new-york\/(?=[^/]+\.json$)/
+
 async function resolveStyleFallbackUrl(url: string) {
-  if (!/\/styles\/new-york\/[^/]+\.json$/.test(url)) {
+  // Only the shadcn-vue registry publishes the new-york/new-york-v4 pair, so
+  // never probe a third-party registry that happens to share the path shape.
+  if (!url.startsWith(REGISTRY_URL) || !LEGACY_STYLE_SEGMENT.test(url)) {
     return null
   }
 
   const fallbackUrl = url.replace(
-    /\/styles\/new-york\/(?=[^/]+\.json$)/,
+    LEGACY_STYLE_SEGMENT,
     `/styles/${FALLBACK_STYLE}/`,
   )
 
   try {
     await ofetch(fallbackUrl, {
       method: "HEAD",
+      retry: 0,
       agent,
       dispatcher: agent,
-      headers: getRegistryHeadersFromContext(fallbackUrl),
+      // Headers are keyed by the requested item url, so reuse the ones that
+      // were resolved for `url` - `fallbackUrl` is never registered.
+      headers: getRegistryHeadersFromContext(url),
     })
     return fallbackUrl
   }

--- a/packages/cli/src/registry/fetcher.ts
+++ b/packages/cli/src/registry/fetcher.ts
@@ -5,6 +5,7 @@ import { ofetch } from "ofetch"
 import path from "pathe"
 import { z } from "zod"
 import { resolveRegistryUrl } from "@/src/registry/builder"
+import { FALLBACK_STYLE } from "@/src/registry/constants"
 import { getRegistryHeadersFromContext } from "@/src/registry/context"
 import {
   RegistryFetchError,
@@ -12,12 +13,38 @@ import {
   RegistryLocalFileError,
   RegistryNotFoundError,
   RegistryParseError,
+  RegistryStyleNotFoundError,
   RegistryUnauthorizedError,
 } from "@/src/registry/errors"
 import { agent } from "@/src/registry/proxy"
 import { registryItemSchema } from "@/src/schema"
 
 const registryCache = new Map<string, Promise<any>>()
+
+// Tailwind v4-only items are absent from the legacy `new-york` registry.
+async function resolveStyleFallbackUrl(url: string) {
+  if (!/\/styles\/new-york\/[^/]+\.json$/.test(url)) {
+    return null
+  }
+
+  const fallbackUrl = url.replace(
+    /\/styles\/new-york\/(?=[^/]+\.json$)/,
+    `/styles/${FALLBACK_STYLE}/`,
+  )
+
+  try {
+    await ofetch(fallbackUrl, {
+      method: "HEAD",
+      agent,
+      dispatcher: agent,
+      headers: getRegistryHeadersFromContext(fallbackUrl),
+    })
+    return fallbackUrl
+  }
+  catch {
+    return null
+  }
+}
 
 export function clearRegistryCache() {
   registryCache.clear()
@@ -93,6 +120,17 @@ export async function fetchRegistry(
             }
 
             if (response.status === 404) {
+              const fallbackUrl = await resolveStyleFallbackUrl(url)
+
+              if (fallbackUrl) {
+                throw new RegistryStyleNotFoundError(
+                  url,
+                  fallbackUrl,
+                  FALLBACK_STYLE,
+                  messageFromServer,
+                )
+              }
+
               throw new RegistryNotFoundError(url, messageFromServer)
             }
 

--- a/packages/cli/src/registry/index.ts
+++ b/packages/cli/src/registry/index.ts
@@ -29,6 +29,7 @@ export {
   RegistryNotFoundError,
   RegistryParseError,
   RegistrySourceFileError,
+  RegistryStyleNotFoundError,
   RegistryUnauthorizedError,
   RegistryValidationError,
 } from "./errors"

--- a/packages/cli/src/registry/resolver.test.ts
+++ b/packages/cli/src/registry/resolver.test.ts
@@ -1,0 +1,137 @@
+import { http, HttpResponse } from "msw"
+import { setupServer } from "msw/node"
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
+import { REGISTRY_URL } from "@/src/registry/constants"
+import { clearRegistryCache } from "@/src/registry/fetcher"
+import { fetchRegistryItems } from "@/src/registry/resolver"
+import { createConfig } from "@/src/utils/get-config"
+import { getProjectInfo } from "@/src/utils/get-project-info"
+
+vi.mock("@/src/utils/get-project-info", async importOriginal => ({
+  ...(await importOriginal<typeof import("@/src/utils/get-project-info")>()),
+  getProjectInfo: vi.fn(),
+}))
+
+const server = setupServer()
+
+const requestedUrls: string[] = []
+
+server.events.on("request:start", ({ request }) => {
+  requestedUrls.push(request.url)
+})
+
+function mockItem(style: string, name: string) {
+  return http.get(`${REGISTRY_URL}/styles/${style}/${name}.json`, () =>
+    HttpResponse.json({ name, type: "registry:ui", files: [] }))
+}
+
+function mockTailwindVersion(tailwindVersion: "v3" | "v4") {
+  vi.mocked(getProjectInfo).mockResolvedValue({ tailwindVersion } as any)
+}
+
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }))
+beforeEach(() => {
+  clearRegistryCache()
+  requestedUrls.length = 0
+  vi.mocked(getProjectInfo).mockReset()
+})
+afterEach(() => server.resetHandlers())
+afterAll(() => {
+  server.events.removeAllListeners()
+  server.close()
+})
+
+describe("fetchRegistryItems - style resolution", () => {
+  it("should upgrade new-york to new-york-v4 on a tailwind v4 project", async () => {
+    // A stale `tailwind.config` keeps components.json on the "new-york" style,
+    // but v4-only items are only published under "new-york-v4".
+    mockTailwindVersion("v4")
+    server.use(mockItem("new-york-v4", "message"))
+
+    const [item] = await fetchRegistryItems(
+      ["message"],
+      createConfig({
+        style: "new-york",
+        tailwind: { config: "tailwind.config.js" },
+        resolvedPaths: { cwd: "/project" },
+      }),
+      { useCache: false },
+    )
+
+    expect(item.name).toBe("message")
+    expect(requestedUrls).toEqual([
+      `${REGISTRY_URL}/styles/new-york-v4/message.json`,
+    ])
+  })
+
+  it("should keep new-york on a tailwind v3 project", async () => {
+    mockTailwindVersion("v3")
+    server.use(mockItem("new-york", "button"))
+
+    const [item] = await fetchRegistryItems(
+      ["button"],
+      createConfig({
+        style: "new-york",
+        tailwind: { config: "tailwind.config.js" },
+        resolvedPaths: { cwd: "/project" },
+      }),
+      { useCache: false },
+    )
+
+    expect(item.name).toBe("button")
+    expect(requestedUrls).toEqual([
+      `${REGISTRY_URL}/styles/new-york/button.json`,
+    ])
+  })
+
+  it("should pass other styles through untouched", async () => {
+    mockTailwindVersion("v4")
+    server.use(mockItem("reka-luma", "button"))
+
+    await fetchRegistryItems(
+      ["button"],
+      createConfig({
+        style: "reka-luma",
+        resolvedPaths: { cwd: "/project" },
+      }),
+      { useCache: false },
+    )
+
+    expect(requestedUrls).toEqual([
+      `${REGISTRY_URL}/styles/reka-luma/button.json`,
+    ])
+  })
+
+  it("should resolve the style once for a batch of items", async () => {
+    mockTailwindVersion("v4")
+    server.use(
+      mockItem("new-york-v4", "message"),
+      mockItem("new-york-v4", "button"),
+    )
+
+    await fetchRegistryItems(
+      ["message", "button"],
+      createConfig({
+        style: "new-york",
+        resolvedPaths: { cwd: "/project" },
+      }),
+      { useCache: false },
+    )
+
+    expect(vi.mocked(getProjectInfo)).toHaveBeenCalledTimes(1)
+  })
+
+  it("should not detect the project for items that carry their own url", async () => {
+    const url = "https://example.com/r/button.json"
+    server.use(
+      http.get(url, () =>
+        HttpResponse.json({ name: "button", type: "registry:ui", files: [] })),
+    )
+
+    await fetchRegistryItems([url], createConfig({ style: "new-york" }), {
+      useCache: false,
+    })
+
+    expect(vi.mocked(getProjectInfo)).not.toHaveBeenCalled()
+  })
+})

--- a/packages/cli/src/registry/resolver.ts
+++ b/packages/cli/src/registry/resolver.ts
@@ -70,6 +70,19 @@ export function resolveRegistryItemsFromRegistries(
   return resolvedItems
 }
 
+// Resolves the style segment used for bare item names i.e `styles/{style}/x.json`.
+// Tailwind v4 projects are upgraded from "new-york" to "new-york-v4" even when
+// components.json still points at a tailwind.config - see getTargetStyleFromConfig.
+async function resolveTargetRegistryStyle(config: Config) {
+  if (!config?.resolvedPaths?.cwd) {
+    return resolveRegistryStyle(config?.style)
+  }
+
+  return resolveRegistryStyle(
+    await getTargetStyleFromConfig(config.resolvedPaths.cwd, config.style),
+  )
+}
+
 // Internal function that fetches registry items without clearing context.
 // This is used for recursive dependency resolution.
 export async function fetchRegistryItems(
@@ -77,6 +90,14 @@ export async function fetchRegistryItems(
   config: Config,
   options: { useCache?: boolean } = {},
 ) {
+  // Shared by every bare item and resolved lazily, so that url, local and
+  // namespaced items don't pay for project detection.
+  let registryStylePromise: Promise<string> | null = null
+  const getRegistryStyle = () => {
+    registryStylePromise ??= resolveTargetRegistryStyle(config)
+    return registryStylePromise
+  }
+
   const results = await Promise.all(
     items.map(async (item) => {
       const address = resolveItemAddress(item)
@@ -110,7 +131,7 @@ export async function fetchRegistryItems(
         }
       }
 
-      const registryStyle = resolveRegistryStyle(config?.style)
+      const registryStyle = await getRegistryStyle()
       const path = `styles/${registryStyle}/${item}.json`
       const [result] = await fetchRegistry([path], options)
       try {
@@ -506,11 +527,7 @@ async function resolveRegistryDependencies(
     new Set(),
   )
 
-  const style = config.resolvedPaths?.cwd
-    ? resolveRegistryStyle(
-        await getTargetStyleFromConfig(config.resolvedPaths.cwd, config.style),
-      )
-    : resolveRegistryStyle(config.style)
+  const style = await resolveTargetRegistryStyle(config)
 
   const urls = registryNames.map(name =>
     resolveRegistryUrl(isUrl(name) ? name : `styles/${style}/${name}.json`),


### PR DESCRIPTION
### 🔗 Linked issue
#1947 

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
The `message` component only exists in the
`new-york-v4` registry, same for `bubble`, `attachment`, `marker`, `questionnaire`
and `message-scroller`. If your `components.json` still has a `tailwind.config`
path set, the CLI resolves to the old `new-york` style and you get "It may not
exist at the registry", which makes it look like a file is missing from the
registry when it's really just the wrong style.

So now when a 404 happens under `styles/new-york`, the fetcher does a quick HEAD
on the same item under `new-york-v4`. If it's there, it throws a new
`RegistryStyleNotFoundError` that says which style has it and tells you to clear
`tailwind.config`. If the item isn't in either style, nothing changes, you still
get the normal `RegistryNotFoundError`.

Resolves #1947

### 📸 Screenshots (if appropriate)

### 📝 Checklist
- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved registry handling for Tailwind v4 style requests.
  * Automatically detects when legacy style URLs have moved and checks the appropriate fallback.
  * Applies style resolution consistently across registry items and dependencies.
  * Provides clearer error details and Tailwind configuration guidance when a requested style is unavailable.
  * Preserves standard not-found behavior when no fallback resource exists.
* **Tests**
  * Added coverage for style resolution, fallback detection, missing resources, and error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->